### PR TITLE
chore(ios): iPhone-only + encryption exemption + build 21 (App Store submit fixes)

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -621,7 +621,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Profile;
@@ -762,7 +762,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1";
 			};
 			name = Debug;
 		};
@@ -815,7 +815,7 @@
 				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -899,7 +899,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1";
 			};
 			name = Debug;
 		};
@@ -927,7 +927,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1";
 			};
 			name = Release;
 		};
@@ -955,7 +955,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1";
 			};
 			name = Profile;
 		};

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -92,5 +92,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: kolabing_app
 description: "Kolabing - Collaboration marketplace connecting businesses and communities"
 publish_to: 'none'
 
-version: 1.5.1+20
+version: 1.5.1+21
 
 environment:
   sdk: ^3.10.7


### PR DESCRIPTION
## 🎯 What does this PR do?

- Makes the iOS app **iPhone-only**: `TARGETED_DEVICE_FAMILY` `1,2` → `1` across all build configs.
- Adds `ITSAppUsesNonExemptEncryption = false` to `ios/Runner/Info.plist` (standard-encryption exemption).
- Bumps build number: `1.5.1+20` → `1.5.1+21`.
- No Dart/UI code changes.

## 🐞 What problem does it solve?

App Store submission was blocked with **"You must upload a screenshot for 13-inch iPad displays."** The app was declaring iPad support (Flutter's default `1,2`), so Apple required iPad screenshots — but we don't support iPad. Dropping to iPhone-only removes that requirement. While rebuilding, we also declare the encryption exemption so the export-compliance prompt stops appearing at submit (the app uses only standard HTTPS/TLS + keychain).

Closes #75

## 🚀 What's needed for this to work in production?

- [x] New App Store build (version / build no: **1.5.1+21**) — rebuild `make ipa-prod`, upload via Xcode Organizer, select build 21 for the version, submit for review.
- Build 20 (still iPad-supporting) should be discarded in favor of 21.
- Nothing else extra: no env var/secret, no backend deploy, no feature flag, no third-party setup.

## 📱 Which branch should be merged for this work?

- Base branch: `master`
- Dependent branch(es): This branch only

## 🧪 How to test this merge (reviewer must be able to reproduce)

- **Affected role:** Business / Community / Attendee (all — app-wide packaging)
- **Test account / data:** N/A (build/packaging metadata only)
- **Steps:**
  1. Check out this branch; confirm `grep TARGETED_DEVICE_FAMILY ios/Runner.xcodeproj/project.pbxproj` shows `"1"` everywhere, `pubspec.yaml` is `1.5.1+21`, and `ITSAppUsesNonExemptEncryption`/`false` is in Info.plist.
  2. `make ipa-prod` → archive; upload build 21 to App Store Connect.
  3. In the version, confirm App Store Connect **no longer requires iPad screenshots** and does **not** prompt for export-compliance docs.
- **Expected result:** Version can be submitted with iPhone screenshots only; app installs on iPhone (not offered on iPad).

## 📸 Screenshots / screen recording

- [x] This PR has **no UI/design change** (no screenshot needed)

Packaging/metadata only — no in-app UI/Dart change. The user-visible effect (no iPad offering, iPhone-only App Store listing) is verifiable in App Store Connect after build 21 is uploaded. Local Xcode signing/upload is done by the maintainer.

| Before | After |
| ------ | ----- |
| Universal (iPhone+iPad); Apple demands 13" iPad screenshots | iPhone-only; no iPad screenshots required |

---

## ✅ Definition of Done (check before requesting review)
- [x] `flutter analyze` is clean — N/A: no Dart/code change (Xcode project + Info.plist + pubspec version only).
- [x] `dart format lib test` applied — N/A: no Dart files changed.
- [ ] Tested on **iOS** — pending: needs signed build 21 + App Store upload (verified locally that the archive builds iPhone-only).
- [x] Tested on **Android** — N/A: iOS-only packaging change.
- [x] **Screenshots for UI/design change** — N/A: no UI change.
- [x] i18n strings in all three ARBs — N/A: no new strings.
- [x] No hardcoded values — N/A: no code change.
- [x] `BACKLOG.md` updated — N/A: iOS packaging chore, not a tracked feature/fix item.

## 🤖 Was AI used?

Yes — Claude Code (Opus 4.8) diagnosed the iPad-screenshot block (TARGETED_DEVICE_FAMILY = 1,2), switched the app to iPhone-only, added the encryption exemption, bumped the build number, created issue #75, and opened this branch/PR. The rebuild + App Store upload/submit remain manual by the maintainer.
