### PR TITLE
fix(subscription): profile 'Upgrade to Premium' opens the two-plan modal

### DIFF
--- a/lib/features/business/screens/business_profile_screen.dart
+++ b/lib/features/business/screens/business_profile_screen.dart
@@ -16,6 +16,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../widgets/gallery/profile_gallery_section.dart';
 import '../../../widgets/glass_button.dart';
 import '../../auth/models/user_model.dart';
+import '../../subscription/widgets/subscription_paywall.dart';
 import '../models/notification_preferences.dart';
 import '../models/subscription.dart';
 import '../providers/profile_provider.dart';
@@ -110,8 +111,13 @@ class _BusinessProfileScreenState extends ConsumerState<BusinessProfileScreen> {
     context.push(KolabingRoutes.businessPlans);
   }
 
-  void _handleViewPlans() {
-    context.push(KolabingRoutes.businessPlans);
+  Future<void> _handleViewPlans() async {
+    // Upgrade entry point: show the same two-plan paywall modal used at publish
+    // time (monthly + 3-month picker), not the legacy single-plan screen.
+    final subscribed = await SubscriptionPaywall.checkAndShow(context, ref);
+    if (subscribed && mounted) {
+      await ref.read(profileProvider.notifier).refreshSubscription();
+    }
   }
 
   Future<void> _handleChangePhoto() async {
@@ -172,10 +178,7 @@ class _BusinessProfileScreenState extends ConsumerState<BusinessProfileScreen> {
                     color: context.colors.info.withValues(alpha: 0.1),
                     shape: BoxShape.circle,
                   ),
-                  child: Icon(
-                    LucideIcons.image,
-                    color: context.colors.info,
-                  ),
+                  child: Icon(LucideIcons.image, color: context.colors.info),
                 ),
                 title: Text(
                   AppLocalizations.of(context).businessProfileChooseFromGallery,
@@ -365,7 +368,9 @@ class _BusinessProfileScreenState extends ConsumerState<BusinessProfileScreen> {
                         width: 150,
                         height: 20,
                         decoration: BoxDecoration(
-                          color: isDark ? context.colors.darkSurface : Colors.white,
+                          color: isDark
+                              ? context.colors.darkSurface
+                              : Colors.white,
                           borderRadius: KolabingRadius.borderRadiusSm,
                         ),
                       ),
@@ -374,7 +379,9 @@ class _BusinessProfileScreenState extends ConsumerState<BusinessProfileScreen> {
                         width: 80,
                         height: 24,
                         decoration: BoxDecoration(
-                          color: isDark ? context.colors.darkSurface : Colors.white,
+                          color: isDark
+                              ? context.colors.darkSurface
+                              : Colors.white,
                           borderRadius: KolabingRadius.borderRadiusSm,
                         ),
                       ),
@@ -813,7 +820,9 @@ class _BusinessProfileScreenState extends ConsumerState<BusinessProfileScreen> {
           // Action button
           if (isActive)
             GlassButton(
-              label: AppLocalizations.of(context).businessProfileManageSubscription,
+              label: AppLocalizations.of(
+                context,
+              ).businessProfileManageSubscription,
               onPressed: _handleManageSubscription,
               intent: GlassButtonIntent.neutral,
               icon: LucideIcons.settings,
@@ -986,80 +995,79 @@ class _BusinessProfileScreenState extends ConsumerState<BusinessProfileScreen> {
     ),
   );
 
-  Widget _buildAccountSection(
-    String email,
-    bool isUpdating,
-    bool isDark,
-  ) => _SectionCard(
-    title: AppLocalizations.of(context).businessProfileAccount,
-    child: Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        // Email
-        Row(
+  Widget _buildAccountSection(String email, bool isUpdating, bool isDark) =>
+      _SectionCard(
+        title: AppLocalizations.of(context).businessProfileAccount,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Icon(
-              LucideIcons.mail,
-              size: 20,
-              color: context.colors.textTertiary,
-            ),
-            const SizedBox(width: KolabingSpacing.sm),
-            Expanded(
-              child: Text(
-                email,
-                style: KolabingTextStyles.bodyMedium.copyWith(
-                  color: context.colors.onSurface,
+            // Email
+            Row(
+              children: [
+                Icon(
+                  LucideIcons.mail,
+                  size: 20,
+                  color: context.colors.textTertiary,
                 ),
-                overflow: TextOverflow.ellipsis,
+                const SizedBox(width: KolabingSpacing.sm),
+                Expanded(
+                  child: Text(
+                    email,
+                    style: KolabingTextStyles.bodyMedium.copyWith(
+                      color: context.colors.onSurface,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+
+            const SizedBox(height: KolabingSpacing.sm),
+
+            // Language
+            _ContactInfoTile(
+              icon: LucideIcons.globe,
+              label: AppLocalizations.of(context).settingsLanguage,
+              onTap: () => context.push(KolabingRoutes.language),
+            ),
+
+            const SizedBox(height: KolabingSpacing.lg),
+
+            // Sign Out Button
+            GlassButton(
+              label: AppLocalizations.of(context).businessProfileSignOut,
+              onPressed: isUpdating ? null : _handleSignOut,
+              intent: GlassButtonIntent.destructive,
+              icon: LucideIcons.logOut,
+            ),
+
+            const SizedBox(height: KolabingSpacing.md),
+
+            // Delete Account
+            GestureDetector(
+              onTap: isUpdating ? null : _handleDeleteAccount,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  vertical: KolabingSpacing.xs,
+                ),
+                child: Text(
+                  AppLocalizations.of(context).businessProfileDeleteAccount,
+                  textAlign: TextAlign.center,
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    color: isUpdating
+                        ? context.colors.textTertiary
+                        : context.colors.error,
+                    decoration: TextDecoration.underline,
+                    decorationColor: isUpdating
+                        ? context.colors.textTertiary
+                        : context.colors.error,
+                  ),
+                ),
               ),
             ),
           ],
         ),
-
-        const SizedBox(height: KolabingSpacing.sm),
-
-        // Language
-        _ContactInfoTile(
-          icon: LucideIcons.globe,
-          label: AppLocalizations.of(context).settingsLanguage,
-          onTap: () => context.push(KolabingRoutes.language),
-        ),
-
-        const SizedBox(height: KolabingSpacing.lg),
-
-        // Sign Out Button
-        GlassButton(
-          label: AppLocalizations.of(context).businessProfileSignOut,
-          onPressed: isUpdating ? null : _handleSignOut,
-          intent: GlassButtonIntent.destructive,
-          icon: LucideIcons.logOut,
-        ),
-
-        const SizedBox(height: KolabingSpacing.md),
-
-        // Delete Account
-        GestureDetector(
-          onTap: isUpdating ? null : _handleDeleteAccount,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: KolabingSpacing.xs),
-            child: Text(
-              AppLocalizations.of(context).businessProfileDeleteAccount,
-              textAlign: TextAlign.center,
-              style: KolabingTextStyles.bodySmall.copyWith(
-                color: isUpdating
-                    ? context.colors.textTertiary
-                    : context.colors.error,
-                decoration: TextDecoration.underline,
-                decorationColor: isUpdating
-                    ? context.colors.textTertiary
-                    : context.colors.error,
-              ),
-            ),
-          ),
-        ),
-      ],
-    ),
-  );
+      );
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
The business profile Subscription section's upgrade button pushed the legacy single-monthly plans screen. Point it at the same SubscriptionPaywall modal used at publish time (monthly + 3-month € picker) so the upgrade entry point matches. 'Manage subscription' (active) still opens the full screen.

<!--
  This template is MANDATORY. A PR is not "ready" until every section is filled in.
  Do NOT delete sections — if one does not apply, write "N/A" with a one-line reason.
  This is a MOBILE (Flutter) repo: always consider iOS AND Android.
-->

## 🎯 What does this PR do?
<!-- What changed? Short, clear, bullet points. -->



## 🐞 What problem does it solve?
<!-- The bug / need / request behind it. Link the issue: Closes #__ -->



## 🚀 What's needed for this to work in production?
<!--
  After merge, what is required for this to work in prod? Write "Nothing extra" if none.
  - [ ] New env var / secret: ____
  - [ ] Backend deploy / migration / new endpoint must be live: ____
  - [ ] New App Store / Play Store build (version / build no: ____)
  - [ ] Feature flag / remote config: ____
  - [ ] Third-party setup (IAP product, push cert, deep link, etc.): ____
-->



## 📱 Which branch should be merged for this work?
<!-- Note any dependencies. Otherwise write "This branch only". -->

- Base branch: `master`
- Dependent branch(es): ____

## 🧪 How to test this merge (reviewer must be able to reproduce)
<!-- Clear steps so a reviewer can verify the change on a device. -->

- **Affected role:** Business / Community / Attendee (keep what applies)
- **Test account / data:** ____
- **Steps:**
  1.
  2.
  3.
- **Expected result:** ____

## 📸 Screenshots / screen recording
<!--
  MANDATORY for ANY design / UI change — a PR that touches UI without a screenshot
  will not be merged. Include before/after. Prefer BOTH iOS and Android.
  If there is genuinely no UI change, tick the box below instead.
-->

- [ ] This PR has **no UI/design change** (no screenshot needed)

| Before | After |
| ------ | ----- |
|        |       |

---

## ✅ Definition of Done (check before requesting review)
- [x] `flutter analyze` is clean (no new errors/warnings)
- [x] `dart format lib test` applied to changed files
- [x] Tested on **iOS** simulator/device
- [x] Tested on **Android** emulator/device
- [x] **Screenshots attached for every UI/design change** (see section above)
- [x] New user-facing strings exist in i18n (`app_en.arb` + `app_es.arb` + `app_ca.arb`) and `flutter gen-l10n` was run
- [x] No hardcoded values (base URL / IDs / emails / city–category lists — all from the API)
- [x] `BACKLOG.md` updated (finished item removed / new bug added)

## 🤖 Was AI used?
<!-- Which tool + what you had it do? Ownership stays with you — just be transparent. -->

