### PR TITLE
fix(subscription): reset Subscribe button when App Store sheet is cancelled

### DIFF
--- a/lib/features/subscription/providers/iap_provider.dart
+++ b/lib/features/subscription/providers/iap_provider.dart
@@ -175,6 +175,15 @@ class IAPNotifier extends Notifier<IAPState> {
       onPending: () {
         state = state.copyWith(isPurchasing: true);
       },
+      onCancelled: () {
+        // User dismissed the App Store sheet — drop the loading state without
+        // showing an error so the Subscribe button returns to normal.
+        state = state.copyWith(
+          isPurchasing: false,
+          isRestoring: false,
+          clearError: true,
+        );
+      },
     );
   }
 

--- a/lib/features/subscription/services/iap_service.dart
+++ b/lib/features/subscription/services/iap_service.dart
@@ -146,11 +146,14 @@ class IAPService {
   }
 
   /// Listen to purchase updates stream
-  /// The [onPurchaseVerified] callback is called after successful backend verification
+  /// The [onPurchaseVerified] callback is called after successful backend verification.
+  /// [onCancelled] fires when the user dismisses the App Store sheet, so callers
+  /// can clear any "purchasing" loading state without surfacing an error.
   void listenToPurchases({
     required void Function(Subscription subscription) onPurchaseVerified,
     required void Function(String error) onError,
     required void Function() onPending,
+    required void Function() onCancelled,
   }) {
     _purchaseSubscription?.cancel();
     _purchaseSubscription = _iap.purchaseStream.listen(
@@ -161,6 +164,7 @@ class IAPService {
             onPurchaseVerified: onPurchaseVerified,
             onError: onError,
             onPending: onPending,
+            onCancelled: onCancelled,
           );
         }
       },
