### PR TITLE
fix(ios): obtain notification consent before any push registration (App Store 4.5.4)

### DIFF
--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -7,7 +7,7 @@
 		<string>$(AppIdentifierPrefix)com.kolabing.kolabingApp</string>
 	</array>
 	<key>aps-environment</key>
-	<string>development</string>
+	<string>production</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>

--- a/lib/features/auth/providers/auth_state_provider.dart
+++ b/lib/features/auth/providers/auth_state_provider.dart
@@ -2,7 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../config/routes/routes.dart';
 import '../../../services/one_signal_service.dart';
-import '../../../services/permission_service.dart';
+import '../utils/auth_navigation.dart';
 import 'auth_provider.dart';
 
 /// Represents the navigation destination after splash screen
@@ -105,18 +105,12 @@ class SplashStateNotifier extends Notifier<SplashState> {
         navTarget = SplashNavigationTarget.communityDashboard;
       }
 
-      // Check if the permission screen needs to be shown
-      final hasShownPermissions = await PermissionService.instance
-          .hasShownPermissionScreen();
-
-      if (!hasShownPermissions) {
-        state = state.copyWith(isLoading: false, navigationTarget: navTarget);
-        return '${KolabingRoutes.permissions}?destination='
-            '${Uri.encodeComponent(dashboard)}';
-      }
+      // The consent prompt must precede any push registration, so every
+      // dashboard entry runs through the permission gate.
+      final route = await gateDestinationOnPermissions(dashboard);
 
       state = state.copyWith(isLoading: false, navigationTarget: navTarget);
-      return dashboard;
+      return route;
     } on Exception catch (e) {
       // On error, default to the safe welcome chooser.
       await OneSignalService.instance.logout();

--- a/lib/features/auth/screens/attendee_register_screen.dart
+++ b/lib/features/auth/screens/attendee_register_screen.dart
@@ -228,8 +228,11 @@ class _AttendeeRegisterScreenState
           _showSuccess = true;
         });
         await Future<void>.delayed(const Duration(milliseconds: 400));
+        final route = await gateDestinationOnPermissions(
+          resolveAuthDestination(user, isNewUser: result.isNewUser),
+        );
         if (!mounted) return;
-        context.go(resolveAuthDestination(user, isNewUser: result.isNewUser));
+        context.go(route);
         return;
       }
 

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -9,7 +9,6 @@ import 'package:google_fonts/google_fonts.dart';
 import '../../../config/theme/colors.dart';
 import '../../../config/theme/typography.dart';
 import '../../../l10n/app_localizations.dart';
-import '../../../services/permission_service.dart';
 import '../providers/auth_provider.dart';
 import '../utils/auth_navigation.dart';
 import '../widgets/apple_sign_in_button.dart';
@@ -31,9 +30,6 @@ const Color _kDivider = Color(0xFFE1D9C8);
 const String _kWelcomeRoute = '/auth/welcome';
 const String _kUserTypeSelectionRoute = '/auth/user-type';
 const String _kForgotPasswordRoute = '/auth/forgot-password';
-const String _kBusinessDashboardRoute = '/business';
-const String _kCommunityDashboardRoute = '/community';
-const String _kPermissionsRoute = '/permissions';
 
 // ---------------------------------------------------------------------------
 // LoginScreen
@@ -294,22 +290,9 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
     final user = result.user;
     if (user == null) return _kWelcomeRoute;
 
