### PR TITLE
docs: sync role docs from kolabing-v2 (feedback gate + admin force-complete)

### DIFF
--- a/docs/ROLES-AND-PERMISSIONS.md
+++ b/docs/ROLES-AND-PERMISSIONS.md
@@ -1,6 +1,6 @@
 # Kolabing — Roles, Permissions & Features (Canonical Reference)
 
-**Last updated:** 2026-06-01
+**Last updated:** 2026-06-01 (feedback gate + admin force-complete shipped same day)
 **Status:** Authoritative. This document overrides assumptions.
 **Sync note:** This file is duplicated in both repos (`kolabing-app` and `kolabing-v2`). Keep the two copies identical. When role behaviour changes, update both **and bump the Last updated date** in both.
 
@@ -103,14 +103,21 @@ If a business's subscription lapses (expires or is cancelled), the business is *
 
 The **community counterparty is NEVER affected**: communities keep full access to the shared collaboration and chat regardless of the business's subscription state. Re-gating is one-sided (business only). This refines §2.7: create/apply are the only first-contact paywalls, but a lapse additionally withdraws ongoing business-side access.
 
-### 2.9 Maintainer-granted access — added 2026-06-01
+### 2.9 Maintainer admin actions — added 2026-06-01
+
+The admin panel (`/admin/*`, `auth:admin + maintainer` guard) exposes these collaboration-level actions:
+- **Force-cancel** (`POST /admin/kolabs/{kolab}/collaboration/cancel`): persists `cancellation_reason` and stamps `cancelled_at`. `cancelled_by_profile_id = null` indicates maintainer action.
+- **Force-complete** (`POST /admin/kolabs/{kolab}/collaboration/complete`): bypasses the feedback gate. Persists `completion_reason` and stamps `completed_at`. `completed_by_profile_id = null` indicates maintainer action. No XP is awarded.
+- **Auto-complete (system)**: a scheduled job (`app:auto-complete-stale-collaborations`, default `dailyAt('03:00')`) completes collaborations whose `scheduled_date` is more than `config('collaborations.auto_complete_threshold_days', 7)` days in the past **and** that have at least one feedback row. Stamps `auto_completed_at`.
+
+### 2.10 Maintainer-granted subscription access — added 2026-06-01
 A Kolabing maintainer can grant a business **12 months of subscription access** from the admin panel (`/admin/users/{profile}/subscription/grant`). This produces a `business_subscriptions` row with `status = active` and **`source = maintainer`**. The grant bypasses Stripe/Apple IAP but is identical to a paid subscription as far as the paywall and re-gating logic are concerned — the business gets full subscribed-business capabilities until the period ends or a maintainer revokes it.
 
 A revoke (`/subscription/revoke`) flips the row to `status = inactive` with `cancel_at_period_end = true`. After revoke, the standard subscription-lapse re-gate (§2.8) kicks in.
 
 **Maintainer grants are auditable** via the `source = maintainer` value. There is no other way for an active subscription row to appear without payment.
 
-### 2.10 Test users — back-channel
+### 2.11 Test users — back-channel
 A profile with `profiles.is_test_user = true` is treated as having an active subscription regardless of whether a `business_subscriptions` row exists. This is reserved for Kolabing internal QA accounts. Never set this flag on real customer profiles.
 
 ---
@@ -162,8 +169,11 @@ Nothing. There is no paywall and no gated action on the community side. If code 
 - **Applications.** Either role applies to the other's post. The applying side picks dates only from the dates the posting side marked available.
 - **Chat.** Unlocked once an application is accepted. The other party's name is shown in chat.
 - **Collaboration.** Created when an application is accepted. Either side can edit the date or time. Either side can mark it finished; it also closes when the date passes. Both sides confirm.
