### PR TITLE
Redesign Business Dashboard to match Community styling

### DIFF
--- a/lib/features/business/screens/business_main_screen.dart
+++ b/lib/features/business/screens/business_main_screen.dart
@@ -138,9 +138,10 @@ class _BusinessMainScreenState extends ConsumerState<BusinessMainScreen> {
         ],
       ),
       floatingActionButton:
-          // Show only on Home (0) / Explore (1). Hidden on My Kolabs (2, has its
-          // own create FAB), Chats (3), and Profile (4).
-          _currentIndex < 2
+          // Hidden on Home (0, the yellow hero card already has a Create Kolab
+          // CTA), My Kolabs (2, has its own create FAB), Chats (3), Profile (4).
+          // Shown only on Explore (1).
+          _currentIndex == 1
           ? KolabingFAB(
               onPressed: _onFabPressed,
               tooltip: l10n.businessMainCreateKolabTooltip,

--- a/lib/features/dashboard/screens/business_dashboard_screen.dart
+++ b/lib/features/dashboard/screens/business_dashboard_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:lucide_icons/lucide_icons.dart';
 
+import '../../../config/constants/radius.dart';
 import '../../../config/constants/spacing.dart';
 import '../../../config/routes/routes.dart';
 import '../../../config/theme/colors.dart';
@@ -13,13 +15,20 @@ import '../../../widgets/ui_icon.dart';
 import '../../auth/providers/auth_provider.dart';
 import '../../../widgets/navigation/profile_avatar_button.dart';
 import '../../notification/widgets/notification_bell.dart';
+import '../../rewards/providers/wallet_provider.dart';
 import '../../rewards/widgets/referral_banner_card.dart';
 import '../../subscription/widgets/subscription_paywall.dart';
 import '../models/dashboard_model.dart';
 import '../providers/dashboard_provider.dart';
 import '../widgets/dashboard_shimmer.dart';
-import '../widgets/dashboard_stat_card.dart';
 import '../widgets/upcoming_collaboration_card.dart';
+
+// Design tokens for the "Business Activity" hero card — matches the
+// Community Dashboard's yellow card language, minus the game-like elements
+// (no progress bar, no level badge).
+const _cardBg = Color(0xFFFFE28C);
+const _inkDark = Color(0xFF19150F);
+const _mutedLabel = Color(0xFF9A7C28);
 
 /// Business Dashboard Screen
 ///
@@ -47,11 +56,27 @@ class _BusinessDashboardScreenState
       if (!state.isInitialized && !state.isLoading) {
         ref.read(dashboardProvider.notifier).load();
       }
+      // Also load wallet data so the referral code is available for the
+      // compact referral card (same provider the Community Dashboard uses).
+      final walletState = ref.read(walletProvider);
+      if (walletState.wallet == null && !walletState.isLoading) {
+        ref.read(walletProvider.notifier).load();
+      }
     });
   }
 
   Future<void> _onRefresh() async {
     await ref.read(dashboardProvider.notifier).refresh();
+  }
+
+  Future<void> _onCreateKolab() async {
+    final allowed = await SubscriptionPaywall.checkAndShow(context, ref);
+    if (!allowed || !mounted) return;
+    await context.push(KolabingRoutes.kolabNew);
+    if (mounted) {
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      if (mounted) ref.invalidate(dashboardProvider);
+    }
   }
 
   @override
@@ -97,19 +122,23 @@ class _BusinessDashboardScreenState
       children: [
         // Header
         _buildHeader(userName, isDark),
+        const SizedBox(height: KolabingSpacing.sm),
+
+        // Positioning message
+        _buildPositioningMessage(),
         const SizedBox(height: KolabingSpacing.lg),
 
-        // Stats grid 2x2
-        _buildStatsGrid(data),
-        const SizedBox(height: KolabingSpacing.xl),
+        // Main yellow "Business Activity" card
+        _buildActivityHeroCard(data),
+        const SizedBox(height: KolabingSpacing.lg),
 
-        // Referral banner (rewards)
-        const ReferralBannerCard(),
-        const SizedBox(height: KolabingSpacing.xl),
+        // Grow Your Business — action cards
+        _buildGrowSection(data),
+        const SizedBox(height: KolabingSpacing.lg),
 
-        // Quick actions
-        _buildQuickActions(),
-        const SizedBox(height: KolabingSpacing.xl),
+        // Referral — compact secondary card
+        const ReferralBannerCard(compact: true),
+        const SizedBox(height: KolabingSpacing.lg),
 
         // Upcoming collaborations
         _buildUpcomingSection(data, isDark),
@@ -132,9 +161,7 @@ class _BusinessDashboardScreenState
             Text(
               AppLocalizations.of(context).dashboardBusinessTitle,
               style: KolabingTextStyles.headlineLarge.copyWith(
-                color: isDark
-                    ? context.colors.textOnDark
-                    : context.colors.onSurface,
+                color: context.colors.titleInk,
                 letterSpacing: 1.0,
               ),
             ),
@@ -153,101 +180,153 @@ class _BusinessDashboardScreenState
   );
 
   // ---------------------------------------------------------------------------