-    final destination = resolveAuthDestination(
-      user,
-      isNewUser: result.isNewUser,
+    return gateDestinationOnPermissions(
+      resolveAuthDestination(user, isNewUser: result.isNewUser),
     );
-    if (destination != _kBusinessDashboardRoute &&
-        destination != _kCommunityDashboardRoute) {
-      return destination;
-    }
-
-    final hasShownPermissions = await PermissionService.instance
-        .hasShownPermissionScreen();
-    if (!hasShownPermissions) {
-      return '$_kPermissionsRoute?destination='
-          '${Uri.encodeComponent(destination)}';
-    }
-    return destination;
   }
 
   void _showUserNotFoundDialog() {

--- a/lib/features/auth/utils/auth_navigation.dart
+++ b/lib/features/auth/utils/auth_navigation.dart
@@ -1,7 +1,39 @@
 import 'package:flutter/foundation.dart';
 
 import '../../../config/routes/routes.dart';
+import '../../../services/permission_service.dart';
 import '../models/user_model.dart';
+
+/// Destinations that drop the user inside the authenticated app, and therefore
+/// must not be reached before the notification consent prompt has been raised.
+const Set<String> _kPermissionGatedDestinations = <String>{
+  KolabingRoutes.businessDashboard,
+  KolabingRoutes.communityDashboard,
+  KolabingRoutes.attendeeDashboard,
+};
+
+/// Routes [destination] through `/permissions` while notification consent is
+/// still outstanding.
+///
+/// Apple guideline 4.5.4 requires the system consent prompt *before* the app
+/// registers for or delivers any push notification. Every post-authentication
+/// path funnels through here so no role can slip past the prompt — an
+/// attendee-shaped destination silently bypassing the gate is what caused the
+/// 1.5 (36) rejection. Onboarding destinations pass straight through; each
+/// onboarding flow calls this helper again on its final step.
+Future<String> gateDestinationOnPermissions(String destination) async {
+  if (!_kPermissionGatedDestinations.contains(destination)) {
+    return destination;
+  }
+
+  final settled = await PermissionService.instance.hasShownPermissionScreen();
+  if (settled) {
+    return destination;
+  }
+
+  return '${KolabingRoutes.permissions}?destination='
+      '${Uri.encodeComponent(destination)}';
+}
 
 /// Resolves the next in-app route after authentication or session restore.
 String resolveAuthDestination(UserModel user, {bool isNewUser = false}) {

--- a/lib/features/onboarding/screens/attendee/attendee_step4_screen.dart
+++ b/lib/features/onboarding/screens/attendee/attendee_step4_screen.dart
@@ -5,10 +5,11 @@ import 'package:lucide_icons/lucide_icons.dart';
 
 import '../../../../config/constants/radius.dart';
 import '../../../../config/constants/spacing.dart';
+import '../../../../config/routes/routes.dart';
 import '../../../../config/theme/colors.dart';
 import '../../../../config/theme/typography.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../../services/permission_service.dart';
+import '../../../auth/utils/auth_navigation.dart';
 import '../../../community/models/community.dart';
 import '../../../community/providers/community_providers.dart';
 import '../../providers/attendee_onboarding_provider.dart';
@@ -72,14 +73,11 @@ class _AttendeeStep4ScreenState extends ConsumerState<AttendeeStep4Screen> {
   }
 
   Future<void> _goHome() async {
-    final hasShownPermissions =
-        await PermissionService.instance.hasShownPermissionScreen();
+    final route = await gateDestinationOnPermissions(
+      KolabingRoutes.attendeeDashboard,
+    );
     if (!mounted) return;
-    if (!hasShownPermissions) {
-      context.go('/permissions?destination=${Uri.encodeComponent('/attendee')}');
-    } else {
-      context.go('/attendee');
-    }
+    context.go(route);
   }
 
   @override

--- a/lib/features/onboarding/screens/business/business_final_screen.dart
+++ b/lib/features/onboarding/screens/business/business_final_screen.dart
@@ -7,10 +7,10 @@ import '../../../../config/routes/routes.dart';
 import '../../../../config/theme/colors.dart';
 import '../../../../config/theme/typography.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../../services/permission_service.dart';
 import '../../../../widgets/referral_code_field.dart';
 import '../../../auth/models/auth_response.dart';
 import '../../../auth/providers/auth_provider.dart';
+import '../../../auth/utils/auth_navigation.dart';
 import '../../../auth/widgets/terms_consent_checkbox.dart';
 import '../../providers/onboarding_provider.dart';
 import '../../utils/onboarding_field_label.dart';
@@ -158,18 +158,12 @@ class _BusinessFinalScreenState extends ConsumerState<BusinessFinalScreen> {
     await Future<void>.delayed(const Duration(milliseconds: 500));
     if (!mounted) return;
 
-    final hasShownPermissions = await PermissionService.instance
-        .hasShownPermissionScreen();
+    final route = await gateDestinationOnPermissions(
+      KolabingRoutes.businessDashboard,
+    );
     if (!mounted) return;
 
-    if (!hasShownPermissions) {
-      context.go(
-        '${KolabingRoutes.permissions}?destination='
-        '${Uri.encodeComponent(KolabingRoutes.businessDashboard)}',
-      );
-    } else {
-      context.go(KolabingRoutes.businessDashboard);
-    }
+    context.go(route);
   }
 
   Future<void> _handleSubmit({required bool authenticatedFlow}) async {

--- a/lib/features/onboarding/screens/community/community_final_screen.dart
+++ b/lib/features/onboarding/screens/community/community_final_screen.dart
@@ -7,7 +7,7 @@ import '../../../../config/routes/routes.dart';
 import '../../../../config/theme/colors.dart';
 import '../../../../config/theme/typography.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../../services/permission_service.dart';
+import '../../../auth/utils/auth_navigation.dart';
 import '../../../auth/widgets/terms_consent_checkbox.dart';
 import '../../providers/onboarding_provider.dart';
 import '../../utils/onboarding_field_label.dart';
@@ -153,19 +153,13 @@ class _CommunityFinalScreenState extends ConsumerState<CommunityFinalScreen> {
       await Future<void>.delayed(const Duration(milliseconds: 500));
       if (!mounted) return;
 
-      // Show permission screen on first registration
-      final hasShownPermissions = await PermissionService.instance
-          .hasShownPermissionScreen();
+      // Show the permission screen on first registration.
+      final route = await gateDestinationOnPermissions(
+        KolabingRoutes.communityDashboard,
+      );
       if (!mounted) return;
 
-      if (!hasShownPermissions) {
-        context.go(
-          '${KolabingRoutes.permissions}?destination='
-          '${Uri.encodeComponent(KolabingRoutes.communityDashboard)}',
-        );
-      } else {
-        context.go(KolabingRoutes.communityDashboard);
-      }
+      context.go(route);
     } else if (result.isNetworkError) {
       setState(() => _isLoading = false);
       _showNetworkErrorSnackBar();

--- a/lib/features/permission/screens/permission_screen.dart
+++ b/lib/features/permission/screens/permission_screen.dart
@@ -61,6 +61,16 @@ class _PermissionScreenState extends ConsumerState<PermissionScreen> {
       _locationGranted = locationStatus?.isGranted ?? false;
       _notificationGranted = notificationStatus.isGranted;
     });
+
+    // Apple guideline 4.5.4 asks that consent be obtained before any push is
+    // delivered — an explainer screen the user can walk past with "Continue"
+    // never raises the system prompt at all. On iOS a not-yet-requested
+    // permission reports as `denied` (an actual refusal becomes
+    // `permanentlyDenied`), so this fires exactly once per install.
+    if (notificationStatus.isDenied &&
+        !notificationStatus.isPermanentlyDenied) {
+      await _requestNotification(promptedAutomatically: true);
+    }
   }
 
   Future<void> _requestLocation() async {
@@ -76,7 +86,9 @@ class _PermissionScreenState extends ConsumerState<PermissionScreen> {
     }
   }
 
-  Future<void> _requestNotification() async {
+  Future<void> _requestNotification({
+    bool promptedAutomatically = false,
+  }) async {
     setState(() => _isRequestingNotification = true);
     final status = await _service.requestNotificationPermission();
     if (status.isGranted) {
@@ -87,6 +99,9 @@ class _PermissionScreenState extends ConsumerState<PermissionScreen> {
       _notificationGranted = status.isGranted;
       _isRequestingNotification = false;
     });
+    // Declining the prompt the app raised on the user's behalf is a valid
+    // answer — only nudge towards Settings when they asked for notifications.
+    if (promptedAutomatically) return;
     if (status.isPermanentlyDenied || status.isDenied) {
       _showSettingsDialog(
         AppLocalizations.of(context).permissionNotificationsTitle,

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -112,8 +112,29 @@ class NotificationService {
   // Token Management
   // ---------------------------------------------------------------------------
 
+  /// Whether the OS notification permission is currently granted.
+  Future<bool> hasPermission() async {
+    try {
+      final settings = await _messaging.getNotificationSettings();
+      return settings.authorizationStatus == AuthorizationStatus.authorized ||
+          settings.authorizationStatus == AuthorizationStatus.provisional;
+    } on Exception catch (e) {
+      debugPrint('[FCM] Could not read notification settings: $e');
+      return false;
+    }
+  }
+
   /// Get the current FCM token. Returns null if not available.
+  ///
+  /// Withheld while the notification permission is not granted: the caller
+  /// registers this token with the backend, which would make the device
+  /// addressable before the user ever consented (Apple guideline 4.5.4).
   Future<String?> getToken() async {
+    if (!await hasPermission()) {
+      debugPrint('[FCM] Token withheld — notification permission not granted');
+      return null;
+    }
+
     try {
       final token = await _messaging.getToken();
       debugPrint('[FCM] Token: $token');

--- a/lib/services/one_signal_service.dart
+++ b/lib/services/one_signal_service.dart
@@ -14,6 +14,7 @@ class OneSignalService {
   static const String _appId = '5fe7283d-a93e-46c7-b12a-f5d88b7c6571';
 
   bool _initialized = false;
+  bool _consentGiven = false;
   bool _clickListenerRegistered = false;
   bool _foregroundListenerRegistered = false;
   String? _currentExternalId;
@@ -21,6 +22,12 @@ class OneSignalService {
   void Function(OSNotification notification)? _onForegroundNotification;
 
   /// Initialize the OneSignal SDK once during app startup.
+  ///
+  /// Consent is declared as required *before* `initialize`, so the SDK creates
+  /// no push subscription and collects nothing until the user has granted the
+  /// system notification permission (Apple guideline 4.5.4). When the
+  /// permission is already granted from an earlier session the consent is
+  /// re-asserted here so the subscription reattaches on this launch.
   Future<void> initialize() async {
     if (_initialized) return;
 
@@ -28,14 +35,38 @@ class OneSignalService {
       await OneSignal.Debug.setLogLevel(OSLogLevel.verbose);
     }
 
+    await OneSignal.consentRequired(true);
     await OneSignal.initialize(_appId);
     _initialized = true;
+
+    if (OneSignal.Notifications.permission) {
+      await _giveConsent();
+    }
   }
 
+  /// Whether the user has granted notification permission on this install.
+  bool get hasConsent => _consentGiven;
+
   /// Request native notification permission through OneSignal.
+  ///
+  /// Consent is handed to the SDK only once the user actually accepts the
+  /// system prompt, so a declined prompt leaves the device unsubscribed.
   Future<bool> requestPermission({bool fallbackToSettings = true}) async {
     await initialize();
-    return OneSignal.Notifications.requestPermission(fallbackToSettings);
+    final granted = await OneSignal.Notifications.requestPermission(
+      fallbackToSettings,
+    );
+    if (granted) {
+      await _giveConsent();
+    }
+    return granted;
+  }
+
+  Future<void> _giveConsent() async {
+    if (_consentGiven) return;
+    await OneSignal.consentGiven(true);
+    await OneSignal.User.pushSubscription.optIn();
+    _consentGiven = true;
   }
 
   /// Attach push click events to app navigation.
@@ -67,8 +98,13 @@ class OneSignalService {
   }
 
   /// Identify the signed-in user for transactional and targeted messages.
+  ///
+  /// No-op until consent exists — identifying (and therefore making
+  /// addressable) a device the user never opted in to is what got the app
+  /// rejected under guideline 4.5.4.
   Future<void> loginUser(UserModel user, {bool force = false}) async {
     await initialize();
+    if (!_consentGiven) return;
 
     final externalId = user.id.trim();
     if (externalId.isEmpty) return;
@@ -88,7 +124,7 @@ class OneSignalService {
   /// becomes available so the push subscription is opted-in and attached.
   Future<void> syncUserAfterPermissionGrant(UserModel user) async {
     await initialize();
-    await OneSignal.User.pushSubscription.optIn();
+    await _giveConsent();
     await loginUser(user, force: true);
   }
 

--- a/lib/services/permission_service.dart
+++ b/lib/services/permission_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:permission_handler/permission_handler.dart';
 
+import '../config/feature_flags.dart';
 import 'notification_service.dart';
 import 'one_signal_service.dart';
 
@@ -17,13 +18,24 @@ class PermissionService {
 
   /// Whether the permission screen should be skipped.
   ///
-  /// Returns true only when both location and notification permissions are
-  /// already granted — i.e. there is nothing left to request.
+  /// Returns true only when there is nothing left to request. Location is only
+  /// part of that answer while the location row is actually shown — otherwise
+  /// the app never requests it, so folding it in here would keep the screen
+  /// pinned open forever (and would read a permission the screen deliberately
+  /// leaves alone).
   Future<bool> hasShownPermissionScreen() async {
     try {
-      final locationStatus = await Permission.locationWhenInUse.status;
       final notificationStatus = await Permission.notification.status;
-      return locationStatus.isGranted && notificationStatus.isGranted;
+      if (!notificationStatus.isGranted) {
+        return false;
+      }
+
+      if (!kLocationPermissionPromptEnabled) {
+        return true;
+      }
+
+      final locationStatus = await Permission.locationWhenInUse.status;
+      return locationStatus.isGranted;
     } on Exception {
       return false;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: kolabing_app
 description: "Kolabing - Collaboration marketplace connecting businesses and communities"
 publish_to: 'none'
 
-version: 1.5.1+35
+version: 1.5.1+37
 
 environment:
   sdk: ^3.10.7

--- a/test/features/auth/utils/auth_navigation_test.dart
+++ b/test/features/auth/utils/auth_navigation_test.dart
@@ -1,9 +1,12 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kolabing_app/config/routes/routes.dart';
 import 'package:kolabing_app/features/auth/models/user_model.dart';
 import 'package:kolabing_app/features/auth/utils/auth_navigation.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   const attendee = UserModel(
     id: 'a-1',
     email: 'a@example.com',
@@ -34,5 +37,80 @@ void main() {
       resolveAuthDestination(business, isNewUser: true),
       KolabingRoutes.businessOnboardingStep5,
     );
+  });
+
+  group('gateDestinationOnPermissions', () {
+    const channel = MethodChannel('flutter.baseflow.com/permissions/methods');
+
+    // PermissionStatus indices as encoded by permission_handler.
+    const denied = 0;
+    const granted = 1;
+
+    void mockPermissionStatus(int status) {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            if (call.method == 'checkPermissionStatus') {
+              return status;
+            }
+            return null;
+          });
+    }
+
+    const dashboards = <String>[
+      KolabingRoutes.businessDashboard,
+      KolabingRoutes.communityDashboard,
+      KolabingRoutes.attendeeDashboard,
+    ];
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    test('every dashboard is gated while consent is outstanding', () async {
+      mockPermissionStatus(denied);
+
+      for (final dashboard in dashboards) {
+        expect(
+          await gateDestinationOnPermissions(dashboard),
+          '${KolabingRoutes.permissions}?destination='
+          '${Uri.encodeComponent(dashboard)}',
+          reason:
+              '$dashboard must not be reachable before the consent prompt '
+              '(Apple guideline 4.5.4)',
+        );
+      }
+    });
+
+    test('the attendee dashboard is gated as well', () async {
+      // The 1.5 (36) rejection: only /business and /community were checked, so
+      // an attendee signing in reached the app without ever being asked.
+      mockPermissionStatus(denied);
+
+      expect(
+        await gateDestinationOnPermissions(KolabingRoutes.attendeeDashboard),
+        startsWith(KolabingRoutes.permissions),
+      );
+    });
+
+    test('dashboards pass through once consent is granted', () async {
+      mockPermissionStatus(granted);
+
+      for (final dashboard in dashboards) {
+        expect(await gateDestinationOnPermissions(dashboard), dashboard);
+      }
+    });
+
+    test('onboarding destinations are never diverted', () async {
+      mockPermissionStatus(denied);
+
+      for (final onboarding in <String>[
+        KolabingRoutes.attendeeOnboardingStep1,
+        KolabingRoutes.businessOnboardingStep5,
+        KolabingRoutes.communityOnboardingStep1,
+      ]) {
+        expect(await gateDestinationOnPermissions(onboarding), onboarding);
+      }
+    });
   });
 }


### PR DESCRIPTION
Closes #126

## What & why

App Store review rejected **1.5 (36)** under **Guideline 4.5.4** — *"The app does not
request and obtain the user's consent before sending push notifications."* Submission
`a0971075-25de-407d-ae02-4422ed4d237b`, reviewed 2026-08-20 on iPad Air 11-inch (M3).
Second rejection for the same guideline.

Two independent defects combined so the device became a **targetable push recipient
before the system prompt was ever shown**.

### 1. The permission gate was keyed on the destination route — and missed attendees

`login_screen.dart` checked only `/business` and `/community`:

```dart
if (destination != _kBusinessDashboardRoute &&
    destination != _kCommunityDashboardRoute) {
  return destination;               // early return — /permissions never reached
}
```

`resolveAuthDestination` returns `/attendee` for an existing attendee, so the attendee
sign-in path skipped `/permissions` entirely. `attendee_register_screen.dart` had no gate
at all. Splash / session-restore *did* handle attendees — that inconsistency is why the
hole went unnoticed.

### 2. The device was registered for push before any consent

- `main.dart` calls `OneSignal.initialize(appId)` at cold start with no consent declared,
  so the SDK creates a push subscription immediately.
- On sign-in, `_syncPushIdentity()` calls `OneSignal.login(externalId)` + `addTags(...)`
  and then `getToken()` → `POST /me/device-tokens` — with no authorization check.

Net effect: addressable from OneSignal *and* from our own backend before the user was asked.

### 3. The explainer screen could be walked past

The permission screen has separate "Allow notifications" and "Continue" buttons. A
reviewer tapping **Continue** never saw the OS prompt — while the app had already
registered the device. This is most likely what Apple actually observed.

## Changes

**Consent before registration**
- `OneSignal.consentRequired(true)` is set **before** `initialize()`, so the SDK creates
  no subscription and collects nothing until consent exists. Consent is given only after
  the user accepts the system prompt, and re-asserted on launch when the permission is
  already granted from an earlier session.
- `loginUser()` no-ops without consent. `syncUserAfterPermissionGrant()` goes through the
  same consent path instead of a bare `pushSubscription.optIn()`.
- `NotificationService.getToken()` withholds the FCM token while the OS permission is not
  granted, so nothing reaches the backend pre-consent. New `hasPermission()` built on
  `getNotificationSettings()`.

**The prompt is now unmissable**
- New `gateDestinationOnPermissions()` in `auth_navigation.dart` centralises the gate and
  covers **all three** dashboards. Every post-auth call site funnels through it: login,
  attendee register, splash restore, and the business / community / attendee onboarding
  final steps. Onboarding destinations still pass through untouched.
- The permission screen raises the system prompt itself the first time it appears.
  Declining an auto-raised prompt no longer pushes the "open Settings" dialog — that
  nudge is reserved for when the user asked for notifications themselves.

**Two adjacent bugs found on the way**
- `hasShownPermissionScreen()` required `locationStatus.isGranted && notificationStatus.isGranted`,
  but `kLocationPermissionPromptEnabled` is `false` so location is never requested — the
  gate could never settle and the screen reappeared on **every** launch. It also read a
  permission the screen deliberately leaves alone. Now notification-only while the
  location row is hidden.
- `ios/Runner/Runner.entitlements` (used by **Release** and Profile) had
  `aps-environment = development`, pointing App Store builds at the APNs **sandbox** —
  production pushes would never arrive. Now `production`. `Runner.Debug.entitlements`
  keeps `development`.

**Resubmission**
- `pubspec.yaml` → `1.5.1+37`.

## Testing

- `flutter analyze` — **0 errors** (info-level lints are pre-existing; no new ones in the
  touched files).
- `flutter test` — **320 passed / 10 failed**. The 10 are the same pre-existing failures
  as `master` (referral banner, opportunity cards, welcome hero, kolab form provider,
  disabled attendee card, community options) — none in the code this PR touches. Baseline
  before this branch was 316 / 10.
- **4 new tests** in `test/features/auth/utils/auth_navigation_test.dart`, mocking the
  `flutter.baseflow.com/permissions/methods` channel:
  - every dashboard is gated while consent is outstanding
  - the attendee dashboard specifically is gated (the 1.5 (36) regression)
  - dashboards pass through once consent is granted
  - onboarding destinations are never diverted

### Still needs device QA before resubmitting
- [ ] Fresh install on an **iPad** → sign in as **attendee** → the system prompt appears
      before the dashboard.
- [ ] Same for business and community.
- [ ] Decline the prompt → confirm no device token reaches the backend
      (`POST /me/device-tokens` absent) and OneSignal shows no subscription.
- [ ] Accept the prompt → token registers, a test push arrives.
- [ ] Verify the release build signs with `aps-environment = production`.

## Mobile impact (kolabing-app)

This *is* the mobile change. **No API contract change** — `POST /me/device-tokens` is
untouched, it is only deferred until after consent. No `kolabing-v2` PR required.

Behavioural note for the backend team: devices that never granted permission will no
longer appear in `device_tokens`, so the table will be smaller and more accurate than
before. Nothing to change server-side.

## Docs & rules updated

- [x] Tracking issue #126 opened with the full diagnosis.
- [ ] `BACKLOG.md` — **deliberately not touched here.** The working tree already carried an
      uncommitted FX-46 BACKLOG edit from a concurrent session; folding it into this commit
      would have shipped someone else's in-progress text. Needs a separate entry once that
      session lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