@@ -220,6 +224,7 @@ class IAPService {
     required void Function(Subscription) onPurchaseVerified,
     required void Function(String) onError,
     required void Function() onPending,
+    required void Function() onCancelled,
   }) async {
     switch (purchase.status) {
       case PurchaseStatus.pending:
@@ -268,7 +273,10 @@ class IAPService {
         debugPrint('IAP: Purchase error: ${purchase.error}');
         _pendingReferralCode = null;
         final errorMessage = purchase.error?.message ?? 'Purchase failed';
-        if (!errorMessage.toLowerCase().contains('cancel')) {
+        if (errorMessage.toLowerCase().contains('cancel')) {
+          // User-initiated cancel surfaced as an error: clear loading, no alert.
+          onCancelled();
+        } else {
           onError(errorMessage);
         }
         if (purchase.pendingCompletePurchase) {
@@ -278,6 +286,9 @@ class IAPService {
       case PurchaseStatus.canceled:
         debugPrint('IAP: Purchase canceled by user');
         _pendingReferralCode = null;
+        // Reset the purchasing state so the Subscribe button leaves its loading
+        // spinner; otherwise it stays stuck after the user dismisses the sheet.
+        onCancelled();
         if (purchase.pendingCompletePurchase) {
           await _iap.completePurchase(purchase);
         }

--- a/test/features/subscription/providers/iap_provider_test.dart
+++ b/test/features/subscription/providers/iap_provider_test.dart
@@ -127,6 +127,7 @@ class _FakeIAPService extends IAPService {
     required void Function(Subscription subscription) onPurchaseVerified,
     required void Function(String error) onError,
     required void Function() onPending,
+    required void Function() onCancelled,
   }) {}
 
   @override

--- a/test/features/subscription/services/iap_service_test.dart
+++ b/test/features/subscription/services/iap_service_test.dart
@@ -12,26 +12,26 @@ import 'package:kolabing_app/features/subscription/services/iap_service.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('initialize loads the subscription from a bundle-based product id', () async {
-    final iap = _TestInAppPurchase(
-      availableProducts: <ProductDetails>[_bundleMonthlyProduct],
-    );
-    addTearDown(iap.dispose);
+  test(
+    'initialize loads the subscription from a bundle-based product id',
+    () async {
+      final iap = _TestInAppPurchase(
+        availableProducts: <ProductDetails>[_bundleMonthlyProduct],
+      );
+      addTearDown(iap.dispose);
 
-    final service = IAPService(
-      iap: iap,
-      isIosPlatform: () => true,
-    );
+      final service = IAPService(iap: iap, isIosPlatform: () => true);
 
-    await service.initialize();
+      await service.initialize();
 
-    expect(
-      iap.lastQueriedProductIds,
-      contains('com.kolabing.kolabingApp.subscription.monthly'),
-    );
-    expect(service.isAvailable, isTrue);
-    expect(service.monthlyProduct?.id, _bundleMonthlyProduct.id);
-  });
+      expect(
+        iap.lastQueriedProductIds,
+        contains('com.kolabing.kolabingApp.subscription.monthly'),
+      );
+      expect(service.isAvailable, isTrue);
+      expect(service.monthlyProduct?.id, _bundleMonthlyProduct.id);
+    },
+  );
 
   test(
     'restored purchases verify with original transaction id when available',
@@ -47,6 +47,7 @@ void main() {
         onPurchaseVerified: verified.complete,
         onError: fail,
         onPending: () {},
+        onCancelled: () {},
       );
 
       iap.emitPurchases(<PurchaseDetails>[
@@ -86,6 +87,53 @@ void main() {
       );
     },
   );
+
+  test(
+    'canceled purchase invokes onCancelled, not onError/onPending',
+    () async {
+      final iap = _TestInAppPurchase();
+      addTearDown(iap.dispose);
+
+      final service = IAPService(iap: iap);
+
+      var cancelled = false;
+      var pending = false;
+      String? error;
+      service.listenToPurchases(
+        onPurchaseVerified: (_) =>
+            fail('should not verify a canceled purchase'),
+        onError: (e) => error = e,
+        onPending: () => pending = true,
+        onCancelled: () => cancelled = true,
+      );
+
+      iap.emitPurchases(<PurchaseDetails>[
+        AppStorePurchaseDetails(
+          productID: kMonthlySubscriptionId,
+          purchaseID: null,
+          verificationData: PurchaseVerificationData(
+            localVerificationData: '',
+            serverVerificationData: '',
+            source: 'app_store',
+          ),
+          transactionDate: null,
+          skPaymentTransaction: SKPaymentTransactionWrapper(
+            payment: const SKPaymentWrapper(
+              productIdentifier: kMonthlySubscriptionId,
+            ),
+            transactionState: SKPaymentTransactionStateWrapper.failed,
+          ),
+          status: PurchaseStatus.canceled,
+        ),
+      ]);
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(cancelled, isTrue);
+      expect(error, isNull);
+      expect(pending, isFalse);
+    },
+  );
 }
 
 class _CapturingProfileService extends ProfileService {
@@ -111,9 +159,9 @@ class _CapturingProfileService extends ProfileService {
 }
 
 class _TestInAppPurchase implements InAppPurchase {
-  _TestInAppPurchase({
-    List<ProductDetails>? availableProducts,
-  }) : _availableProducts = availableProducts ?? <ProductDetails>[_monthlyProduct];
+  _TestInAppPurchase({List<ProductDetails>? availableProducts})
+    : _availableProducts =
+          availableProducts ?? <ProductDetails>[_monthlyProduct];
 
   final StreamController<List<PurchaseDetails>> _controller =
       StreamController<List<PurchaseDetails>>.broadcast();


### PR DESCRIPTION
## 🎯 What does this PR do?
Fixes the Subscribe button staying stuck in its loading spinner after the user dismisses the Apple payment sheet.

- `PurchaseStatus.canceled` (and the cancel variant of `PurchaseStatus.error`) never signalled back, so the global `iapProvider.isPurchasing` stayed `true` — the spinner persisted even after closing/reopening the modal.
- Added an `onCancelled` callback to `IAPService.listenToPurchases`; the cancel paths now invoke it (no error alert). `iapProvider` clears `isPurchasing`/`isRestoring` on cancel.

## 🐞 What problem does it solve?
Subscribe button stuck loading after cancel; modal had to be killed/reopened and still showed loading.

Closes (no GH issue) — reported in-app.

## 🚀 What's needed for this to work in production?
Nothing extra (client-only).

## 📱 Which branch should be merged for this work?
- Base branch: `master`
- Dependent branch(es): None.

## 🧪 How to test this merge (reviewer must be able to reproduce)
- **Affected role:** Business (iOS IAP).
- **Steps:** Business w/o subscription → open the paywall → tap **Subscribe** → on the Apple sheet tap **Cancel**.
- **Expected:** the Subscribe button returns to its normal (non-loading) state immediately; reopening the modal shows a normal button. No error alert on cancel.

## 📸 Screenshots / screen recording
- [x] This PR has **no UI/design change** (no screenshot needed)

Behavior/state fix only.

---

## ✅ Definition of Done
- [x] `flutter analyze` clean
- [x] `dart format` applied
- [x] Tested on **iOS** simulator + unit test (cancel → onCancelled, not onError/onPending)
- [ ] Tested on **Android** — N/A (iOS IAP path)
- [x] Screenshots — N/A, no UI change
- [x] i18n — N/A
- [x] No hardcoded values
- [ ] `BACKLOG.md` — N/A

## 🤖 Was AI used?
Yes — Claude Code (Opus 4.8) traced the stuck-loading state, added the `onCancelled` path, and wrote the regression test.