### PR TITLE
feat: route collaboration completion notifications to detail screen

### DIFF
--- a/lib/features/notification/models/app_notification.dart
+++ b/lib/features/notification/models/app_notification.dart
@@ -14,6 +14,9 @@ enum NotificationType {
   /// Your application was declined
   applicationDeclined,
 
+  /// Your application was withdrawn
+  applicationWithdrawn,
+
   /// A rewards badge was awarded to the user
   badgeAwarded,
 
@@ -57,6 +60,8 @@ enum NotificationType {
         return NotificationType.applicationAccepted;
       case 'application_declined':
         return NotificationType.applicationDeclined;
+      case 'application_withdrawn':
+        return NotificationType.applicationWithdrawn;
       case 'badge_awarded':
         return NotificationType.badgeAwarded;
       case 'challenge_verified':
@@ -92,6 +97,8 @@ enum NotificationType {
         return 'application_accepted';
       case NotificationType.applicationDeclined:
         return 'application_declined';
+      case NotificationType.applicationWithdrawn:
+        return 'application_withdrawn';
       case NotificationType.badgeAwarded:
         return 'badge_awarded';
       case NotificationType.challengeVerified:

--- a/lib/features/notification/models/app_notification.dart
+++ b/lib/features/notification/models/app_notification.dart
@@ -29,6 +29,21 @@ enum NotificationType {
   /// Follow-up reminder for uncompleted collab ("Did it happen?")
   collabFollowUpReminder,
 
+  /// A collaboration was created from an accepted application
+  collaborationCreated,
+
+  /// A collaboration moved into its active state
+  collaborationActivated,
+
+  /// Feedback was received for a collaboration
+  collaborationFeedbackReceived,
+
+  /// A collaboration was completed
+  collaborationCompleted,
+
+  /// A collaboration was cancelled
+  collaborationCancelled,
+
   /// A backend type the current app does not handle explicitly yet
   unknown;
 
@@ -52,6 +67,16 @@ enum NotificationType {
         return NotificationType.collabDayReminder;
       case 'collab_followup_reminder':
         return NotificationType.collabFollowUpReminder;
+      case 'collaboration_created':
+        return NotificationType.collaborationCreated;
+      case 'collaboration_activated':
+        return NotificationType.collaborationActivated;
+      case 'collaboration_feedback_received':
+        return NotificationType.collaborationFeedbackReceived;
+      case 'collaboration_completed':
+        return NotificationType.collaborationCompleted;
+      case 'collaboration_cancelled':
+        return NotificationType.collaborationCancelled;
       default:
         return NotificationType.unknown;
     }
@@ -77,6 +102,16 @@ enum NotificationType {
         return 'collab_day_reminder';
       case NotificationType.collabFollowUpReminder:
         return 'collab_followup_reminder';
+      case NotificationType.collaborationCreated:
+        return 'collaboration_created';
+      case NotificationType.collaborationActivated:
+        return 'collaboration_activated';
+      case NotificationType.collaborationFeedbackReceived:
+        return 'collaboration_feedback_received';
+      case NotificationType.collaborationCompleted:
+        return 'collaboration_completed';
+      case NotificationType.collaborationCancelled:
+        return 'collaboration_cancelled';
       case NotificationType.unknown:
         return 'unknown';
     }
@@ -162,8 +197,7 @@ class AppNotification {
     final rawType = json['type'] as String? ?? '';
     final id =
         json['id']?.toString() ?? json['notification_id']?.toString() ?? '';
-    final notificationId =
-        json['notification_id']?.toString() ?? id;
+    final notificationId = json['notification_id']?.toString() ?? id;
 
     return AppNotification(
       id: id,
@@ -206,22 +240,21 @@ class AppNotification {
     String? actorAvatarUrl,
     String? targetId,
     String? targetType,
-  }) =>
-      AppNotification(
-        id: id ?? this.id,
-        notificationId: notificationId ?? this.notificationId,
-        type: type ?? this.type,
-        rawType: rawType ?? this.rawType,
-        title: title ?? this.title,
-        body: body ?? this.body,
-        createdAt: createdAt ?? this.createdAt,
-        isRead: isRead ?? this.isRead,
-        readAt: readAt ?? this.readAt,
-        deeplink: deeplink ?? this.deeplink,
-        priority: priority ?? this.priority,
-        actorName: actorName ?? this.actorName,
-        actorAvatarUrl: actorAvatarUrl ?? this.actorAvatarUrl,
-        targetId: targetId ?? this.targetId,
-        targetType: targetType ?? this.targetType,
-      );
+  }) => AppNotification(
+    id: id ?? this.id,
+    notificationId: notificationId ?? this.notificationId,
+    type: type ?? this.type,
+    rawType: rawType ?? this.rawType,
+    title: title ?? this.title,
+    body: body ?? this.body,
+    createdAt: createdAt ?? this.createdAt,
+    isRead: isRead ?? this.isRead,
+    readAt: readAt ?? this.readAt,
+    deeplink: deeplink ?? this.deeplink,
+    priority: priority ?? this.priority,
+    actorName: actorName ?? this.actorName,
+    actorAvatarUrl: actorAvatarUrl ?? this.actorAvatarUrl,
+    targetId: targetId ?? this.targetId,
+    targetType: targetType ?? this.targetType,
+  );
 }

--- a/lib/features/notification/screens/notifications_screen.dart
+++ b/lib/features/notification/screens/notifications_screen.dart
@@ -356,7 +356,8 @@ class _NotificationTile extends StatelessWidget {
           context.colors.success.withValues(alpha: 0.15),
           context.colors.activeText,
         ),
-      NotificationType.applicationDeclined => (
+      NotificationType.applicationDeclined ||
+      NotificationType.applicationWithdrawn => (
           LucideIcons.xCircle,
           context.colors.error.withValues(alpha: 0.12),
           context.colors.error,

--- a/lib/features/notification/screens/notifications_screen.dart
+++ b/lib/features/notification/screens/notifications_screen.dart
@@ -377,7 +377,12 @@ class _NotificationTile extends StatelessWidget {
           context.colors.activeText,
         ),
       NotificationType.collabDayReminder ||
-      NotificationType.collabFollowUpReminder => (
+      NotificationType.collabFollowUpReminder ||
+      NotificationType.collaborationCreated ||
+      NotificationType.collaborationActivated ||
+      NotificationType.collaborationFeedbackReceived ||
+      NotificationType.collaborationCompleted ||
+      NotificationType.collaborationCancelled => (
           LucideIcons.calendarCheck,
           context.colors.primary.withValues(alpha: 0.15),
           context.colors.accentOrangeText,

--- a/lib/features/notification/utils/notification_navigation.dart
+++ b/lib/features/notification/utils/notification_navigation.dart
@@ -32,6 +32,7 @@ String resolveNotificationRoute({
     case 'application_received':
     case 'application_accepted':
     case 'application_declined':
+    case 'application_withdrawn':
       return KolabingRoutes.applicationDetails.replaceFirst(
         ':id',
         normalizedId,

--- a/lib/features/notification/utils/notification_navigation.dart
+++ b/lib/features/notification/utils/notification_navigation.dart
@@ -32,10 +32,21 @@ String resolveNotificationRoute({
     case 'application_received':
     case 'application_accepted':
     case 'application_declined':
-      return KolabingRoutes.applicationDetails.replaceFirst(':id', normalizedId);
+      return KolabingRoutes.applicationDetails.replaceFirst(
+        ':id',
+        normalizedId,
+      );
     case 'collab_day_reminder':
     case 'collab_followup_reminder':
-      return KolabingRoutes.collaborationDetails.replaceFirst(':id', normalizedId);
+    case 'collaboration_created':
+    case 'collaboration_activated':
+    case 'collaboration_feedback_received':
+    case 'collaboration_completed':
+    case 'collaboration_cancelled':
+      return KolabingRoutes.collaborationDetails.replaceFirst(
+        ':id',
+        normalizedId,
+      );
     default:
       return KolabingRoutes.notifications;
   }

--- a/test/features/notification/models/app_notification_test.dart
+++ b/test/features/notification/models/app_notification_test.dart
@@ -26,6 +26,37 @@ void main() {
     expect(notification.priority, NotificationPriority.high);
   });
 
+  test('fromJson parses collaboration completion-flow types', () {
+    const cases = <String, NotificationType>{
+      'collaboration_created': NotificationType.collaborationCreated,
+      'collaboration_activated': NotificationType.collaborationActivated,
+      'collaboration_feedback_received':
+          NotificationType.collaborationFeedbackReceived,
+      'collaboration_completed': NotificationType.collaborationCompleted,
+      'collaboration_cancelled': NotificationType.collaborationCancelled,
+    };
+
+    cases.forEach((rawType, expectedType) {
+      final notification = AppNotification.fromJson(<String, dynamic>{
+        'id': 'notif-$rawType',
+        'type': rawType,
+        'title': 'Collaboration update',
+        'body': 'Your collaboration changed state',
+        'deeplink': '/collaboration/col-1',
+        'priority': 'normal',
+        'is_read': false,
+        'created_at': '2026-05-09T10:20:30Z',
+        'target_id': 'col-1',
+        'target_type': 'collaboration',
+      });
+
+      expect(notification.type, expectedType);
+      expect(notification.rawType, rawType);
+      expect(notification.type.toJson(), rawType);
+      expect(notification.deeplink, '/collaboration/col-1');
+    });
+  });
+
   test('fromJson maps unsupported types to unknown instead of new message', () {
     final notification = AppNotification.fromJson(<String, dynamic>{
       'id': 'notif-2',

--- a/test/features/notification/models/app_notification_test.dart
+++ b/test/features/notification/models/app_notification_test.dart
@@ -57,6 +57,26 @@ void main() {
     });
   });
 
+  test('fromJson parses application_withdrawn with round-trip toJson', () {
+    final notification = AppNotification.fromJson(<String, dynamic>{
+      'id': 'notif-withdrawn',
+      'type': 'application_withdrawn',
+      'title': 'Application withdrawn',
+      'body': 'Ayse withdrew their application',
+      'deeplink': '/application/app-1',
+      'priority': 'normal',
+      'is_read': false,
+      'created_at': '2026-05-09T10:20:30Z',
+      'target_id': 'app-1',
+      'target_type': 'application',
+    });
+
+    expect(notification.type, NotificationType.applicationWithdrawn);
+    expect(notification.rawType, 'application_withdrawn');
+    expect(notification.type.toJson(), 'application_withdrawn');
+    expect(notification.deeplink, '/application/app-1');
+  });
+
   test('fromJson maps unsupported types to unknown instead of new message', () {
     final notification = AppNotification.fromJson(<String, dynamic>{
       'id': 'notif-2',

--- a/test/features/notification/utils/notification_navigation_test.dart
+++ b/test/features/notification/utils/notification_navigation_test.dart
@@ -14,24 +14,48 @@ void main() {
     expect(route, KolabingRoutes.communityWallet);
   });
 
-  test('resolveNotificationRoute falls back to legacy route when deeplink missing', () {
-    final route = resolveNotificationRoute(
-      type: 'new_message',
-      id: 'app-42',
-    );
+  test(
+    'resolveNotificationRoute falls back to legacy route when deeplink missing',
+    () {
+      final route = resolveNotificationRoute(type: 'new_message', id: 'app-42');
 
-    expect(
-      route,
-      KolabingRoutes.applicationChat.replaceFirst(':id', 'app-42'),
-    );
-  });
+      expect(
+        route,
+        KolabingRoutes.applicationChat.replaceFirst(':id', 'app-42'),
+      );
+    },
+  );
 
-  test('resolveNotificationRoute falls back to notifications for unsupported input', () {
-    final route = resolveNotificationRoute(
-      type: 'totally_unknown_type',
-      deeplink: '/not-a-real-route',
-    );
+  for (final type in const <String>[
+    'collaboration_created',
+    'collaboration_activated',
+    'collaboration_feedback_received',
+    'collaboration_completed',
+    'collaboration_cancelled',
+  ]) {
+    test('resolveNotificationRoute routes $type to collaboration detail', () {
+      final route = resolveNotificationRoute(
+        type: type,
+        id: 'col-7',
+        targetType: 'collaboration',
+      );
 
-    expect(route, KolabingRoutes.notifications);
-  });
+      expect(
+        route,
+        KolabingRoutes.collaborationDetails.replaceFirst(':id', 'col-7'),
+      );
+    });
+  }
+
+  test(
+    'resolveNotificationRoute falls back to notifications for unsupported input',
+    () {
+      final route = resolveNotificationRoute(
+        type: 'totally_unknown_type',
+        deeplink: '/not-a-real-route',
+      );
+
+      expect(route, KolabingRoutes.notifications);
+    },
+  );
 }

--- a/test/features/notification/utils/notification_navigation_test.dart
+++ b/test/features/notification/utils/notification_navigation_test.dart
@@ -47,6 +47,19 @@ void main() {
     });
   }
 
+  test('resolveNotificationRoute routes application_withdrawn to detail', () {
+    final route = resolveNotificationRoute(
+      type: 'application_withdrawn',
+      id: 'app-9',
+      targetType: 'application',
+    );
+
+    expect(
+      route,
+      KolabingRoutes.applicationDetails.replaceFirst(':id', 'app-9'),
+    );
+  });
+
   test(
     'resolveNotificationRoute falls back to notifications for unsupported input',
     () {


### PR DESCRIPTION
## 🎯 What does this PR do?

- Adds 6 notification types to `AppNotificationType` (`fromString` + `toJson`): the 5 collaboration completion-flow types (`collaboration_created`, `collaboration_activated`, `collaboration_feedback_received`, `collaboration_completed`, `collaboration_cancelled`) **and** `application_withdrawn`.
- Routes the 5 collaboration types to the existing `CollaborationDetailScreen` (`/collaboration/:id`) and `application_withdrawn` to the application detail (`/application/:id`), mirroring the existing application types.
- Maps the new types to icons in the notification list (collaboration → calendar icon; withdrawn → the application icon).

## 🐞 What problem does it solve?

The backend now sends completion-flow + withdraw notifications (to both business and community); tapping them must deep-link to the right screen. Closes #39.

## 🚀 What's needed for this to work in production?

- [x] Backend deploy must be live: paired `kolabing-v2` PR (#53) dispatching the 6 types + the localization work.
- [ ] New App Store / Play Store build to ship the new enum + routing. (Taps already resolve on current builds via the supported deeplink paths; the enum/icon work is for clean display + type fallback.)
- **Localization needs no app change:** the app already sends `locale` on `POST /device-token`; the backend now persists it and localizes notification copy server-side (en/es/ca), and the app renders the localized stored strings.

## 📱 Which branch should be merged for this work?

- Base branch: `master`
- Dependent branch(es): paired backend PR `kolabing-v2#53` (contract + localization source). App routes are forward-compatible.

## 🧪 How to test this merge (reviewer must be able to reproduce)

- **Affected role:** Business / Community
- **Test account / data:** a business + community pair with a collaboration / application
- **Steps:**
  1. Trigger a completion-flow event (complete / cancel / feedback) or withdraw an application from the backend.
  2. Receive the push or open the in-app notification list.
  3. Tap the notification.
- **Expected result:** collaboration notifications open `CollaborationDetailScreen` (`/collaboration/{id}`); `application_withdrawn` opens the application detail (`/application/{id}`). With `preferred_locale = es/ca`, the copy is in Spanish/Catalan.

## 📸 Screenshots / screen recording

- [x] This PR has **no UI/design change** (no screenshot needed) — only reuses existing icons (calendar / application) for the new notification types; titles/bodies are backend-provided. No new layout or component.

---

## ✅ Definition of Done (check before requesting review)
- [x] `flutter analyze` is clean (no new errors/warnings) — only pre-existing `info` lints in untouched code.
- [x] `dart format lib test` applied to changed files
- [ ] Tested on **iOS** simulator/device — not run (routing/logic change covered by unit tests)
- [ ] Tested on **Android** emulator/device — not run (routing/logic change covered by unit tests)
- [x] **Screenshots attached for every UI/design change** — N/A, no design change
- [x] New user-facing strings exist in i18n — N/A; notification copy is backend-provided and localized server-side (en/es/ca), not in the app's `.arb`.
- [x] No hardcoded values (base URL / IDs / emails / city–category lists — all from the API)
- [x] `BACKLOG.md` updated — N/A here; tracked in the backend repo's single canonical BACKLOG.

## 🤖 Was AI used?

Yes — Claude Code (Opus 4.8). Implemented the enum + routing + tests against a fixed cross-repo contract; reviewed and verified by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
