### PR TITLE
fix(auth): guard login back button against GoError 'nothing to pop' (FLUTTER-4)

### DIFF
--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -193,7 +193,14 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
   }
 
   void _handleBack() {
-    context.pop();
+    // Login can be the navigation root (post-logout redirect, deep link, or
+    // initial route), where there is nothing to pop. Calling pop() then throws
+    // GoError("There is nothing to pop"), so fall back to the welcome screen.
+    if (context.canPop()) {
+      context.pop();
+    } else {
+      context.go(_kWelcomeRoute);
+    }
   }
 
   void _navigateToSignUp() {

--- a/test/features/auth/screens/login_screen_test.dart
+++ b/test/features/auth/screens/login_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:kolabing_app/l10n/app_localizations.dart';
 
 import 'package:kolabing_app/features/auth/providers/auth_provider.dart';
@@ -115,6 +116,55 @@ void main() {
         findsOneWidget,
       );
       expect(tester.takeException(), isNull);
+    },
+  );
+
+  // Regression for Sentry FLUTTER-4 (GoError: There is nothing to pop): the
+  // login back button must not crash when login is the navigation root; it
+  // should route to the welcome screen instead.
+  testWidgets(
+    'back button on root login routes to welcome instead of throwing',
+    (WidgetTester tester) async {
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1.0;
+
+      final router = GoRouter(
+        initialLocation: '/auth/login',
+        routes: [
+          GoRoute(
+            path: '/auth/login',
+            builder: (context, state) => const LoginScreen(),
+          ),
+          GoRoute(
+            path: '/auth/welcome',
+            builder: (context, state) =>
+                const Scaffold(body: Text('WELCOME ROOT')),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: router,
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 900));
+
+      // Login is the root route, so there is nothing to pop.
+      await tester.tap(find.byIcon(Icons.arrow_back_ios_new_rounded));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('WELCOME ROOT'), findsOneWidget);
     },
   );
 }


### PR DESCRIPTION
## 🎯 What does this PR do?

Fixes **Sentry FLUTTER-4 — `GoError: There is nothing to pop`** on the login screen. The back button called `context.pop()` unconditionally; when login is the navigation root (post-logout redirect, deep link, or initial route) there is nothing to pop and it throws.

- `_handleBack` now guards with `context.canPop()` and falls back to `context.go('/auth/welcome')`.
- Adds a regression widget test (login as GoRouter root → tap back → lands on welcome, no exception).

## 🐞 What problem does it solve?

Real crash for users who reach login with an empty navigation stack. `Fixes FLUTTER-4`.

## 🚀 What's needed for this to work in production?

Nothing extra (client-only). New mobile build to ship.

## 📱 Which branch should be merged for this work?

- Base branch: `master`
- Dependent branch(es): None — this branch only.

## 🧪 How to test this merge (reviewer must be able to reproduce)

- **Affected role:** All (auth).
- **Steps:**
  1. Reach the login screen as the navigation root (e.g. log out, or cold-launch to login).
  2. Tap the top-left **back** button.
- **Expected result:** navigates to the Welcome screen (no `GoError`, no crash). When login was pushed onto a stack, back still pops normally.

## 📸 Screenshots / screen recording

- [x] This PR has **no UI/design change** (no screenshot needed)

Behavior-only fix (navigation guard); no visual change.

---

## ✅ Definition of Done (check before requesting review)
- [x] `flutter analyze` clean
- [x] `dart format` applied
- [x] Tested on **iOS** simulator + regression widget test (RED→GREEN verified)
- [ ] Tested on **Android** — not run (no Android-specific code)
- [x] Screenshots — N/A, no UI change
- [x] i18n — N/A, no new strings
- [x] No hardcoded values
- [ ] `BACKLOG.md` — tracked via Sentry FLUTTER-4

## 🤖 Was AI used?

Yes — Claude Code (Opus 4.8) diagnosed the Sentry issue, implemented the canPop guard, and added the regression test. Review/ownership remain with the author.
