### PR TITLE
fix(auth): provider-neutral 'account not found' copy for Apple sign-in (App Review 2.1a)

### DIFF
--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -174,7 +174,7 @@
   "loginHeroWelcome": "Benvingut de nou.",
   "loginSignUpLink": "Registrar-se",
   "loginUserNotFoundTitle": "Compte no trobat",
-  "loginUserNotFoundMessage": "No existeix cap compte amb aquest correu de Google. Crea un compte primer.",
+  "loginUserNotFoundMessage": "Encara no existeix cap compte per a aquest inici de sessió. Crea un compte primer.",
   "loginCreateAccountButton": "Crear compte",
   "forgotPasswordFormTitle": "Restableix la teva contrasenya",
   "forgotPasswordFormSubtitle": "Introdueix el correu del teu compte i t'enviarem un enllaç segur per restablir-la.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -695,7 +695,7 @@
   "@loginUserNotFoundTitle": {
     "description": "Dialog title shown when Google sign-in finds no matching account."
   },
-  "loginUserNotFoundMessage": "No account exists with this Google email. Please create an account first.",
+  "loginUserNotFoundMessage": "No account exists for this sign-in yet. Please create an account first.",
   "@loginUserNotFoundMessage": {
     "description": "Dialog body shown when Google sign-in finds no matching account."
   },

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -174,7 +174,7 @@
   "loginHeroWelcome": "Bienvenido de nuevo.",
   "loginSignUpLink": "Registrarse",
   "loginUserNotFoundTitle": "Cuenta no encontrada",
-  "loginUserNotFoundMessage": "No existe ninguna cuenta con este correo de Google. Crea una cuenta primero.",
+  "loginUserNotFoundMessage": "Aún no existe ninguna cuenta para este inicio de sesión. Crea una cuenta primero.",
   "loginCreateAccountButton": "Crear cuenta",
   "forgotPasswordFormTitle": "Restablece tu contraseña",
   "forgotPasswordFormSubtitle": "Introduce el correo de tu cuenta y te enviaremos un enlace seguro para restablecerla.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1147,7 +1147,7 @@ abstract class AppLocalizations {
   /// Dialog body shown when Google sign-in finds no matching account.
   ///
   /// In en, this message translates to:
-  /// **'No account exists with this Google email. Please create an account first.'**
+  /// **'No account exists for this sign-in yet. Please create an account first.'**
   String get loginUserNotFoundMessage;
 
   /// Button in the user-not-found dialog to start account creation.

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -573,7 +573,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get loginUserNotFoundMessage =>
-      'No existeix cap compte amb aquest correu de Google. Crea un compte primer.';
+      'Encara no existeix cap compte per a aquest inici de sessió. Crea un compte primer.';
 
   @override
   String get loginCreateAccountButton => 'Crear compte';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -566,7 +566,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get loginUserNotFoundMessage =>
-      'No account exists with this Google email. Please create an account first.';
+      'No account exists for this sign-in yet. Please create an account first.';
 
   @override
   String get loginCreateAccountButton => 'Create Account';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -568,7 +568,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get loginUserNotFoundMessage =>
-      'No existe ninguna cuenta con este correo de Google. Crea una cuenta primero.';
+      'Aún no existe ninguna cuenta para este inicio de sesión. Crea una cuenta primero.';
 
   @override
   String get loginCreateAccountButton => 'Crear cuenta';


### PR DESCRIPTION
## 🎯 What does this PR do?
Rewords the shared login "account not found" dialog so it no longer says **"Google"** for an Apple sign-in.

## 🐞 What problem does it solve?
App Store rejection **Guideline 2.1(a)**: "displayed a 'No account exists with this Google email' message after we tried to Sign in with Apple." Root cause: `login_screen`'s `_UserNotFoundDialog` uses `loginUserNotFoundMessage`, which was hardcoded `"No account exists with this Google email…"` and is shown for **both** Google and Apple `isUserNotFound` results. So Apple sign-in for a non-existent account surfaced Google-worded copy.

Fix: `loginUserNotFoundMessage` → provider-neutral **"No account exists for this sign-in yet. Please create an account first."** (en/es/ca). The dialog already offers **Create Account** → routes to sign-up, so a new Apple user is not dead-ended.

Closes #98

## 🚀 Production needs
New iOS binary. Also ensure the backend `/auth/apple` build is deployed to the reviewed environment (the endpoint is correct on `master`; the reviewer likely also hit a stale deploy).

## 📱 Branch
- Base: `master` · This branch only.

## 🧪 How to test (iPad)
1. Sign in with Apple using an Apple ID that has **no** Kolabing account.
2. Expect the "Account Not Found" dialog with the **neutral** message (no "Google") + a **Create Account** button that opens sign-up.
3. Sign in with Apple for an **existing** account → logs in.

## 📸 Screenshots
- [ ] This PR has no UI/design change — copy only; screen recording of Apple sign-in on a physical iPad to be attached for App Review.

| Before | After |
|--|--|
| "No account exists with this **Google** email…" (on Apple) | "No account exists for this sign-in yet…" |

## ✅ Definition of Done
- [x] `flutter analyze` clean (gen-l10n regenerated)
- [x] i18n updated in en/es/ca
- [x] No hardcoded values
- [ ] Device test on iPad (Apple sign-in)

## 🤖 Was AI used?
Yes — Claude Code (Opus 4.8) root-caused + fixed. Ownership stays with @olucvolkan.