### PR TITLE
feat(completion): show review form to both first and second confirmers

### DIFF
--- a/lib/features/collaboration/widgets/kolab_completion_sheet.dart
+++ b/lib/features/collaboration/widgets/kolab_completion_sheet.dart
@@ -34,13 +34,10 @@ class KolabCompletionResult {
 ///            `/completion` immediately (earns XP once, regardless of answer).
 ///            - 'yes' → also attempts `/complete`.
 ///            - 'no' / 'not yet' → acknowledges and closes; no `/complete` call.
-///   Step 1 — OPTIONAL, SKIPPABLE impact data (star rating + yes/no questions +
-///            role-aware metrics), reached after ANY 'yes' answer — whether
-///            `/complete` fully succeeded or is still waiting on the partner
-///            (QA fix 2026-06-27: previously only the SECOND confirmer ever
-///            saw this step; the first lost access to it permanently).
-///            POSTs `/feedback` only if the user fills it in; "Skip for now" is
-///            always available and does not block completion (it already
+///   Step 1 — OPTIONAL, SKIPPABLE 5-star review form, reached after ANY 'yes'
+///            answer by EITHER party (first or second confirmer). POSTs
+///            `/review` if filled in; "Skip for now" is always available and
+///            does not block completion (the completion confirmation already
 ///            happened from the caller's side). Whoever skips can come back
 ///            later from the collaboration detail screen.
 ///   Step 2 — Celebration + XP preview (only when `/complete` fully succeeded)
@@ -241,14 +238,10 @@ class _KolabCompletionSheetState extends State<KolabCompletionSheet>
       if (!mounted) return;
       setState(() {
         _isConfirming = false;
-        // The 5-star review (POST /review) is only accepted by the backend for
-        // an active|completed collaboration. When /complete did NOT finish the
-        // Kolab (still awaiting the partner — e.g. a scheduled Kolab one party
-        // confirmed), go straight to the awaiting-partner step instead of the
-        // review form, which would 422 `collaboration_not_reviewable`. The
-        // review stays available from the detail screen once the Kolab actually
-        // completes (startAtFeedback re-entry).
-        _step = _completeSucceeded ? 1 : 4;
+        // Always show the optional review form (Step 1) after a 'yes' answer,
+        // regardless of whether /complete succeeded yet. The destination after
+        // Step 1 is decided by _completeSucceeded inside _goToCelebration().
+        _step = 1;
       });
       HapticFeedback.mediumImpact();
     } catch (_) {


### PR DESCRIPTION
## 🎯 What does this PR do?
- Removes the gate that skipped the 5-star review form for the first confirmer in the dual-confirmation flow
- Both parties now always land on the review form (Step 1) immediately after confirming "yes"
- After the form, the routing is unchanged: celebration if the collab completed, "awaiting partner" screen if still pending

## 🐞 What problem does it solve?
The first confirmer (whichever of business/community taps "mark as completed" first) was jumped directly to the "awaiting partner" screen, never seeing the review form at all. Only the second confirmer (whose "yes" caused the collab to flip to `completed`) saw it. This was a UX regression introduced when the completion gate was moved from rich feedback to the lightweight yes/no confirmation.

Closes N/A — bug reported in-session

## 🚀 What's needed for this to work in production?
- [ ] Backend deploy must be live: the companion backend PR (kolabing-v2 `feat/review-form-first-confirmer`) must be merged and deployed first. Without it, first confirmers on `scheduled`-status collabs would receive a 422 from `POST /review`.

## 📱 Which branch should be merged for this work?
- Base branch: `feat/kolab-public-reputation`
- Dependent branch(es): kolabing-v2 `feat/review-form-first-confirmer` (backend, must deploy first)

## 🧪 How to test this merge (reviewer must be able to reproduce)
- **Affected role:** Business and Community
- **Test account / data:** Any active or scheduled collaboration with a partner
- **Steps:**
  1. Open any collaboration in `scheduled` or `active` status
  2. Tap "Mark as completed"
  3. In Step 0, tap "Yes, it happened"
  4. Observe Step 1 (the 5-star review form)
- **Expected result:** The review form appears immediately for BOTH the first and second confirmer. After submitting or skipping: second confirmer → celebration screen; first confirmer → "awaiting partner" screen.
- **Before fix:** First confirmer skipped straight to "awaiting partner" with no review form shown.

## 📸 Screenshots / screen recording
- [ ] This PR has **no UI/design change** (no screenshot needed)

The review form itself is unchanged — only the condition for showing it changed.

---

## ✅ Definition of Done (check before requesting review)
- [x] `flutter analyze` is clean (no new errors/warnings introduced by this PR)
- [x] Tested on **iOS** simulator
- [ ] Tested on **Android** emulator/device
- [x] No hardcoded values

## 🤖 Was AI used?
Claude Code (claude-sonnet-4-6) — diagnosed the root cause, planned and implemented the fix under human review.