### PR TITLE
chore: add mandatory English PR template + master branch protection

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,52 +1,56 @@
 <!--
-  Bu template ZORUNLUDUR. Her başlığı doldurmadan PR "hazır" sayılmaz.
-  Boş bıraktığın başlıkları silme — "Yok / Gerekmiyor" yaz.
-  Bu bir MOBILE (Flutter) reposudur: iOS + Android birlikte düşünülmeli.
+  This template is MANDATORY. A PR is not "ready" until every section is filled in.
+  Do NOT delete sections — if one does not apply, write "N/A" with a one-line reason.
+  This is a MOBILE (Flutter) repo: always consider iOS AND Android.
 -->
 
-## 🎯 Bu feature'da ne yapıldı?
-<!-- Bu PR neyi değiştiriyor? Kısa ve net, madde madde. -->
+## 🎯 What does this PR do?
+<!-- What changed? Short, clear, bullet points. -->
 
 
 
-## 🐞 Hangi sorunu çözdük?
-<!-- Hangi bug / ihtiyaç / talep için yapıldı? Varsa issue linki: Closes #__ -->
+## 🐞 What problem does it solve?
+<!-- The bug / need / request behind it. Link the issue: Closes #__ -->
 
 
 
-## 🚀 Production'da çalışması için gereken değişiklikler
+## 🚀 What's needed for this to work in production?
 <!--
-  Merge sonrası prod'da çalışması için NE gerekiyor? Yoksa "Ekstra değişiklik gerekmiyor" yaz.
-  - [ ] Yeni env / secret: ____
-  - [ ] Backend deploy / migration / yeni endpoint canlıda olmalı: ____
-  - [ ] App Store / Play Store build alınmalı (versiyon/build no: ____)
+  After merge, what is required for this to work in prod? Write "Nothing extra" if none.
+  - [ ] New env var / secret: ____
+  - [ ] Backend deploy / migration / new endpoint must be live: ____
+  - [ ] New App Store / Play Store build (version / build no: ____)
   - [ ] Feature flag / remote config: ____
+  - [ ] Third-party setup (IAP product, push cert, deep link, etc.): ____
 -->
 
 
 
-## 📱 Bu iş için mobilde hangi branch merge edilmeli?
-<!-- Bağımlılık varsa yaz. Yoksa "Sadece bu branch". -->
+## 📱 Which branch should be merged for this work?
+<!-- Note any dependencies. Otherwise write "This branch only". -->
 
 - Base branch: `master`
-- Bağımlı branch(ler): ____
+- Dependent branch(es): ____
 
-## 🧪 Bu merge nasıl test edilir? (reviewer adım adım çalıştırabilsin)
-<!-- Reviewer'ın senin değişikliğini cihazda doğrulayabilmesi için NET adımlar. -->
+## 🧪 How to test this merge (reviewer must be able to reproduce)
+<!-- Clear steps so a reviewer can verify the change on a device. -->
 
-- **Etkilenen rol:** Business / Community / Attendee (ilgili olanı bırak)
-- **Test hesabı / data:** ____
-- **Adımlar:**
+- **Affected role:** Business / Community / Attendee (keep what applies)
+- **Test account / data:** ____
+- **Steps:**
   1.
   2.
   3.
-- **Beklenen sonuç:** ____
+- **Expected result:** ____
 
-## 📸 Ekran görüntüsü / video (ZORUNLU — UI'a dokunan her PR'da)
+## 📸 Screenshots / screen recording
 <!--
-  En az 1 görsel ekle. UI değiştiyse before/after koy.
-  Mümkünse hem iOS hem Android. UI değişikliği yoksa "UI değişikliği yok" yaz.
+  MANDATORY for ANY design / UI change — a PR that touches UI without a screenshot
+  will not be merged. Include before/after. Prefer BOTH iOS and Android.
+  If there is genuinely no UI change, tick the box below instead.
 -->
+
+- [ ] This PR has **no UI/design change** (no screenshot needed)
 
 | Before | After |
 | ------ | ----- |
@@ -54,15 +58,16 @@
 
 ---
 