-  // Stats Grid
+  // Positioning message (static display copy)
   // ---------------------------------------------------------------------------
 
-  Widget _buildStatsGrid(BusinessDashboard data) => Column(
-    children: [
-      Row(
-        children: [
-          Expanded(
-            child: DashboardStatCard(
-              title: AppLocalizations.of(context).dashboardStatPublished,
-              count: data.opportunities.published,
-              icon: LucideIcons.megaphone,
-              accent: StatCardAccent.active,
-              subtitle: '${data.opportunities.total} total requests',
-            ),
+  Widget _buildPositioningMessage() => Padding(
+    padding: const EdgeInsets.only(right: KolabingSpacing.xl),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Fill your business with the right people.',
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontWeight: FontWeight.w700,
+            color: context.colors.onSurface,
           ),
-          const SizedBox(width: KolabingSpacing.sm),
-          Expanded(
-            child: DashboardStatCard(
-              title: AppLocalizations.of(context).dashboardStatPendingApplications,
-              count: data.applicationsReceived.pending,
-              icon: LucideIcons.clock,
-              iconSlug: UiIconSlug.clock,
-              accent: StatCardAccent.pending,
-              subtitle: '${data.applicationsReceived.total} total',
-            ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          'Create experiences that turn communities into visits, content and loyalty.',
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontSize: 12,
+            color: context.colors.textTertiary,
           ),
-        ],
-      ),
-      const SizedBox(height: KolabingSpacing.sm),
-      Row(
-        children: [
-          Expanded(
-            child: DashboardStatCard(
-              title: AppLocalizations.of(context).dashboardStatActiveKolabs,
-              count: data.collaborations.active,
-              icon: LucideIcons.users,
-              accent: StatCardAccent.accepted,
-              subtitle: '${data.collaborations.upcoming} upcoming',
-            ),
-          ),
-          const SizedBox(width: KolabingSpacing.sm),
-          Expanded(
-            child: DashboardStatCard(
-              title: AppLocalizations.of(context).dashboardStatCompleted,
-              count: data.collaborations.completed,
-              icon: LucideIcons.checkCircle,
-              iconSlug: UiIconSlug.checkCircle,
-              accent: StatCardAccent.completed,
-              subtitle: '${data.collaborations.total} total',
-            ),
-          ),
-        ],
-      ),
-    ],
+        ),
+      ],
+    ),
   );
 
   // ---------------------------------------------------------------------------
-  // Quick Actions
+  // Main yellow "Business Activity" hero card
   // ---------------------------------------------------------------------------
 
