### PR TITLE
chore(ios): build 34 for App Review resubmission + Podfile.lock sync

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,6 +1,4 @@
 PODS:
-  - app_links (6.4.1):
-    - Flutter
   - AppAuth (1.7.6):
     - AppAuth/Core (= 1.7.6)
     - AppAuth/ExternalUserAgent (= 1.7.6)
@@ -219,7 +217,6 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
-  - app_links (from `.symlinks/plugins/app_links/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_crashlytics (from `.symlinks/plugins/firebase_crashlytics/ios`)
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
@@ -269,8 +266,6 @@ SPEC REPOS:
     - Sentry
 
 EXTERNAL SOURCES:
-  app_links:
-    :path: ".symlinks/plugins/app_links/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
   firebase_crashlytics:
@@ -315,7 +310,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  app_links: 3dbc685f76b1693c66a6d9dd1e9ab6f73d97dc0a
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   Firebase: d99ac19b909cd2c548339c2241ecd0d1599ab02e

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: kolabing_app
 description: "Kolabing - Collaboration marketplace connecting businesses and communities"
 publish_to: 'none'
 
-version: 1.5.1+32
+version: 1.5.1+34
 
 environment:
   sdk: ^3.10.7


### PR DESCRIPTION
## 🎯 What does this PR do?

- Bumps `pubspec.yaml` from `1.5.1+32` to **`1.5.1+34`** so a new binary can be uploaded to App Store Connect.
- Syncs `ios/Podfile.lock`: drops the stale **`app_links`** pod. It is no longer in `pubspec.lock` and no longer symlinked under `ios/.symlinks/plugins/`, but `Podfile.lock` still pinned it — the `pod install` inside `flutter build ipa` regenerated it. Committing it means the next `pod install` is a no-op instead of a surprise diff in someone's working tree.
- No Dart code change.

## 🐞 What problem does it solve?

App Review looked at build **33** and rejected it on 2026-08-04, so any new upload must carry a strictly higher build number. `master` has since gained everything the resubmission depends on:

| PR | What |
|---|---|
| #109 | €39.99 → €49 pricing pass + `docs/release/APP-REVIEW-2026-08-04-resolution.md` |
| #106 | `SubscriptionLegalFooter` — auto-renew disclosure + **Terms of Use (EULA)** + **Privacy Policy** links on the paywall and the subscription screen (**Guideline 3.1.2**) |
| #93 | request/response body `debugPrint` redaction in `opportunity_service.dart` |
| #111 | monthly price corrected €49 → **€49.99** to match the ASC price point |

Refs #112

## 🚀 What's needed for this to work in production?

- [x] **New App Store build** — version **1.5.1**, build **34**, built with `make ipa-prod` (i.e. `--dart-define=APP_ENV=prod`; a bare Xcode Archive would *not* pass the define).
- [x] **Third-party setup (IAP product):** the Monthly subscription price point is already set to **49,99 €** in App Store Connect.
- [ ] **App Store Connect (Account Holder), before resubmitting:** Business → Agreements → **Paid Applications Agreement "In Effect"** + Bank/Tax complete; App Privacy labels corrected (nothing under *"Used to Track You"*); Monthly + 3-months + the *Kolabing Premium* group **Ready to Submit** and attached to the version. Full checklist in `docs/release/APP-REVIEW-2026-08-04-resolution.md`.
- [ ] **Backend:** `config/subscriptions.php` in `kolabing-v2` still needs the 49.99 bump (separate repo, Stripe/web path only — does not gate this build).
- Nothing else: no env var, no migration, no feature flag.

## 📱 Which branch should be merged for this work?

- Base branch: `master`
- Dependent branch(es): none — this branch only. #109, #106, #93 and #111 are already merged.

## 🧪 How to test this merge (reviewer must be able to reproduce)

- **Affected role:** Business
- **Test account / data:** a Business account **without** an active subscription, on a device signed into a **Sandbox Apple ID**.
- **Steps:**
  1. Install build **34** from TestFlight.
  2. Settings → General → About, or TestFlight's build row: confirm it reads **1.5.1 (34)**.
  3. Sign in as the Business user → **My Kolabs → create a Kolab** to open the paywall.
  4. Read the monthly price on the plan card.
  5. Below the subscribe CTA, tap **Terms of Use (EULA)** and then **Privacy Policy**.
  6. Complete a sandbox purchase of the monthly plan.
- **Expected result:**
  - Price reads **49,99 €** (StoreKit live price on iOS).
  - Both legal links open the real pages in the external browser, and the auto-renew disclosure is visible above them.
  - The sandbox purchase completes and unlocks Kolab creation.

## 📸 Screenshots / screen recording

- [x] This PR has **no UI/design change** (no screenshot needed) — one line of `pubspec.yaml` + a lockfile. The UI it *ships* was reviewed on #106 / #111.

| Before | After |
| ------ | ----- |
| `version: 1.5.1+32` | `version: 1.5.1+34` |

App launch smoke-checked on the **iPhone 17 Pro simulator (iOS 26.2)** against the prod backend (`flutter run --dart-define=APP_ENV=prod`) — app boots, welcome screen renders, `https://kolabing.com/api/v1` confirmed in the logs. The paywall itself (49,99 € + EULA/Privacy links) still needs a Business account without a subscription to walk through — **not verified in this PR**.

## ---

## ✅ Definition of Done (check before requesting review)
- [x] `flutter analyze` is clean (0 errors on `master`; this PR adds no Dart code)
- [x] `dart format lib test` — N/A, no Dart file touched
- [x] Tested on **iOS** — release archive built locally with `make ipa-prod` (`Runner.xcarchive`, 1.5.1 (34)); the app also boots on the iOS 26.2 simulator against prod
- [ ] Tested on **Android** — **N/A for this PR**: the bump exists to satisfy the iOS App Store build-number rule. Android ships from the same `pubspec.yaml` and is unaffected.
- [x] **Screenshots** — N/A, no UI change (see box above)
- [x] i18n — N/A, no new user-facing strings
- [x] No hardcoded values
- [x] `BACKLOG.md` — no new entry needed; FX-39/FX-41/FX-42 already describe what this build carries

## 🤖 Was AI used?

Yes — Claude Code (Opus 5) merged #109/#106/#93 (resolving their conflicts), opened and prepared #111, bumped the build number, ran `make ipa-prod`, and drafted this description. Review and ownership stay with @olucvolkan.