-## ✅ Definition of Done (kapatmadan kontrol et)
-- [ ] `flutter analyze` temiz (yeni error/warning eklemedim)
-- [ ] Değişen dosyalara `dart format` uygulandı
-- [ ] **iOS** simülatör/cihazda denendi
-- [ ] **Android** emülatör/cihazda denendi
-- [ ] Kullanıcıya görünen yeni metinler i18n'de var (`app_en.arb` + `app_es.arb` + `app_ca.arb`) ve `flutter gen-l10n` çalıştırıldı
-- [ ] Hardcode yok (base URL / ID / email / şehir-kategori listesi — hepsi API'den)
-- [ ] `BACKLOG.md` güncellendi (biten iş çıkarıldı / yeni bug eklendi)
+## ✅ Definition of Done (check before requesting review)
+- [ ] `flutter analyze` is clean (no new errors/warnings)
+- [ ] `dart format lib test` applied to changed files
+- [ ] Tested on **iOS** simulator/device
+- [ ] Tested on **Android** emulator/device
+- [ ] **Screenshots attached for every UI/design change** (see section above)
+- [ ] New user-facing strings exist in i18n (`app_en.arb` + `app_es.arb` + `app_ca.arb`) and `flutter gen-l10n` was run
+- [ ] No hardcoded values (base URL / IDs / emails / city–category lists — all from the API)
+- [ ] `BACKLOG.md` updated (finished item removed / new bug added)
 
-## 🤖 AI ile mi yazıldı?
-<!-- Hangi tool + ne yaptırdın? Sorumluluk sende kalır, sorun değil — sadece şeffaf ol. -->
+## 🤖 Was AI used?
+<!-- Which tool + what you had it do? Ownership stays with you — just be transparent. -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+<!--
+  Bu template ZORUNLUDUR. Her başlığı doldurmadan PR "hazır" sayılmaz.
+  Boş bıraktığın başlıkları silme — "Yok / Gerekmiyor" yaz.
+-->
+
+## 🎯 Bu feature'da ne yapıldı?
+<!-- Bu PR neyi değiştiriyor? Kısa ve net, madde madde. -->
+
+
+
+## 🐞 Hangi sorunu çözdük?
+<!-- Hangi bug / ihtiyaç / talep için yapıldı? Varsa issue linki: Closes #__ -->
+
+
+
+## 🚀 Production'da çalışması için gereken değişiklikler
+<!--
+  Merge sonrası prod'da çalışması için NE gerekiyor?
+  Yoksa "Ekstra değişiklik gerekmiyor" yaz.
+  Örnekler:
+  - [ ] Yeni env değişkeni / secret: ____
+  - [ ] Backend deploy / migration: ____
+  - [ ] Yeni API endpoint canlıda olmalı: ____
+  - [ ] App Store / Play Store build alınmalı
+  - [ ] Feature flag / config: ____
+-->
+
+
+
+## 📱 Bu iş için mobilde hangi branch merge edilmeli?
+<!-- Bağımlılık varsa yaz. Yoksa "Sadece bu branch" yaz. -->
+
+- Base branch: `master`
+- Bağımlı branch(ler): ____
+
+---
+
+## ✅ Definition of Done (kapatmadan kontrol et)
+- [ ] `flutter analyze` temiz (hata yok)
+- [ ] `flutter test` yeşil
+- [ ] `dart format lib/` uygulandı
+- [ ] Yeni kullanıcıya görünen metinler i18n'de var (`app_en.arb` + `app_es.arb` + `app_ca.arb`), `flutter gen-l10n` çalıştırıldı
+- [ ] Hardcode yok (base URL / ID / email / şehir-kategori listesi — hepsi API'den)
+- [ ] `BACKLOG.md` güncellendi (biten iş çıkarıldı / yeni bug eklendi)
+
+## 🤖 AI ile mi yazıldı?
+<!-- Hangi tool + ne yaptırdın? Sorumluluk sende kalır, sorun değil — sadece şeffaf ol. -->
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 <!--
   Bu template ZORUNLUDUR. Her başlığı doldurmadan PR "hazır" sayılmaz.
   Boş bıraktığın başlıkları silme — "Yok / Gerekmiyor" yaz.
+  Bu bir MOBILE (Flutter) reposudur: iOS + Android birlikte düşünülmeli.
 -->
 
 ## 🎯 Bu feature'da ne yapıldı?
@@ -15,31 +16,50 @@
 
 ## 🚀 Production'da çalışması için gereken değişiklikler
 <!--
-  Merge sonrası prod'da çalışması için NE gerekiyor?
-  Yoksa "Ekstra değişiklik gerekmiyor" yaz.
-  Örnekler:
-  - [ ] Yeni env değişkeni / secret: ____
-  - [ ] Backend deploy / migration: ____
-  - [ ] Yeni API endpoint canlıda olmalı: ____
-  - [ ] App Store / Play Store build alınmalı
-  - [ ] Feature flag / config: ____
+  Merge sonrası prod'da çalışması için NE gerekiyor? Yoksa "Ekstra değişiklik gerekmiyor" yaz.
+  - [ ] Yeni env / secret: ____
+  - [ ] Backend deploy / migration / yeni endpoint canlıda olmalı: ____
+  - [ ] App Store / Play Store build alınmalı (versiyon/build no: ____)
+  - [ ] Feature flag / remote config: ____
 -->
 
 
 
 ## 📱 Bu iş için mobilde hangi branch merge edilmeli?
-<!-- Bağımlılık varsa yaz. Yoksa "Sadece bu branch" yaz. -->
+<!-- Bağımlılık varsa yaz. Yoksa "Sadece bu branch". -->
 
 - Base branch: `master`
 - Bağımlı branch(ler): ____
 
+## 🧪 Bu merge nasıl test edilir? (reviewer adım adım çalıştırabilsin)
+<!-- Reviewer'ın senin değişikliğini cihazda doğrulayabilmesi için NET adımlar. -->
+
+- **Etkilenen rol:** Business / Community / Attendee (ilgili olanı bırak)
+- **Test hesabı / data:** ____
+- **Adımlar:**
+  1.
+  2.
+  3.
+- **Beklenen sonuç:** ____
+
+## 📸 Ekran görüntüsü / video (ZORUNLU — UI'a dokunan her PR'da)
+<!--
+  En az 1 görsel ekle. UI değiştiyse before/after koy.
+  Mümkünse hem iOS hem Android. UI değişikliği yoksa "UI değişikliği yok" yaz.
+-->
+
+| Before | After |
+| ------ | ----- |
+|        |       |
+
 ---
 
 ## ✅ Definition of Done (kapatmadan kontrol et)
-- [ ] `flutter analyze` temiz (hata yok)
-- [ ] `flutter test` yeşil
-- [ ] `dart format lib/` uygulandı
-- [ ] Yeni kullanıcıya görünen metinler i18n'de var (`app_en.arb` + `app_es.arb` + `app_ca.arb`), `flutter gen-l10n` çalıştırıldı
+- [ ] `flutter analyze` temiz (yeni error/warning eklemedim)
+- [ ] Değişen dosyalara `dart format` uygulandı
+- [ ] **iOS** simülatör/cihazda denendi
+- [ ] **Android** emülatör/cihazda denendi
+- [ ] Kullanıcıya görünen yeni metinler i18n'de var (`app_en.arb` + `app_es.arb` + `app_ca.arb`) ve `flutter gen-l10n` çalıştırıldı
 - [ ] Hardcode yok (base URL / ID / email / şehir-kategori listesi — hepsi API'den)
 - [ ] `BACKLOG.md` güncellendi (biten iş çıkarıldı / yeni bug eklendi)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,4 +23,17 @@ Follow Flutter conventions with 2-space indentation and trailing commas for mult
 Use `flutter_test` for widget and unit tests. Name test files `*_test.dart` and keep them under `test/`, mirroring the feature they cover where practical. Add or update tests for new business logic, providers, and reusable widgets. The current suite is minimal, so contributors should strengthen coverage rather than rely on the default smoke test.
 
 ## Commit & Pull Request Guidelines
-Recent history favors short Conventional Commit-style messages such as `feat: ...`, `fix: ...`, and `chore: ...`. Keep commits focused and descriptive. Pull requests should include a clear summary, linked issue or task when relevant, test results (`flutter analyze`, `flutter test`), and screenshots or screen recordings for UI changes.
+Recent history favors short Conventional Commit-style messages such as `feat: ...`, `fix: ...`, and `chore: ...`. Keep commits focused and descriptive.
+
+**The PR template is mandatory.** Every PR MUST use `.github/pull_request_template.md` and fill in **every** section — a PR with empty sections is not ready for review and must not be merged. `master` is protected: changes land through PRs and only `olucvolkan` can merge. Required sections:
+
+- **What does this PR do?** — concise bullets of the change.
+- **What problem does it solve?** — the bug/need behind it, with linked issue (`Closes #__`).
+- **What's needed for production?** — env/secret, backend deploy/migration, new App Store/Play Store build, feature flag, third-party setup, or "Nothing extra".
+- **Which branch should be merged** — base branch and any dependencies.
+- **How to test this merge** — affected role (Business/Community/Attendee), test account/data, numbered steps, expected result, so a reviewer can reproduce it.
+- **Screenshots / screen recording** — **MANDATORY for ANY design/UI change** (before/after, ideally both iOS and Android). A UI-touching PR without a screenshot must not be merged; only tick the "no UI/design change" box when there is genuinely no visual change.
+- **Definition of Done** — `flutter analyze` clean, `dart format` applied, tested on iOS AND Android, i18n in all three ARBs, no hardcoded values, `BACKLOG.md` updated.
+- **Was AI used?** — which tool and what for; be transparent.
+
+Keep this section, `.github/pull_request_template.md`, and the CLAUDE.md PR section in sync — if you change one, change the others.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,33 @@ If you catch a literal while editing a file, fix it in passing. Do not add new d
 
 ---
 
+## MUST FOLLOW — Pull Request template is mandatory (every PR)
+
+Every PR MUST use [`.github/pull_request_template.md`](.github/pull_request_template.md)
+and **fill in every section** — a PR with empty sections is not ready for review and
+must not be merged. `master` is protected: changes land through PRs, and only
+`olucvolkan` can merge.
+
+Hard rules when you open a PR (or write its body):
+1. **Fill all sections.** If one truly does not apply, write `N/A` with a one-line
+   reason — never delete the heading.
+2. **Screenshots are mandatory for ANY design/UI change.** Include before/after,
+   ideally both iOS and Android. A UI-touching PR without a screenshot must not be
+   merged. Only tick the "no UI/design change" box when there is genuinely no visual
+   change.
+3. **"How to test" must be reproducible** — affected role (Business/Community/
+   Attendee), test account/data, numbered steps, expected result.
+4. **State production needs** explicitly (env/secret, backend deploy/migration, new
+   App Store/Play Store build, feature flag, third-party setup) or write "Nothing extra".
+5. Tick the **Definition of Done**: `flutter analyze` clean, `dart format` applied,
+   tested on iOS AND Android, i18n added in all three ARBs, no hardcoded values,
+   `BACKLOG.md` updated.
+
+Keep this section, `.github/pull_request_template.md`, and the AGENTS.md PR section in
+sync — if you change one, change the others.
+
+---
+
 ## MUST READ — Backend schema (before any data/model/API/DB change)
 
 Read [`docs/BACKEND-SCHEMA.md`](docs/BACKEND-SCHEMA.md) before changing anything that


### PR DESCRIPTION
## 🎯 What does this PR do?
- Add `.github/pull_request_template.md` — English, mobile best-practice, with fixed required sections.
- Make the template mandatory in `CLAUDE.md` and `AGENTS.md` (fill every section, screenshots required for UI changes).
- (Already applied) `master` branch protection: PR required, only `olucvolkan` can merge.

## 🐞 What problem does it solve?
Small team + AI-assisted contributors pushing untracked changes to master. Now every change goes through a PR with a consistent, reviewable format; screenshots are required for any design change.

## 🚀 What's needed for this to work in production?
Nothing extra. Once merged, the template auto-populates on every new PR.

## 📱 Which branch should be merged for this work?
- Base branch: `master`
- Dependent branch(es): None

## 🧪 How to test this merge
- **Affected role:** N/A (repo tooling/docs only)
- **Steps:**
  1. Merge this PR.
  2. Open a new PR — confirm the template body appears pre-filled.
  3. Confirm a non-`olucvolkan` account cannot push to / merge master.
- **Expected result:** Template shows on new PRs; master is protected.

## 📸 Screenshots / screen recording
- [x] This PR has **no UI/design change** (no screenshot needed)

## ✅ Definition of Done
- [x] No app code changed (docs + GitHub config only)
- [x] `CLAUDE.md` and `AGENTS.md` updated and kept in sync with the template

## 🤖 Was AI used?
Claude Code — wrote the template + doc rules and set up branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)