-  Widget _buildQuickActions() => Row(
-    children: [
-      Expanded(
-        child: KolabingButton(
-          label: AppLocalizations.of(context).dashboardCreateKolabRequest,
-          onPressed: () async {
-            final allowed = await SubscriptionPaywall.checkAndShow(
-              context,
-              ref,
-            );
-            if (!allowed || !mounted) return;
-            await context.push(KolabingRoutes.kolabNew);
-            if (mounted) {
-              await Future<void>.delayed(const Duration(milliseconds: 300));
-              if (mounted) ref.invalidate(dashboardProvider);
-            }
-          },
-          variant: KolabingButtonVariant.primary,
-          size: KolabingButtonSize.compact,
-          icon: const Icon(LucideIcons.plus),
+  Widget _buildActivityHeroCard(BusinessDashboard data) => Container(
+    width: double.infinity,
+    padding: const EdgeInsets.all(16),
+    decoration: const BoxDecoration(
+      color: _cardBg,
+      borderRadius: BorderRadius.all(Radius.circular(24)),
+    ),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Top-left black pill
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+          decoration: const BoxDecoration(
+            color: _inkDark,
+            borderRadius: BorderRadius.all(Radius.circular(999)),
+          ),
+          child: Text(
+            'BUSINESS ACTIVITY',
+            style: GoogleFonts.inter(
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              color: _cardBg,
+              letterSpacing: 0.8,
+            ),
+          ),
         ),
-      ),
-      const SizedBox(width: KolabingSpacing.sm),
-      Expanded(
-        child: KolabingButton(
-          label: AppLocalizations.of(context).dashboardFindAKolab,
-          onPressed: () => widget.onSwitchTab?.call(1),
-          variant: KolabingButtonVariant.secondary,
-          size: KolabingButtonSize.compact,
-          icon: const Icon(LucideIcons.search),
+        const SizedBox(height: KolabingSpacing.xs),
+
+        // Main number: live/published offers
+        Text(
+          '${data.opportunities.published}',
+          style: GoogleFonts.anton(fontSize: 40, color: _inkDark, height: 0.9),
         ),
-      ),
-    ],
+        Text(
+          'LIVE OFFERS',
+          style: GoogleFonts.inter(
+            fontSize: 11,
+            fontWeight: FontWeight.w700,
+            color: _mutedLabel,
+            letterSpacing: 1.2,
+          ),
+        ),
+
+        const SizedBox(height: KolabingSpacing.sm),
+
+        // Supporting stats
+        Row(
+          children: [
+            _HeroMiniStat(count: data.applicationsReceived.pending, label: 'NEW APPS'),
+            const SizedBox(width: KolabingSpacing.xs),
+            _HeroMiniStat(count: data.collaborations.active, label: 'ACTIVE'),
+            const SizedBox(width: KolabingSpacing.xs),
+            _HeroMiniStat(count: data.collaborations.completed, label: 'COMPLETED'),
+          ],
+        ),
+
+        const SizedBox(height: KolabingSpacing.sm),
+
+        KolabingButton(
+          label: '+ CREATE A KOLAB',
+          onPressed: _onCreateKolab,
+          variant: KolabingButtonVariant.dark,
+          height: 42,
+        ),
+      ],
+    ),
   );
+
+  // ---------------------------------------------------------------------------
+  // Grow Your Business — action cards
+  // ---------------------------------------------------------------------------
+
+  Widget _buildGrowSection(BusinessDashboard data) {
+    final pending = data.applicationsReceived.pending;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'GROW YOUR BUSINESS',
+          style: KolabingTextStyles.labelLarge.copyWith(color: context.colors.onSurface, letterSpacing: 1.0),
+        ),
+        const SizedBox(height: KolabingSpacing.sm),
+        _GrowActionCard(
+          icon: LucideIcons.plus,
+          title: 'Create a Kolab',
+          subtitle: 'Post a new offer for communities to apply',
+          onTap: _onCreateKolab,
+        ),
+        const SizedBox(height: KolabingSpacing.xs),
+        _GrowActionCard(
+          icon: LucideIcons.inbox,
+          title: 'Review applications',
+          subtitle: pending > 0 ? '$pending pending review' : 'No pending applications',
+          onTap: () => widget.onSwitchTab?.call(2),
+          highlighted: pending > 0,
+          badgeCount: pending > 0 ? pending : null,
+        ),
+        const SizedBox(height: KolabingSpacing.xs),
+        _GrowActionCard(
+          icon: LucideIcons.search,
+          title: AppLocalizations.of(context).dashboardFindAKolab,
+          subtitle: 'Browse community requests',
+          onTap: () => widget.onSwitchTab?.call(1),
+        ),
+        const SizedBox(height: KolabingSpacing.xs),
+        _GrowActionCard(
+          icon: LucideIcons.users,
+          title: 'View your Kolabs',
+          subtitle: '${data.collaborations.active} active · ${data.collaborations.completed} completed',
+          onTap: () => widget.onSwitchTab?.call(2),
+        ),
+      ],
+    );
+  }
 
   // ---------------------------------------------------------------------------
   // Upcoming Collaborations
