### PR TITLE
fix(profile): render Past Kolabs items + compact gallery (no empty gaps)

### DIFF
--- a/lib/features/profile/screens/public_profile_screen.dart
+++ b/lib/features/profile/screens/public_profile_screen.dart
@@ -349,7 +349,11 @@ class PublicProfileScreen extends ConsumerWidget {
     icon: LucideIcons.trophy,
     title: AppLocalizations.of(context).publicProfilePastKolabs,
     count: profile.kolabsCount,
-    child: profile.hasCollaborations
+    // Branch on whether there are actual cards to show — NOT the count. The
+    // count can be > 0 while the list is empty (e.g. a backend count/list
+    // mismatch); rendering the list then would leave a blank box instead of
+    // the empty state.
+    child: profile.pastCollaborations.isNotEmpty
         ? SizedBox(
             height: 110,
             child: ListView.separated(

--- a/lib/features/profile/services/public_profile_service.dart
+++ b/lib/features/profile/services/public_profile_service.dart
@@ -172,17 +172,20 @@ class PublicProfileService {
 
     if (response.statusCode == 200) {
       final json = jsonDecode(response.body) as Map<String, dynamic>;
-      // The endpoint is paginated: `data` is the list of completed
-      // collaborations (each a PublicCollaborationResource), with `meta` for
-      // paging. We only render the first page on the profile screen.
+      // The endpoint paginates via `$paginator->through(...)` wrapped under the
+      // `data` key, so the items are NESTED at `data.data` (Laravel paginator
+      // shape), with a separate top-level `meta`. Tolerate a flat `data` list
+      // too, in case the backend shape changes. We only render the first page.
       final data = json['data'];
-      if (data is List) {
-        return data
-            .whereType<Map<String, dynamic>>()
-            .map(PastCollaboration.fromJson)
-            .toList();
-      }
-      return const [];
+      final list = data is List
+          ? data
+          : (data is Map<String, dynamic> && data['data'] is List
+                ? data['data'] as List
+                : const <dynamic>[]);
+      return list
+          .whereType<Map<String, dynamic>>()
+          .map(PastCollaboration.fromJson)
+          .toList();
     }
 
     if (response.statusCode == 401 && allowRetry) {

--- a/lib/widgets/gallery/public_gallery_section.dart
+++ b/lib/widgets/gallery/public_gallery_section.dart
@@ -12,12 +12,12 @@ import 'photo_viewer_dialog.dart';
 ///
 /// Unlike [ProfileGallerySection], this does not allow adding or deleting photos.
 class PublicGallerySection extends StatelessWidget {
-  const PublicGallerySection({
-    required this.photos,
-    super.key,
-  });
+  const PublicGallerySection({required this.photos, super.key});
 
   final List<GalleryPhoto> photos;
+
+  /// Square thumbnail edge for the horizontal strip.
+  static const double _thumbSize = 112;
 
   @override
   Widget build(BuildContext context) {
@@ -43,11 +43,7 @@ class PublicGallerySection extends StatelessWidget {
           // Header
           Row(
             children: [
-              Icon(
-                LucideIcons.image,
-                size: 20,
-                color: context.colors.primary,
-              ),
+              Icon(LucideIcons.image, size: 20, color: context.colors.primary),
               const SizedBox(width: KolabingSpacing.xs),
               Text(
                 'Gallery',
@@ -66,66 +62,73 @@ class PublicGallerySection extends StatelessWidget {
           ),
           const SizedBox(height: KolabingSpacing.md),
 
-          // Photo grid
-          GridView.builder(
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 3,
-              crossAxisSpacing: KolabingSpacing.xs,
-              mainAxisSpacing: KolabingSpacing.xs,
-            ),
-            itemCount: photos.length,
-            itemBuilder: (context, index) {
-              final photo = photos[index];
-              return GestureDetector(
-                onTap: () => PhotoViewerDialog.show(
-                  context,
-                  photos: photos,
-                  initialIndex: index,
-                ),
-                child: ClipRRect(
-                  borderRadius: KolabingRadius.borderRadiusSm,
-                  child: photo.url.isEmpty
-                      ? Container(
-                          color: context.colors.surfaceVariant,
-                          child: Icon(
-                            LucideIcons.imageOff,
-                            size: 24,
-                            color: context.colors.textTertiary,
-                          ),
-                        )
-                      : Image.network(
-                          photo.url,
-                          fit: BoxFit.cover,
-                          loadingBuilder: (context, child, loadingProgress) {
-                            if (loadingProgress == null) return child;
-                            return Container(
+          // Horizontal thumbnail strip — sizes to its content so 1–2 photos
+          // never leave a sparse 3-column grid with empty rows/columns; more
+          // photos scroll horizontally. Matches the own-profile gallery.
+          SizedBox(
+            height: _thumbSize,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              padding: EdgeInsets.zero,
+              itemCount: photos.length,
+              separatorBuilder: (context, index) =>
+                  const SizedBox(width: KolabingSpacing.xs),
+              itemBuilder: (context, index) {
+                final photo = photos[index];
+                return GestureDetector(
+                  onTap: () => PhotoViewerDialog.show(
+                    context,
+                    photos: photos,
+                    initialIndex: index,
+                  ),
+                  child: ClipRRect(
+                    borderRadius: KolabingRadius.borderRadiusMd,
+                    child: SizedBox(
+                      width: _thumbSize,
+                      height: _thumbSize,
+                      child: photo.url.isEmpty
+                          ? Container(
                               color: context.colors.surfaceVariant,
-                              child: Center(
-                                child: SizedBox(
-                                  width: 16,
-                                  height: 16,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                    color: context.colors.primary,
-                                  ),
+                              child: Icon(
+                                LucideIcons.imageOff,
+                                size: 24,
+                                color: context.colors.textTertiary,
+                              ),
+                            )
+                          : Image.network(
+                              photo.url,
+                              fit: BoxFit.cover,
+                              loadingBuilder:
+                                  (context, child, loadingProgress) {
+                                    if (loadingProgress == null) return child;
+                                    return Container(
+                                      color: context.colors.surfaceVariant,
+                                      child: Center(
+                                        child: SizedBox(
+                                          width: 16,
+                                          height: 16,
+                                          child: CircularProgressIndicator(
+                                            strokeWidth: 2,
+                                            color: context.colors.primary,
+                                          ),
+                                        ),
+                                      ),
+                                    );
+                                  },
+                              errorBuilder: (_, __, ___) => Container(
+                                color: context.colors.surfaceVariant,
+                                child: Icon(
+                                  LucideIcons.imageOff,
+                                  size: 24,
+                                  color: context.colors.textTertiary,
                                 ),
                               ),
-                            );
-                          },
-                          errorBuilder: (_, __, ___) => Container(
-                            color: context.colors.surfaceVariant,
-                            child: Icon(
-                              LucideIcons.imageOff,
-                              size: 24,
-                              color: context.colors.textTertiary,
                             ),
-                          ),
-                        ),
-                ),
-              );
-            },
+                    ),
+                  ),
+                );
+              },
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
## 🎯 What does this PR do?
Two profile-screen fixes found while testing #51:
- **Past Kolabs rendered a blank box.** `GET /profiles/{id}/collaborations` returns a Laravel paginator wrapped under `data`, so the items are nested at `data.data`; the service parsed `json['data']` as a flat list → always empty (count said "2" but no cards). Now reads `data.data` (tolerates a flat list too). Also, the section rendered the (empty) list whenever the **count** was > 0 — now it branches on `pastCollaborations.isNotEmpty`, so an empty list shows the empty state instead of a blank box.
- **Gallery had a large empty gap** with few photos (single small thumbnail in a sparse 3-column grid). Reworked `PublicGallerySection` into a horizontal 112px thumbnail strip (BoxFit.cover, rounded), matching the own-profile gallery — no gap for 1–2 photos, scrolls for more.

## 🐞 What problem does it solve?
Public/community profiles showed "Past Kolabs (2)" with nothing below it, and a gallery card that looked broken/empty with one photo. Both are now correct.

## 🚀 What's needed for this to work in production?
Nothing extra — pure client fixes against the existing `/profiles/{id}` + `/profiles/{id}/collaborations` contracts.

## 📱 Which branch should be merged for this work?
- Base branch: `master`
- Dependent branch(es): This branch only.

## 🧪 How to test this merge (reviewer must be able to reproduce)
- **Affected role:** Business / Community (any viewer of a public profile).
- **Test account / data:** a profile with ≥1 completed collaboration review and ≥1 gallery photo (e.g. the seeded "Real Run Club" on dev).
- **Steps:**
  1. Open a public profile (My Kolabs → a collaboration → tap the partner; or Explore → a Kolab → View profile).
  2. **Past Kolabs:** confirm the cards render (count matches cards). For a profile with 0 collaborations, confirm the "No past kolabs" empty state (never a blank box).
  3. **Gallery:** confirm photos show as a horizontal thumbnail strip with no large empty gap above/around a single photo; tap a thumbnail → full-screen viewer.
- **Expected result:** Past Kolabs lists the collaborations; gallery is a compact strip.

## 📸 Screenshots / screen recording
- [ ] This PR has **no UI/design change** (no screenshot needed)

> Verified live on the iOS simulator (dev backend): Past Kolabs now renders 2 cards (was a blank box); gallery is a compact horizontal strip. Before/after sim screenshots available; attach to the PR if required before merge.

| Before | After |
| ------ | ----- |
| Past Kolabs "(2)" + blank box; gallery single photo with big empty gap | Past Kolabs lists the cards; gallery = compact horizontal strip |

---

## ✅ Definition of Done
- [x] `flutter analyze` clean (no new errors/warnings)
- [x] `dart format` applied to changed files
- [x] Verified on iOS simulator (dev backend) via hot reload
- [ ] Android not separately verified (layout-only, no platform code)
- [x] No new user-facing strings (reused existing l10n)
- [x] No hardcoded values (endpoints unchanged)
- [ ] BACKLOG.md — n/a (bugfix, not a tracked backlog item)

## 🤖 Was AI used?
Yes — Claude Code root-caused both bugs (captured the live `/collaborations` paginator body to confirm the parse mismatch) and implemented the fixes. Reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
