### PR TITLE
chore(ios): bump build 21 → 32 for App Review resubmission

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: kolabing_app
 description: "Kolabing - Collaboration marketplace connecting businesses and communities"
 publish_to: 'none'
 
-version: 1.5.1+21
+version: 1.5.1+32
 
 environment:
   sdk: ^3.10.7


### PR DESCRIPTION
Bumps `version: 1.5.1+21` → `1.5.1+32` (must exceed build 31 already on App Store Connect). Carries the merged App Review fixes: #102 (bg-location), #103 (Apple sign-in copy), #104 (UGC moderation). No functional change. N/A screenshots (build metadata only).