@@ -281,12 +360,17 @@ class _BusinessDashboardScreenState
 
   Widget _buildEmptyUpcoming(bool isDark) => Container(
     width: double.infinity,
-    padding: const EdgeInsets.symmetric(vertical: KolabingSpacing.xl),
+    padding: const EdgeInsets.all(KolabingSpacing.lg),
+    decoration: BoxDecoration(
+      color: context.colors.surface,
+      borderRadius: KolabingRadius.borderRadiusLg,
+      border: Border.all(color: context.colors.hairline),
+    ),
     child: Column(
       children: [
         UiIcon(
           icon: UiIconSlug.calendar,
-          size: 40,
+          size: 32,
           color: isDark
               ? context.colors.textOnDark.withValues(alpha: 0.5)
               : context.colors.textTertiary,
@@ -294,9 +378,24 @@ class _BusinessDashboardScreenState
         const SizedBox(height: KolabingSpacing.sm),
         Text(
           AppLocalizations.of(context).dashboardNoUpcomingKolabs,
-          style: KolabingTextStyles.bodySmall.copyWith(color: isDark
-                ? context.colors.textOnDark.withValues(alpha: 0.5)
-                : context.colors.textTertiary),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontWeight: FontWeight.w600,
+            color: context.colors.onSurface,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          'Create a Kolab to start filling your calendar',
+          style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.textTertiary),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: KolabingSpacing.md),
+        KolabingButton(
+          label: AppLocalizations.of(context).dashboardCreateKolabRequest,
+          onPressed: _onCreateKolab,
+          variant: KolabingButtonVariant.secondary,
+          size: KolabingButtonSize.compact,
+          icon: const Icon(LucideIcons.plus),
         ),
       ],
     ),
@@ -334,4 +433,131 @@ class _BusinessDashboardScreenState
       ),
     ),
   );