-- **Two-way reviews.** After a collaboration, the business reviews the community and the community reviews the business. Ratings are visible on profiles and affect positioning.
-- **Feedback.** A mini feedback modal on completion. Business feedback captures star rating, stories posted, posts/reels, revenue, expectation match, and "would you recommend this community." Community feedback captures star rating, benefits received, posts/reels, expectation match, and "would you recommend this business."
+- **Two-way reviews (public).** After a collaboration, the business reviews the community and the community reviews the business via `POST /collaborations/{id}/review`. Ratings are visible on profiles via `PublicProfileReviewResource` and affect positioning.
+- **Rich feedback (private + gates completion).** A non-dismissible feedback step on completion via `POST /collaborations/{id}/feedback`. Required fields: rating (1–5), expectation match, would recommend. Optional shared: posts/reels. Business-only: stories posted, revenue. Community-only: benefits. **A collaboration only transitions to `completed` once both parties have a feedback row** (server-enforced via `config('collaborations.complete_requires_feedback')`, default true). XP fires per party on feedback submission, not on `/complete`. Editing your row via `PUT /feedback` is allowed until the partner submits — after that, both lock.
+  - Visibility (Q10 in the 2026-06-01 plan): rating + expectation_match + would_recommend are cross-visible to participants once both feedbacks land; revenue / stories_posted / posts_reels / benefits stay private to the submitter (and to maintainers).
+  - Re-gate exemption: a lapsed business can still submit `/feedback` on a past collab — feedback is post-mortem and unblocked even when `/collaborations` index is re-gated.
+  - **Backend mirror (rollout aid):** while the legacy app still POSTs to `/review`, the server transparently writes a stub `/feedback` row (mirror) so the gate succeeds. Mirrored rows carry `mirrored_from_review = true` and are excluded from the rich admin-stats aggregates.
 
 ---
 

--- a/docs/ROLES-BACKEND-DB-MAP.md
+++ b/docs/ROLES-BACKEND-DB-MAP.md
@@ -1,6 +1,6 @@
 # Kolabing — Roles → Backend → Database Map (Ground-Truth)
 
-**Last updated:** 2026-06-01
+**Last updated:** 2026-06-01 (feedback gate + admin force-complete + auto-timeout shipped same day)
 **Status:** Authoritative companion to [`ROLES-AND-PERMISSIONS.md`](./ROLES-AND-PERMISSIONS.md). Read that first (the *what*), then this (the *where*).
 **Sync note:** Duplicated in both repos (`kolabing-app`, `kolabing-v2`). Keep identical, and **bump the Last updated date in both** when role behaviour or backend wiring changes.
 
@@ -19,7 +19,8 @@
 5. ✅ **Profile logos serialize as absolute URLs from the correct column.** `PublicProfileResource::absoluteUrl()` resolves the URL from the extended profile's `profile_photo` first, falling back to `profiles.avatar_url`. See §5.
 6. ⚠️ **NEW — attendee gamification track has shipped** but the canonical permissions doc still describes attendees as "deferred / out of scope". `AttendeeProfile`, `Wallet`, `EarnedBadge`, `EventCheckin`, `ChallengeCompletion`, and ~40 gamification endpoints are live. See §11.
 7. ⚠️ **NEW — `coliving` is in the canonical role spec (`ROLES-AND-PERMISSIONS.md` §2.1) but missing from `BusinessOnboardingRequest::BUSINESS_TYPES`.** A `coliving` onboarding payload is rejected server-side. Trivial fix; see §8 checklist.
-8. ⚠️ **NEW — admin operator surfaces.** Maintainers can grant a 12-month subscription with `source = maintainer` and force-cancel collaborations from `/admin/*`. Make sure new gate code accounts for `source = maintainer` (still an `active` row; behaves identically to a Stripe-paid sub). See §9.
+8. ⚠️ **NEW — admin operator surfaces.** Maintainers can grant a 12-month subscription with `source = maintainer`, force-cancel collaborations, and (since 2026-06-01) **force-complete** collaborations from `/admin/*`. Make sure new gate code accounts for `source = maintainer` (still an `active` row; behaves identically to a Stripe-paid sub). See §9.
+9. ✅ **Feedback gate on `/complete` is live** (2026-06-01). `CollaborationService::complete()` refuses until both participants have a `collaboration_feedback` row; per-party CollaborationComplete XP fires on `/feedback` not `/complete`; legacy `/review` calls auto-mirror a stub feedback row so the gate succeeds during mobile rollout. Soft-rollout knob: `config('collaborations.complete_requires_feedback')`. See §3 and §10.
 
 ---
 
