### PR TITLE
feat(api): migrate mobile from /opportunities/* to /kolabs/*

### DIFF
--- a/docs/api/legacy_migration.md
+++ b/docs/api/legacy_migration.md
@@ -1,0 +1,106 @@
+# Mobile Migration Guide — `/opportunities/*` → `/kolabs/*`
+
+> Tracking: **kolabing-app #20** (mobile) · **kolabing-v2 #30** (backend cleanup, merged via PR #32) · **kolabing-v2 #31** (backend follow-up: shim removal + parity + table drop)
+> Source of truth: `CreateKolabRequest` (validation rules) and `KolabResource` in `kolabing-v2`, branch `chore/remove-legacy-collab-opportunities`.
+
+## TL;DR
+
+Two parts, very different risk:
+
+- **SAFE** — URL changes only. Every endpoint already returns the same `KolabResource` body on both paths.
+- **BREAKING** — the `create`/`update` **request body** is a different, intent-driven contract (not a rename).
+
+The backend keeps the old `/opportunities/*` endpoints working until this ships, so you can migrate incrementally — but you must finish before backend **#31** removes the shim.
+
+---
+
+## 1 · Endpoint URL mapping — response unchanged
+
+| Old | New |
+|---|---|
+| `GET /opportunities` | `GET /kolabs` |
+| `GET /me/opportunities` | `GET /kolabs/me` |
+| `GET /opportunities/{id}` | `GET /kolabs/{id}` |
+| `POST /opportunities` | `POST /kolabs` ⚠️ **body change — see §2** |
+| `PUT /opportunities/{id}` | `PUT /kolabs/{id}` ⚠️ **body change — see §2** |
+| `DELETE /opportunities/{id}` | `DELETE /kolabs/{id}` |
+| `POST /opportunities/{id}/publish` | `POST /kolabs/{id}/publish` |
+| `POST /opportunities/{id}/close` | `POST /kolabs/{id}/close` |
+| `GET /opportunities/{id}/applications` | `GET /kolabs/{id}/applications` (**new**) |
+| `POST /opportunities/{id}/applications` | `POST /kolabs/{id}/applications` (**new**) |
+| `GET /discovery/opportunities` | `GET /discovery/opportunities` (**no change**) |
+
+Apply-flow request body is unchanged: `{ message, availability }` — `availability` is required, 20–500 chars.
+
+---
+
+## 2 · Create / update body — BREAKING (intent-driven)
+
+The legacy flat model (`business_offer` / `community_deliverables` / `venue_mode`) is replaced by an **`intent_type`** that selects which fields apply. First pick the intent, then send that intent's fields.
+
+### Step A — choose `intent_type`
+
+| Old signal | New `intent_type` |
+|---|---|
+| Community account (any) | `community_seeking` |
+| Business + `venue_mode: business_venue` | `venue_promotion` |
+| Business + other | `product_promotion` |
+
+> **Account rules (enforced server-side):** community accounts may ONLY create `community_seeking`. `venue_promotion` requires the business to have a `primary_venue` on its business profile, else the request is rejected (`422`, key `primary_venue`).
+
+### Step B — field mapping
+
+| Legacy field | New field(s) | Notes |
+|---|---|---|
+| `title`, `description` | `title`, `description` | unchanged (required) |
+| `business_offer` | `offering` (business) / `needs` (community) | array of enum codes |
+| `community_deliverables` | `expects` (business) / `offers_in_return` (community) | array of enum codes |
+| `venue_mode` | `intent_type` + `venue_preference` | preference: `business_provides` / `community_provides` / `no_venue` (community_seeking only) |
+| `address` | `venue_address` | max 500 |
+| `offer_photo` (single URL) | `media[]` | `[{url, type:image\|video, thumbnail_url?, sort_order?}]`; required for `venue_promotion` |
+| `categories` | `community_types` / `seeking_communities` | per intent; `community_types` now usually inherited from profile |
+| `availability_*`, `selected_time`, `recurring_days` | same keys | `availability_mode` adds `specific_dates`; required only for `venue_promotion` |
+| `preferred_city` | `preferred_city` | required *unless* `venue_promotion` |
+
+### Intent-specific required fields (beyond `title`/`description`)
+
+| `intent_type` | Required |
+|---|---|
+| `community_seeking` | `needs[]`, `offers_in_return[]`, `typical_attendance`, `preferred_city` |
+| `venue_promotion` | `offering[]`, `media[]`, `availability_mode`, `availability_start` |
+| `product_promotion` | `offering[]`, `product_name`, `product_type`, `preferred_city` |
+
+> **Enum values are server-defined.** `offering`, `needs`, `offers_in_return`, `expects`, `venue_type`, `product_type` only accept codes from the backend `OfferOption` catalogue. Do **not** hardcode them — fetch the valid option lists from the API and send those codes.
+
+---
+
+## 3 · Response fields to stop reading — deprecating
+
+Application/Collaboration responses currently include backward-compat aliases. They still work today but are removed with the shim in **#31**. Switch now:
+
+| Stop reading | Read instead |
+|---|---|
+| `collab_opportunity_id` | `kolab_id` |
+| `collab_opportunity` | `kolab` |
+| `opportunity` | `kolab` |
+
+---
+
+## 4 · Backend parity delivered before shim removal (#31)
+
+These exist only on the legacy path today; the backend will port them to `/kolabs` before removing `/opportunities`, so behaviour is preserved — just verify after the backend follow-up lands:
+
+- **Freemium / paywall collaboration limit** on `POST /kolabs` — confirm the limit error still surfaces on create.
+- **Creator `portfolio_photos`** in `GET /kolabs/{id}` (detail) — confirm detail screens still render photos.
+
+---
+
+## 5 · Migration checklist
+
+- [ ] Repoint all 10 endpoints to `/kolabs/*` (§1); leave `discovery/opportunities`.
+- [ ] Adopt `GET`/`POST /kolabs/{id}/applications` for the apply flow.
+- [ ] Rebuild the create/edit form around `intent_type` (§2): map fields, fetch enum option lists from API.
+- [ ] Handle the two server-side rules: community → `community_seeking` only; `venue_promotion` needs `primary_venue`.
+- [ ] Read `kolab_id`/`kolab` in responses; drop `collab_opportunity*` / `opportunity` (§3).
+- [ ] Regression-test create, publish, close, apply, list-applications, and detail (photos) end-to-end.
+- [ ] Coordinate release with backend **#31** (don't ship after the shim is removed without this done).

--- a/docs/plans/2026-06-18-kolabs-endpoint-migration.md
+++ b/docs/plans/2026-06-18-kolabs-endpoint-migration.md
@@ -1,0 +1,96 @@
+# Plan — `/opportunities/*` → `/kolabs/*` mobile migration (kolabing-app #20)
+
+Source of truth: `docs/api/legacy_migration.md`.
+
+## Discovered state (before)
+
+- **§2 create/update (BREAKING) is ALREADY DONE.** Creation is fully on `/kolab/flow`
+  (`KolabService` → `POST/PUT /kolabs`, body = `kolab.toJson()` incl. `intent_type`;
+  publish/close/delete via `my_kolabs_provider` → `KolabService`). OfferOption enum
+  catalogue fetched from `/lookup/*` (`offer_option_provider.dart`). Routes hard-redirect
+  legacy create → kolab flow. ⇒ **no create-form rebuild needed.**
+- Explore/browse uses `DiscoveryService` → `/discovery/opportunities` (**unchanged** — leave).
+- **Still legacy / to fix:**
+  1. Apply flow: `application_service.submitApplication` → `POST /opportunities/{id}/applications`.
+  2. `OpportunityService` reads/lifecycle on `/opportunities` — of these, **`getOpportunity`
+     is live** (`opportunityDetailProvider` → `community_offer_detail_screen` + `/opportunity/:id`).
+  3. Models still read `collab_opportunity*` / `opportunity`.
+
+## Changes
+
+### A. Apply flow (`lib/features/application/services/application_service.dart`)
+- `submitApplication`: URL `/opportunities/{id}/applications` → `/kolabs/{id}/applications`.
+  Body (`{message, availability}`) unchanged. Id is the kolab id.
+
+### B. Legacy reads/lifecycle (`lib/features/opportunity/services/opportunity_service.dart`)
+Repoint to `/kolabs` (response is identical `KolabResource` on both paths):
+- `getOpportunity` `/opportunities/{id}` → `/kolabs/{id}` **(live)**
+- `getOpportunities` `/opportunities` → `/kolabs`
+- `getMyOpportunities` `/me/opportunities` → `/kolabs/me`
+- `publishOpportunity` `/opportunities/{id}/publish` → `/kolabs/{id}/publish`
+- `_publishViaStatusUpdate` `/opportunities/{id}` → `/kolabs/{id}`
+- `closeOpportunity` `/opportunities/{id}/close` → `/kolabs/{id}/close`
+- `deleteOpportunity` `/opportunities/{id}` → `/kolabs/{id}`
+- **LEAVE `createOpportunity` / `updateOpportunity` on `/opportunities`** — they send the
+  legacy flat body and are dead (kolab flow is the active path). Repointing them without a
+  body rebuild would 422. Add a deprecation note.
+
+### C. Response fields — kolab-first, legacy fallback (§3, survives #31 shim removal)
+- `application/models/application.dart`: `opportunityId` ← `kolab_id` ?? `collab_opportunity_id`
+  ?? `opportunity_id`; nested object ← `kolab` ?? `collab_opportunity`.
+- `collaboration/models/collaboration.dart`: nested ← `kolab` ?? `opportunity`.
+- `dashboard/models/dashboard_model.dart`: nested ← `kolab` ?? `opportunity`.
+- `collaboration/providers/collaboration_detail_provider.dart`: ← `kolab` ?? `collab_opportunity`.
+- `discovery/models/discovery_item.dart`: add `kolab_id` (direct keys) and `kolab` (nested
+  candidates) to the FRONT of the existing resolver lists.
+
+## Out of scope / verify-after-backend (#31, §4)
+- Paywall limit on `POST /kolabs` (KolabService already handles 402/`ApiException`).
+- Creator `portfolio_photos` on `GET /kolabs/{id}` detail.
+
+## Automated verification (done)
+- `flutter analyze` clean on the 7 changed files (no new errors/warnings).
+- 27 tests pass across `application`, `discovery`, `dashboard`, `opportunity`.
+- Adversarial 3-agent workflow: **PASS** — no missed `/opportunities` API call site; apply id is
+  the kolab id; response fallbacks null-safe; kolab create flow untouched.
+
+## Manual verification (simulator) — how to check this case
+
+> Tip: every migrated call logs its URL. Watch the `flutter run` console — you should see
+> `…/kolabs/…` and **never** `…/opportunities/…` (except `discovery/opportunities`, which is
+> intentionally unchanged). Filter the console for `KolabService:`, `OpportunityService:`,
+> `ApplicationService:`.
+
+1. **Apply to a Kolab (the headline fix).** As a **Community** account, open Explore → tap a
+   business Kolab → **Apply**, fill availability (20–500 chars) → submit.
+   - ✅ Expect success; console shows `ApplicationService: POST …/kolabs/<id>/applications`
+     (NOT `/opportunities/...`). The application appears under My Kolabs → Requests.
+
+2. **Kolab/offer detail.** Open a Kolab detail (`/opportunity/:id` route, e.g. business tapping a
+   community offer on Explore, or opening one of your own).
+   - ✅ Detail loads with title/description/photos; console shows
+     `OpportunityService: GET …/kolabs/<id>`.
+
+3. **Manage your Kolabs (business & community).** My Kolabs → Offers: open one and
+   **Publish**, then **Close**, then **Delete** a draft.
+   - ✅ Each succeeds; console shows `…/kolabs/<id>/publish`, `…/kolabs/<id>/close`,
+     `DELETE …/kolabs/<id>`. My Kolabs list (`/kolabs/me`) refreshes correctly.
+
+4. **Create a Kolab (regression — should be unchanged).** FAB → choose an intent
+   (community-seeking / venue / product) → complete the steps → publish.
+   - ✅ Still works; console shows `KolabService: POST …/kolabs` with an `intent_type` body.
+
+5. **Collaboration detail & dashboard.** Open an active/finished collaboration; open the Home
+   dashboard with an upcoming collaboration.
+   - ✅ The linked Kolab info (title) renders. These now read the `kolab` field first and fall
+     back to the legacy `opportunity` field, so they render whether the backend sends the new or
+     old key.
+
+6. **Explore feed (regression — intentionally unchanged).** Browse Explore as both roles.
+   - ✅ Feed loads via `DiscoveryService: GET …/discovery/opportunities` (this path is correct
+     and must stay on `/discovery/opportunities`).
+
+### After backend #31 lands (shim removal) — re-verify (§4)
+- Paywall: a free business hitting its collaboration limit on create still gets the limit message
+  (KolabService handles `402`).
+- Detail photos: creator `portfolio_photos` still render on `GET /kolabs/{id}`.

--- a/lib/features/application/models/application.dart
+++ b/lib/features/application/models/application.dart
@@ -70,8 +70,7 @@ class SenderProfile {
       // (and the avatar as `avatar_url`); tolerate the flat `name`/
       // `profile_photo` shapes too. Reading only `name` showed "Unknown".
       name: (json['display_name'] ?? json['name'])?.toString() ?? 'Unknown',
-      profilePhoto:
-          (json['avatar_url'] ?? json['profile_photo'])?.toString(),
+      profilePhoto: (json['avatar_url'] ?? json['profile_photo'])?.toString(),
       userType: json['user_type']?.toString(),
     );
   }
@@ -309,11 +308,15 @@ class Application {
     Map<String, dynamic> json, {
     String? currentUserId,
   }) {
-    // Parse nested collab_opportunity if present
+    // Parse the nested kolab (new) / collab_opportunity (legacy alias).
+    // Prefer kolab only when it is actually a Map, so a non-Map `kolab` value
+    // falls through to the legacy key instead of being kept by `??`.
     Opportunity? opportunity;
-    final collabOpp = json['collab_opportunity'];
-    if (collabOpp is Map<String, dynamic>) {
-      opportunity = Opportunity.fromJson(collabOpp);
+    final kolabJson = json['kolab'] is Map<String, dynamic>
+        ? json['kolab']
+        : json['collab_opportunity'];
+    if (kolabJson is Map<String, dynamic>) {
+      opportunity = Opportunity.fromJson(kolabJson);
     }
 
     // Parse applicant_profile if present
@@ -373,6 +376,7 @@ class Application {
     return Application(
       id: json['id']?.toString() ?? '',
       opportunityId:
+          json['kolab_id']?.toString() ??
           json['collab_opportunity_id']?.toString() ??
           json['opportunity_id']?.toString() ??
           '',

--- a/lib/features/application/services/application_service.dart
+++ b/lib/features/application/services/application_service.dart
@@ -54,16 +54,14 @@ class ApplicationService {
   // Submit Application
   // ---------------------------------------------------------------------------
 
-  /// POST /api/v1/opportunities/{id}/applications
-  /// Apply to an opportunity
+  /// POST /api/v1/kolabs/{id}/applications
+  /// Apply to a kolab. [opportunityId] is the kolab id (same entity).
   Future<Application> submitApplication({
     required String opportunityId,
     required String message,
     required String availability,
   }) async {
-    final uri = Uri.parse(
-      '$_baseUrl/opportunities/$opportunityId/applications',
-    );
+    final uri = Uri.parse('$_baseUrl/kolabs/$opportunityId/applications');
     final body = jsonEncode({'message': message, 'availability': availability});
 
     debugPrint('ApplicationService: POST $uri');
@@ -71,11 +69,8 @@ class ApplicationService {
 
     try {
       final response = await _sendWithRefresh(
-        () async => _httpClient.post(
-          uri,
-          headers: await _getHeaders(),
-          body: body,
-        ),
+        () async =>
+            _httpClient.post(uri, headers: await _getHeaders(), body: body),
         allowRetry: true,
       );
 
@@ -391,11 +386,8 @@ class ApplicationService {
 
     try {
       final response = await _sendWithRefresh(
-        () async => _httpClient.post(
-          uri,
-          headers: await _getHeaders(),
-          body: body,
-        ),
+        () async =>
+            _httpClient.post(uri, headers: await _getHeaders(), body: body),
         allowRetry: true,
       );
 
@@ -447,10 +439,7 @@ class ApplicationService {
 
     try {
       final response = await _sendWithRefresh(
-        () async => _httpClient.post(
-          uri,
-          headers: await _getHeaders(),
-        ),
+        () async => _httpClient.post(uri, headers: await _getHeaders()),
         allowRetry: true,
       );
 
@@ -566,11 +555,8 @@ class ApplicationService {
 
     try {
       final response = await _sendWithRefresh(
-        () async => _httpClient.post(
-          uri,
-          headers: await _getHeaders(),
-          body: body,
-        ),
+        () async =>
+            _httpClient.post(uri, headers: await _getHeaders(), body: body),
         allowRetry: true,
       );
 
@@ -621,10 +607,7 @@ class ApplicationService {
 
     try {
       final response = await _sendWithRefresh(
-        () async => _httpClient.post(
-          uri,
-          headers: await _getHeaders(),
-        ),
+        () async => _httpClient.post(uri, headers: await _getHeaders()),
         allowRetry: true,
       );
 

--- a/lib/features/collaboration/models/collaboration.dart
+++ b/lib/features/collaboration/models/collaboration.dart
@@ -95,8 +95,9 @@ class CollaborationPartner {
       // must not crash parsing and silently drop the whole collaboration.
       id: json['id']?.toString() ?? '',
       name: json['name']?.toString() ?? '',
-      profilePhoto:
-          normalizeRemoteMediaUrlOrNull(json['profile_photo'] as String?),
+      profilePhoto: normalizeRemoteMediaUrlOrNull(
+        json['profile_photo'] as String?,
+      ),
       category: json['category'] as String?,
       city: json['city'] is Map
           ? (json['city'] as Map<String, dynamic>)['name'] as String?
@@ -211,7 +212,9 @@ class Collaboration {
       communityPartner: CollaborationPartner.fromJson(
         json['community_partner'] as Map<String, dynamic>,
       ),
-      opportunity: json['opportunity'] != null
+      opportunity: json['kolab'] is Map<String, dynamic>
+          ? Opportunity.fromJson(json['kolab'] as Map<String, dynamic>)
+          : json['opportunity'] is Map<String, dynamic>
           ? Opportunity.fromJson(json['opportunity'] as Map<String, dynamic>)
           : null,
       contactMethods: json['contact_methods'] != null

--- a/lib/features/collaboration/providers/collaboration_detail_provider.dart
+++ b/lib/features/collaboration/providers/collaboration_detail_provider.dart
@@ -13,12 +13,14 @@ import '../../gamification/models/challenge.dart';
 import '../models/collaboration.dart';
 
 /// Provider for collaboration detail.
-final collaborationDetailProvider =
-    FutureProvider.family<Collaboration?, String>((ref, id) async {
-      // No mock fallback: a failed fetch surfaces as an error/empty state so we
-      // never render fabricated data (see docs/BACKEND-SCHEMA.md — never hardcode).
-      return fetchCollaborationDetail(id);
-    });
+final collaborationDetailProvider = FutureProvider.family<Collaboration?, String>((
+  ref,
+  id,
+) async {
+  // No mock fallback: a failed fetch surfaces as an error/empty state so we
+  // never render fabricated data (see docs/BACKEND-SCHEMA.md — never hardcode).
+  return fetchCollaborationDetail(id);
+});
 
 Future<Collaboration?> fetchCollaborationDetail(String id) {
   return _fetchCollaborationDetail(id, allowRetry: true);
@@ -211,7 +213,9 @@ Future<Collaboration> _patchSchedule(
 
 /// Provider for the system challenge catalogue (the pool a collaboration can
 /// pick from). Fetches the real backend list — `GET /api/v1/challenges/system`.
-final availableChallengesProvider = FutureProvider<List<Challenge>>((ref) async {
+final availableChallengesProvider = FutureProvider<List<Challenge>>((
+  ref,
+) async {
   final authService = AuthService();
   final token = await authService.getToken();
   if (token == null || token.isEmpty) {
@@ -294,11 +298,23 @@ final challengeSelectionProvider =
     );
 
 Map<String, dynamic> normalizeCollaborationResponse(Map<String, dynamic> raw) {
-  final creator = raw['creator_profile'] is Map<String, dynamic> ? raw['creator_profile'] as Map<String, dynamic> : null;
-  final applicant = raw['applicant_profile'] is Map<String, dynamic> ? raw['applicant_profile'] as Map<String, dynamic> : null;
-  final opportunity = raw['collab_opportunity'] is Map<String, dynamic> ? raw['collab_opportunity'] as Map<String, dynamic> : null;
-  final businessProfile = raw['business_profile'] is Map<String, dynamic> ? raw['business_profile'] as Map<String, dynamic> : null;
-  final communityProfile = raw['community_profile'] is Map<String, dynamic> ? raw['community_profile'] as Map<String, dynamic> : null;
+  final creator = raw['creator_profile'] is Map<String, dynamic>
+      ? raw['creator_profile'] as Map<String, dynamic>
+      : null;
+  final applicant = raw['applicant_profile'] is Map<String, dynamic>
+      ? raw['applicant_profile'] as Map<String, dynamic>
+      : null;
+  final opportunity = raw['kolab'] is Map<String, dynamic>
+      ? raw['kolab'] as Map<String, dynamic>
+      : raw['collab_opportunity'] is Map<String, dynamic>
+      ? raw['collab_opportunity'] as Map<String, dynamic>
+      : null;
+  final businessProfile = raw['business_profile'] is Map<String, dynamic>
+      ? raw['business_profile'] as Map<String, dynamic>
+      : null;
+  final communityProfile = raw['community_profile'] is Map<String, dynamic>
+      ? raw['community_profile'] as Map<String, dynamic>
+      : null;
 
   final businessSummary = creator?['user_type'] == 'business'
       ? creator
@@ -372,4 +388,3 @@ Map<String, dynamic> normalizeCollaborationResponse(Map<String, dynamic> raw) {
     'viewer_must_resubscribe': raw['viewer_must_resubscribe'],
   };
 }
-

--- a/lib/features/dashboard/models/dashboard_model.dart
+++ b/lib/features/dashboard/models/dashboard_model.dart
@@ -243,7 +243,11 @@ class UpcomingCollaboration {
         json['status'] as String? ?? 'scheduled',
       ),
       scheduledDate: json['scheduled_date'] as String?,
-      opportunity: json['opportunity'] is Map<String, dynamic>
+      opportunity: json['kolab'] is Map<String, dynamic>
+          ? UpcomingOpportunityInfo.fromJson(
+              json['kolab'] as Map<String, dynamic>,
+            )
+          : json['opportunity'] is Map<String, dynamic>
           ? UpcomingOpportunityInfo.fromJson(
               json['opportunity'] as Map<String, dynamic>,
             )

--- a/lib/features/discovery/models/discovery_item.dart
+++ b/lib/features/discovery/models/discovery_item.dart
@@ -317,6 +317,7 @@ class DiscoveryItem {
 
   static String? _resolveCanonicalOpportunityId(Map<String, dynamic> json) {
     const directKeys = <String>[
+      'kolab_id',
       'opportunity_id',
       'collab_opportunity_id',
       'legacy_opportunity_id',
@@ -334,6 +335,7 @@ class DiscoveryItem {
     }
 
     final nestedCandidates = <Object?>[
+      json['kolab'],
       json['opportunity'],
       json['collab_opportunity'],
       json['application_target'],

--- a/lib/features/opportunity/services/opportunity_service.dart
+++ b/lib/features/opportunity/services/opportunity_service.dart
@@ -39,7 +39,7 @@ class OpportunityService {
   // Browse published opportunities
   // ---------------------------------------------------------------------------
 
-  /// GET /api/v1/opportunities
+  /// GET /api/v1/kolabs
   Future<PaginatedResponse<Opportunity>> getOpportunities({
     OpportunityFilters filters = const OpportunityFilters(),
     int page = 1,
@@ -68,7 +68,7 @@ class OpportunityService {
     // Categories need array notation
     final categoryParams = filters.toCategoryParams();
 
-    var uriString = '$_baseUrl/opportunities?';
+    var uriString = '$_baseUrl/kolabs?';
     uriString += queryParams.entries
         .map(
           (e) =>
@@ -132,7 +132,7 @@ class OpportunityService {
   // My opportunities
   // ---------------------------------------------------------------------------
 
-  /// GET /api/v1/me/opportunities
+  /// GET /api/v1/kolabs/me
   Future<PaginatedResponse<Opportunity>> getMyOpportunities({
     String? status,
     int page = 1,
@@ -159,7 +159,7 @@ class OpportunityService {
     };
 
     final uri = Uri.parse(
-      '$_baseUrl/me/opportunities',
+      '$_baseUrl/kolabs/me',
     ).replace(queryParameters: queryParams);
     debugPrint('OpportunityService: GET $uri');
 
@@ -198,7 +198,7 @@ class OpportunityService {
   // Single opportunity detail
   // ---------------------------------------------------------------------------
 
-  /// GET /api/v1/opportunities/{id}
+  /// GET /api/v1/kolabs/{id}
   Future<Opportunity> getOpportunity(String id) async {
     return _getOpportunity(id, allowRetry: true);
   }
@@ -207,7 +207,7 @@ class OpportunityService {
     String id, {
     required bool allowRetry,
   }) async {
-    final uri = Uri.parse('$_baseUrl/opportunities/$id');
+    final uri = Uri.parse('$_baseUrl/kolabs/$id');
     debugPrint('OpportunityService: GET $uri');
 
     try {
@@ -256,6 +256,11 @@ class OpportunityService {
   // ---------------------------------------------------------------------------
 
   /// POST /api/v1/opportunities
+  ///
+  /// DEPRECATED legacy create path (flat body). The active create flow is the
+  /// kolab flow (`KolabService.create` → POST /kolabs, intent-driven body), so
+  /// this is intentionally NOT repointed to /kolabs — the new endpoint rejects
+  /// the legacy flat body.
   Future<Opportunity> createOpportunity(Opportunity opportunity) async {
     return _createOpportunity(opportunity, allowRetry: true);
   }
@@ -313,6 +318,10 @@ class OpportunityService {
   // ---------------------------------------------------------------------------
 
   /// PUT /api/v1/opportunities/{id}
+  ///
+  /// DEPRECATED legacy update path (flat body) — see [createOpportunity].
+  /// Intentionally NOT repointed to /kolabs; the kolab flow
+  /// (`KolabService.update`) is the active edit path.
   Future<Opportunity> updateOpportunity(
     String id,
     Opportunity opportunity,
@@ -372,7 +381,7 @@ class OpportunityService {
   // Publish opportunity
   // ---------------------------------------------------------------------------
 
-  /// POST /api/v1/opportunities/{id}/publish
+  /// POST /api/v1/kolabs/{id}/publish
   ///
   /// Tries the dedicated publish endpoint first.
   /// Falls back to updating status via PUT if the publish endpoint returns 403.
@@ -385,7 +394,7 @@ class OpportunityService {
     required bool allowRetry,
   }) async {
     // First try the dedicated publish endpoint
-    final uri = Uri.parse('$_baseUrl/opportunities/$id/publish');
+    final uri = Uri.parse('$_baseUrl/kolabs/$id/publish');
     debugPrint('OpportunityService: POST $uri');
 
     try {
@@ -438,7 +447,7 @@ class OpportunityService {
     String id, {
     required bool allowRetry,
   }) async {
-    final uri = Uri.parse('$_baseUrl/opportunities/$id');
+    final uri = Uri.parse('$_baseUrl/kolabs/$id');
     final body = jsonEncode({'status': 'published'});
     debugPrint('OpportunityService: PUT $uri (status update fallback)');
 
@@ -491,7 +500,7 @@ class OpportunityService {
   // Close opportunity
   // ---------------------------------------------------------------------------
 
-  /// POST /api/v1/opportunities/{id}/close
+  /// POST /api/v1/kolabs/{id}/close
   Future<Opportunity> closeOpportunity(String id) async {
     return _closeOpportunity(id, allowRetry: true);
   }
@@ -500,7 +509,7 @@ class OpportunityService {
     String id, {
     required bool allowRetry,
   }) async {
-    final uri = Uri.parse('$_baseUrl/opportunities/$id/close');
+    final uri = Uri.parse('$_baseUrl/kolabs/$id/close');
     debugPrint('OpportunityService: POST $uri');
 
     try {
@@ -541,13 +550,13 @@ class OpportunityService {
   // Delete opportunity
   // ---------------------------------------------------------------------------
 
-  /// DELETE /api/v1/opportunities/{id}
+  /// DELETE /api/v1/kolabs/{id}
   Future<void> deleteOpportunity(String id) async {
     return _deleteOpportunity(id, allowRetry: true);
   }
 
   Future<void> _deleteOpportunity(String id, {required bool allowRetry}) async {
-    final uri = Uri.parse('$_baseUrl/opportunities/$id');
+    final uri = Uri.parse('$_baseUrl/kolabs/$id');
     debugPrint('OpportunityService: DELETE $uri');
 
     try {


### PR DESCRIPTION
## 🎯 What does this PR do?

Migrates the mobile app from the legacy `/opportunities/*` API to `/kolabs/*` (kolabing-app #20).
The intent-driven create/edit flow was already on `/kolabs` (KolabService); this finishes the rest:

- **Apply flow:** `POST /opportunities/{id}/applications` → `POST /kolabs/{id}/applications` (body unchanged).
- **`OpportunityService`** reads + lifecycle repointed to `/kolabs`: browse, `/kolabs/me`, detail, publish, close, delete. Legacy `createOpportunity`/`updateOpportunity` left on `/opportunities` and marked **DEPRECATED** (dead path — the kolab flow is the active create/edit; repointing the flat body would 422).
- **Response fields:** 5 models now read `kolab`/`kolab_id` first and fall back to legacy `collab_opportunity*`/`opportunity` (application, collaboration, dashboard, discovery, collaboration-detail provider) — survives the backend #31 shim removal.
- Adds the migration guide `docs/api/legacy_migration.md` and a plan/QA doc with manual test steps.
- Explore browse intentionally stays on `/discovery/opportunities` (unchanged per the guide).

## 🐞 What problem does it solve?

The backend is retiring `/opportunities/*` (kolabing-v2 #30/#31). Mobile must move to `/kolabs/*` before the shim is removed, or apply/list/detail/manage break.

Closes #20

## 🚀 What's needed for this to work in production?

- [x] Backend deploy/migration: **N/A for this PR** — `/kolabs/*` endpoints are already live (shim keeps both paths working). Just coordinate release timing with backend **#31** (don't ship after the shim is removed without this).
- [x] New App Store/Play Store build: yes, ships in the next mobile build.
- [x] Env/secret, feature flag, third-party setup: **Nothing extra.**

## 📱 Which branch should be merged for this work?

- Base branch: `master`
- Dependent branch(es): None — this branch only (1 commit + guide, fast-forwardable).

## 🧪 How to test this merge (reviewer must be able to reproduce)

- **Affected role:** Business **and** Community (app-wide API layer).
- **Test account/data:** any account on the target environment.
- **Steps** (watch the `flutter run` console — expect `…/kolabs/…`, never `…/opportunities/…` except `discovery/opportunities`):
  1. **Apply:** Community → Explore → open a Kolab → **Apply** → submit. ✅ `ApplicationService: POST …/kolabs/<id>/applications`.
  2. **Detail:** open a Kolab/offer. ✅ `OpportunityService: GET …/kolabs/<id>`.
  3. **Manage:** My Kolabs → publish / close / delete. ✅ `…/kolabs/<id>/publish|close`, `DELETE …/kolabs/<id>`.
  4. **Create (regression):** FAB → pick intent → publish. ✅ `KolabService: POST …/kolabs` with `intent_type`.
  5. **Collab detail & dashboard:** linked Kolab renders (reads `kolab`, falls back to `opportunity`).
  6. **Explore (regression):** loads via `/discovery/opportunities`.
- **Expected result:** all flows succeed; no `/opportunities` API calls. Full guide: `docs/plans/2026-06-18-kolabs-endpoint-migration.md`.

## 📸 Screenshots / screen recording

- [x] This PR has **no UI/design change** (no screenshot needed)

Pure API/parsing layer — no visual changes.

---

## ✅ Definition of Done (check before requesting review)
- [x] `flutter analyze` is clean (no new errors/warnings on the 7 changed files)
- [x] `dart format lib test` applied to changed files
- [x] Tested on **iOS** simulator (builds + runs; dev and prod environments verified hitting the right host)
- [ ] Tested on **Android** — not run on Android (no Android-specific code; identical Dart path)
- [x] Screenshots for UI changes — N/A, no UI change
- [x] i18n in all three ARBs — N/A, no new user-facing strings
- [x] No hardcoded values — URLs derived from `ApiConfig.baseUrl`
- [ ] `BACKLOG.md` updated — tracked via issue #20 instead

## 🤖 Was AI used?

Yes — Claude Code (Opus 4.8) scouted the codebase, implemented the migration, and ran an adversarial 3-agent verification (all passed). Review/ownership remain with the author.