+}
+
+// ---------------------------------------------------------------------------
+// Local widgets — used exclusively by the Business Dashboard
+// ---------------------------------------------------------------------------
+
+/// Small supporting stat inside the yellow hero card.
+class _HeroMiniStat extends StatelessWidget {
+  const _HeroMiniStat({required this.count, required this.label});
+
+  final int count;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) => Expanded(
+    child: Container(
+      padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 8),
+      decoration: BoxDecoration(
+        color: _inkDark.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(
+        children: [
+          Text(
+            '$count',
+            style: GoogleFonts.anton(fontSize: 17, color: _inkDark, height: 1.0),
+          ),
+          const SizedBox(height: 1),
+          Text(
+            label,
+            textAlign: TextAlign.center,
+            style: GoogleFonts.inter(
+              fontSize: 9,
+              fontWeight: FontWeight.w700,
+              color: _mutedLabel,
+              letterSpacing: 0.4,
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+/// White rounded action card used in the "Grow Your Business" section.
+class _GrowActionCard extends StatelessWidget {
+  const _GrowActionCard({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+    this.highlighted = false,
+    this.badgeCount,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+  final bool highlighted;
+  final int? badgeCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = context.colors;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: KolabingRadius.borderRadiusLg,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: KolabingSpacing.sm, vertical: KolabingSpacing.sm),
+          decoration: BoxDecoration(
+            color: highlighted ? c.softYellow : c.surface,
+            borderRadius: KolabingRadius.borderRadiusLg,
+            border: Border.all(color: highlighted ? c.softYellowBorder : c.hairline),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: c.surfaceContainerLow,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Icon(icon, size: 17, color: c.onSurface),
+              ),
+              const SizedBox(width: KolabingSpacing.sm),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: KolabingTextStyles.bodySmall.copyWith(
+                        fontWeight: FontWeight.w700,
+                        color: c.onSurface,
+                      ),
+                    ),
+                    Text(
+                      subtitle,
+                      style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: c.textTertiary),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+              if (badgeCount != null) ...[
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                  decoration: const BoxDecoration(color: _inkDark, borderRadius: BorderRadius.all(Radius.circular(999))),
+                  child: Text(
+                    '$badgeCount',
+                    style: GoogleFonts.inter(fontSize: 11, fontWeight: FontWeight.w700, color: _cardBg),
+                  ),
+                ),
+                const SizedBox(width: KolabingSpacing.xs),
+              ],
+              Icon(LucideIcons.chevronRight, size: 18, color: c.textTertiary),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/lib/features/rewards/widgets/referral_banner_card.dart
+++ b/lib/features/rewards/widgets/referral_banner_card.dart
@@ -18,10 +18,19 @@ import '../../../widgets/kolabing_button.dart';
 /// where the user can copy or share the code.
 ///
 /// When [usePastelStyle] is true, uses a pastel yellow background and border.
+///
+/// When [compact] is true, renders a small secondary card (icon + two lines +
+/// share button) instead of the full step-by-step layout — used by dashboards
+/// that already have a primary hero card and just need a lightweight nudge.
 class ReferralBannerCard extends ConsumerWidget {
-  const ReferralBannerCard({super.key, this.usePastelStyle = false});
+  const ReferralBannerCard({
+    super.key,
+    this.usePastelStyle = false,
+    this.compact = false,
+  });
 
   final bool usePastelStyle;
+  final bool compact;
 
   // ---------------------------------------------------------------------------
   // Build
@@ -43,6 +52,13 @@ class ReferralBannerCard extends ConsumerWidget {
     const stepBoxFill = Color(0xFFFFF9E6);
     const badgeFill = Color(0xFFFFE28C);
     const arrowCircleFill = Color(0xFFFFFDF5);
+
+    if (compact) {
+      return _CompactReferralCard(
+        referralCode: referralCode,
+        onTap: () => _showReferralCodeSheet(context, referralCode),
+      );
+    }
 
     return Container(
       width: double.infinity,
@@ -439,5 +455,74 @@ class _ReferralCodeSheet extends StatelessWidget {
         );
       }
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Compact secondary card — small gift icon, two lines, share action
+// ---------------------------------------------------------------------------
+
+class _CompactReferralCard extends StatelessWidget {
+  const _CompactReferralCard({required this.referralCode, required this.onTap});
+
+  final String referralCode;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(KolabingSpacing.md),
+      decoration: BoxDecoration(
+        color: context.colors.surface,
+        borderRadius: KolabingRadius.borderRadiusLg,
+        border: Border.all(color: context.colors.softYellowBorder),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: context.colors.softYellow,
+              shape: BoxShape.circle,
+            ),
+            child: const Icon(LucideIcons.gift, size: 18, color: Color(0xFF19150F)),
+          ),
+          const SizedBox(width: KolabingSpacing.sm),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  l10n.referralBannerEarnBySharing,
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    color: context.colors.onSurface,
+                    letterSpacing: 0.8,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  l10n.referralBannerTagline,
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    fontSize: 12,
+                    color: context.colors.textTertiary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: KolabingSpacing.xs),
+          IconButton(
+            onPressed: onTap,
+            icon: const Icon(LucideIcons.share2, size: 18),
+            color: context.colors.onSurface,
+          ),
+        ],
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Summary
- Replaces the 2x2 stat-card grid and oversized referral block on the Business Dashboard with a compact yellow "Business Activity" hero card, a "Grow Your Business" action list, and a smaller secondary "Earn by Sharing" referral card, matching the Community Dashboard's visual language while staying more professional (no XP/levels/progress bar).
- Removed the redundant "Your Activity" stats strip (duplicated data already shown in the hero card) and moved the referral card above "Upcoming Kolabs".
- Hid the floating Create-Kolab FAB on the Home tab now that the hero card has its own CTA (still shown on Explore).
- Added an opt-in `compact` display mode to the shared `ReferralBannerCard` widget (default behavior for the Community Dashboard is unchanged).

Design/layout only — no backend, API, model, route, or state-management changes. All values reuse the existing `BusinessDashboard` model fields (`opportunities.published`, `applicationsReceived.pending`, `collaborations.active/completed`) and all actions reuse existing callbacks/tab-switch routes.

## Test plan
- [x] `flutter analyze` on the three changed files — 0 errors (pre-existing style-lint infos only)
- [x] Ran the app on iOS Simulator (dev backend) and verified the dashboard rebuilds and renders without runtime errors
- [ ] Manual visual check on a business-role account in the simulator (needs reviewer with business test credentials)
- [ ] Confirm Community Dashboard is unaffected (uses `ReferralBannerCard` with default `compact: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)