### PR TITLE
fix(profile): hide "0 partners" on reputation card when no partners (#57)

### DIFF
--- a/lib/features/profile/screens/public_profile_screen.dart
+++ b/lib/features/profile/screens/public_profile_screen.dart
@@ -1319,13 +1319,16 @@ class _ReputationSummaryCard extends StatelessWidget {
               label: l10n.publicProfileReputationReviewsCount(rep.reviewCount),
             ),
           ),
-          Flexible(
-            child: _ReputationStat(
-              label: l10n.publicProfileReputationPartnersCount(
-                rep.uniquePartnerCount,
+          // Hide the partner count entirely when there are none — "0 partners"
+          // is noise on a fresh profile.
+          if (rep.uniquePartnerCount > 0)
+            Flexible(
+              child: _ReputationStat(
+                label: l10n.publicProfileReputationPartnersCount(
+                  rep.uniquePartnerCount,
+                ),
               ),
             ),
-          ),
         ],
       ),
     );


### PR DESCRIPTION
## 🎯 What does this PR do?
- On the public profile reputation summary card, hides the partner-count stat when `uniquePartnerCount == 0`.
- Rating and the reviews stat are unchanged; the `spaceBetween` row simply drops the empty "0 partners" item.

## 🐞 What problem does it solve?
A profile with reviews but no linked partners showed a meaningless "0 partners" on the reputation card. Reported with a screenshot (⭐ 5.0 · 2 reviews · 0 partners).

Closes #57

## 🚀 What's needed for this to work in production?
Nothing extra — client-only presentation change.

## 📱 Which branch should be merged for this work?
- Base branch: `master`
- Dependent branch(es): This branch only.

## 🧪 How to test this merge (reviewer must be able to reproduce)
- **Affected role:** Business / Community (any public profile viewer)
- **Test account / data:** a profile that has ≥1 review but 0 unique partners (fresh reviewed profile); and, for the control, a profile with ≥1 partner.
- **Steps:**
  1. Open the public profile of an account with reviews but no partners.
  2. Look at the reputation summary card (rating · reviews · partners row).
  3. Open a profile that has ≥1 partner.
- **Expected result:** The 0-partner profile shows only rating + reviews (no "0 partners"). The ≥1-partner profile still shows the partner count as before.

## 📸 Screenshots / screen recording
Before (reported):

⭐ 5.0    2 reviews    0 partners

After: the "0 partners" item is removed → ⭐ 5.0    2 reviews

- [ ] This PR has **no UI/design change** (no screenshot needed)

| Before | After |
| ------ | ----- |
| `⭐ 5.0 · 2 reviews · 0 partners` | `⭐ 5.0 · 2 reviews` |

_On-device after-screenshot to be captured during review verification._

---

## ✅ Definition of Done (check before requesting review)
- [x] `flutter analyze` is clean (no new errors/warnings — remaining infos in the file are pre-existing)
- [x] `dart format lib test` applied to changed files
- [ ] Tested on **iOS** simulator/device (pending device verify)
- [ ] Tested on **Android** emulator/device (pending device verify)
- [x] **Screenshots** — before/after described above (visual change is a removal of one text item)
- [x] New user-facing strings exist in i18n — N/A, no new strings (an existing string is conditionally hidden)
- [x] No hardcoded values
- [ ] `BACKLOG.md` updated — N/A, small polish tied to the reputation-card feature; no backlog item

## 🤖 Was AI used?
Yes — Claude Code (Opus 4.8) located the card and made the conditional-render change. Ownership/review remains with the author.