@@ -70,6 +71,8 @@ Spec: paywall is **Business-only**, on **exactly two actions** (create a collabo
 | Client: create entry (intent) | `intent_selection_screen.dart` shows the paywall for unsubscribed business; communities only see the FREE CommunitySeeking option | Business only | ✅ correct |
 
 All four backend gates now follow the same pattern: `if ($profile->isBusiness() && ! $profile->hasActiveSubscription())`. **Never copy this gate into community or attendee paths.**
+
+**Feedback gate on `/complete` (added 2026-06-01, not a paywall):** `CollaborationService::complete()` now calls `enforceFeedbackGate()` which throws `awaiting_own_feedback` (422) or `awaiting_partner_feedback` (422) until both participants have a `collaboration_feedback` row. Subject to `config('collaborations.complete_requires_feedback', true)` so the gate can be soft-rolled. This is a UX gate, **not role-discriminatory** — both business and community must submit. The `awaiting_partner_feedback` error context carries `pending_feedback_from: ['business'|'community']` so the client knows who to nudge.
 
 ---
 
@@ -178,6 +181,7 @@ Fixed since the last revision:
 - [x] Account deletion frees the email + closes posts on both systems + cancels active collaborations. (§6)
 - [x] Profile logo returns an absolute URL via `PublicProfileResource::absoluteUrl()` from the correct column. (§5)
 - [x] Collaboration cancellation now persists `cancellation_reason`, `cancelled_at`, and `cancelled_by_profile_id` (§10).
+- [x] **Feedback gate on `/complete` shipped** with admin force-complete, auto-timeout scheduler, and a `/review`→`/feedback` mirror for legacy clients (§3, §9, §10). XP moved from `/complete` to `/feedback` per Q7. PR #9, 2026-06-01.
 
 Still open:
 
@@ -206,6 +210,7 @@ The admin panel is a **server-rendered Blade surface inside this Laravel backend
 | Grant subscription | `POST /admin/users/{profile}/subscription/grant` → `::grantSubscription` | `ManagedProfileService::grantSubscription($profile, $months = 12)` | `updateOrCreate` `business_subscriptions` with `status = active`, `source = maintainer`, `current_period_start = now()`, `current_period_end = now()+12mo`. Aborts 422 if profile is not `business`. |
 | Revoke subscription | `POST /admin/users/{profile}/subscription/revoke` → `::revokeSubscription` | `ManagedProfileService::revokeSubscription` | Sets `status = inactive`, `cancel_at_period_end = true`. Standard re-gate (`ROLES-AND-PERMISSIONS.md §2.8`) then applies. |
 | Force-cancel collaboration | `POST /admin/kolabs/{kolab}/collaboration/cancel` → `Admin\KolabController::cancelCollaboration` | `CollaborationService::cancel($collab, $reason, $cancelledBy = null)` | Requires a reason (min 3 chars). Persists `cancellation_reason`, `cancelled_at`, leaves `cancelled_by_profile_id` null — **`null` = cancelled by maintainer**. |
+| Force-complete collaboration | `POST /admin/kolabs/{kolab}/collaboration/complete` → `Admin\KolabController::completeCollaboration` | `CollaborationService::adminForceComplete($collab, $reason)` | Bypasses the feedback gate. Requires a reason. Persists `completion_reason`, stamps `completed_at`, leaves `completed_by_profile_id` null. No XP awarded. |
 
 **Key invariant for the role logic:** an admin-granted subscription is indistinguishable from a paid sub at the gate level. `Profile::hasActiveSubscription()` checks `status == active`; it does not branch on `source`. The `source` column is purely for audit and analytics. **Do not** add `source == stripe` checks anywhere — that would silently lock out maintainer-granted users.
 
@@ -225,8 +230,18 @@ Added by the 2026-05-31 admin stats sprint. These columns are **observability-on
 | `collaborations.cancellation_reason` | varchar 500 nullable | `CollaborationService::cancel()` |
 | `collaborations.cancelled_by_profile_id` | foreignUuid nullable | `CollaborationService::cancel()` — **null = maintainer-cancelled** |
 | `profiles.last_active_at` | timestamp nullable (indexed) | `TouchProfileActivity` middleware on the API `auth:sanctum` group; throttled to once per 5 minutes per profile |
+| `collaborations.completion_reason` | varchar 500 nullable | `CollaborationService::adminForceComplete()` |
+| `collaborations.completed_by_profile_id` | foreignUuid nullable | reserved for participant-completion paths; admin force-complete leaves it null (= maintainer) |
+| `collaborations.auto_completed_at` | timestamp nullable | `CollaborationService::autoComplete()` (called by `app:auto-complete-stale-collaborations`) |
+| `collaboration_feedback.mirrored_from_review` | boolean default false | `CollaborationFeedbackService::mirrorFromReview()` (stub rows created when a legacy client POSTs `/review`) |
+| `collaboration_feedback.expectation_match` / `would_recommend` | bool **nullable** (was NOT NULL) | relaxed in the same migration so mirrored stubs sit alongside rich rows |
 
 Backfill for legacy rows: `php artisan app:backfill-lifecycle-timestamps [--dry-run]` copies `updated_at` into the matching transition column. Run once per environment after deploy.
+
+**Auto-completion scheduler:** `app:auto-complete-stale-collaborations` runs `dailyAt('03:00')` per `routes/console.php`. Configurable thresholds in `config/collaborations.php`:
+- `auto_complete_threshold_days` (default 7): days past `scheduled_date` before a stale collab is eligible.
+- `auto_complete_requires_feedback_rows` (default true): also require at least one `collaboration_feedback` row before auto-completing (avoids declaring "done" on collabs nobody acknowledged).
+- `complete_requires_feedback` (default true): the `/complete` feedback gate. Soft-rollout knob if a mobile cutover regresses.
 
 ---
 


### PR DESCRIPTION
## Summary
Mirrors the backend PRs that landed in [`kolabing-v2#8`](https://github.com/kolabing/kolabing-v2/pull/8), [`#9`](https://github.com/kolabing/kolabing-v2/pull/9), plus a small follow-on doc sync from today. The two role files (`docs/ROLES-AND-PERMISSIONS.md` + `docs/ROLES-BACKEND-DB-MAP.md`) are explicitly meant to stay identical across this repo and `kolabing-v2` — this brings the app copy back in line.

### What changed
- **ROLES-AND-PERMISSIONS.md**
  - §2.9 split into "Maintainer admin actions" (force-cancel, force-complete, auto-complete scheduler) and §2.10 "Maintainer-granted subscription access". §2.10 → §2.11 (Test users).
  - §4 (Shared features) rewritten — "Two-way reviews (public)" + new "Rich feedback (private + gates completion)" covering `POST /feedback`, `PUT /feedback`, the gated `/complete`, visibility rules (Q10), the re-gate exemption (Q5), and the legacy `/review` → `/feedback` mirror.
- **ROLES-BACKEND-DB-MAP.md**
  - §0 hot spot #8 extended to mention force-complete alongside force-cancel / grant-sub.
  - §0 hot spot #9 NEW: feedback gate is ✅ live, with the soft-rollout knob.
  - §3 picks up a paragraph on the new feedback gate as a UX gate distinct from the role paywalls.

No app code changes. Backend already shipped.

## Test plan
- [x] `diff` against `kolabing-v2/docs/ROLES-*.md` is now empty.
- [ ] Manual: scan the new §4 wording on the rich feedback step and confirm it matches the app-side spec you want to build against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)