### PR TITLE
fix(ios): remove 'location' from UIBackgroundModes (App Review 2.5.4)

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -73,7 +73,6 @@
 	<array>
 		<string>fetch</string>
 		<string>remote-notification</string>
-		<string>location</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>


### PR DESCRIPTION
## 🎯 What does this PR do?
Removes the `location` entry from `UIBackgroundModes` in `ios/Runner/Info.plist` (keeps `fetch` + `remote-notification`).

## 🐞 What problem does it solve?
App Store rejection **Guideline 2.5.4** — the app declared background `location` but has no persistent background-location feature (geolocator is used foreground-only for event/kolab discovery).

Closes #96

## 🚀 Production needs
New iOS binary. Nothing else.

## 📱 Branch
- Base: `master` · This branch only.

## 🧪 How to test
- Discovery/nearby features still work in the foreground; no background-location capability is requested. Verify the app builds and location-based discovery works while the app is open.

## 📸 Screenshots
- [x] No UI/design change (native Info.plist only)

| Before | After |
|--|--|
| N/A | N/A |

## ✅ Definition of Done
- [x] `plutil -lint` passes
- [x] `flutter analyze` N/A (no Dart change)
- [ ] Tested on iOS device (build)
- [x] No UI change
- [x] No hardcoded values
- [x] Info.plist valid

## 🤖 Was AI used?
Yes — Claude Code (Opus 4.8). Ownership stays with @olucvolkan.