### PR TITLE
chore(ios): bump build number 19 → 20 to ship new App Store icon

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: kolabing_app
 description: "Kolabing - Collaboration marketplace connecting businesses and communities"
 publish_to: 'none'
 
-version: 1.5.1+19
+version: 1.5.1+20
 
 environment:
   sdk: ^3.10.7


### PR DESCRIPTION
## 🎯 What does this PR do?

- Bumps the iOS/Android build number in `pubspec.yaml`: `1.5.1+19` → `1.5.1+20`.
- No icon files or config change — the correct **KOLABING cloud** app icon is already in the iOS asset catalog (`ios/Runner/Assets.xcassets/AppIcon.appiconset/`), generated by `flutter_launcher_icons` from `assets/brand/kolabing-wordmark-yellow-bg.png`.

## 🐞 What problem does it solve?

The App Store listing still shows the **old "K" app icon** (attached to the live build, no. 2). The App Store marketing icon is baked into the build binary and **cannot be changed in App Store Connect directly** — a new build carrying the already-correct icon must be uploaded and selected. This bump lets App Store Connect accept that new upload.

Closes #73

## 🚀 What's needed for this to work in production?

- [x] New App Store build (version / build no: **1.5.1+20**) — must be built (`make ipa-prod`), uploaded via Transporter/Xcode Organizer, selected for the version in App Store Connect, and submitted for review.
- The new icon only appears on the App Store **after that build is approved and released** (icon is part of the binary).
- Nothing else extra: no env var/secret, no backend deploy, no feature flag, no third-party setup.

## 📱 Which branch should be merged for this work?

- Base branch: `master`
- Dependent branch(es): This branch only

## 🧪 How to test this merge (reviewer must be able to reproduce)

- **Affected role:** Business / Community / Attendee (all — app-wide icon)
- **Test account / data:** N/A (build metadata only)
- **Steps:**
  1. Check out this branch and confirm `pubspec.yaml` reads `version: 1.5.1+20`.
  2. `make ipa-prod` → produces `build/ios/ipa/*.ipa`.
  3. Upload the IPA to App Store Connect and select build **20** for the version.
- **Expected result:** In App Store Connect the version's **Included Assets → App Icon** shows the KOLABING cloud icon (not the old "K"). Home-screen icon after install is the KOLABING cloud icon.

## 📸 Screenshots / screen recording

- [x] This PR has **no UI/design change** (no screenshot needed)

The diff is a one-line build-number bump; no in-app UI/Dart code changes. The visible effect (App Store/home-screen icon) comes from the icon asset already committed to the repo and can only be verified on the App Store after the new build is uploaded — local Xcode signing is not configured in this environment.

| Before | After |
| ------ | ----- |
| App Store icon: old "K" (build 2) | App Store icon: KOLABING cloud (build 20, after upload+review) |

---

## ✅ Definition of Done (check before requesting review)
- [x] `flutter analyze` is clean — N/A: no Dart/code change, only the `pubspec.yaml` version string.
- [x] `dart format lib test` applied to changed files — N/A: no Dart files changed.
- [ ] Tested on **iOS** simulator/device — pending: needs signed build + App Store upload (local signing not configured here).
- [ ] Tested on **Android** emulator/device — N/A for the App Store icon; icon set is already generated.
- [x] **Screenshots attached for every UI/design change** — N/A: no UI/design change in the diff (see above).
- [x] New user-facing strings exist in i18n — N/A: no new strings.
- [x] No hardcoded values — N/A: no code change.
- [x] `BACKLOG.md` updated — N/A: build-number chore, not a tracked feature/fix backlog item.

## 🤖 Was AI used?

Yes — Claude Code (Opus 4.8) diagnosed why the App Store icon was stale (marketing icon baked into the build; repo icon already correct), created issue #73, opened this branch, and bumped the build number. Build + upload steps remain manual by the maintainer.
