### PR TITLE
fix(settings): notification toggles must reflect OS consent, not default to on (App Store 4.5.4)

### DIFF
--- a/lib/features/settings/providers/push_permission_provider.dart
+++ b/lib/features/settings/providers/push_permission_provider.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import '../../../services/permission_service.dart';
+
+/// Whether the OS notification permission is currently granted.
+///
+/// The notification settings screen reads this so its push toggles describe
+/// reality: while iOS is suppressing every push, a switch showing "on" is both
+/// untrue and — per Apple guideline 4.5.4 — a rejection ("the toggle in the app
+/// settings was pre-set to enable notifications").
+///
+/// Invalidate after raising the system prompt to re-read the decision.
+final pushPermissionGrantedProvider = FutureProvider<bool>((ref) async {
+  final status = await PermissionService.instance.checkNotificationPermission();
+  return status.isGranted;
+});

--- a/lib/features/settings/screens/notification_settings_screen.dart
+++ b/lib/features/settings/screens/notification_settings_screen.dart
@@ -1,16 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:permission_handler/permission_handler.dart';
 
+import '../../../config/constants/radius.dart';
 import '../../../config/constants/spacing.dart';
 import '../../../config/theme/colors.dart';
 import '../../../config/theme/typography.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../services/permission_service.dart';
+import '../../auth/providers/auth_provider.dart';
 import '../../business/models/notification_preferences.dart';
 import '../providers/notification_settings_provider.dart';
+import '../providers/push_permission_provider.dart';
 
 /// Notification preferences (NF-16 B3). Toggles bound to
-/// `GET`/`PUT /me/notification-preferences`, including `message_notifications`
-/// (default on). Works for any role — the endpoint is account-scoped.
+/// `GET`/`PUT /me/notification-preferences`. Works for any role — the endpoint
+/// is account-scoped.
+///
+/// Every push toggle is gated on the OS notification permission. Until that is
+/// granted the switches read off and act as the opt-in, because Apple guideline
+/// 4.5.4 treats a pre-enabled toggle as consent the user never gave.
 class NotificationSettingsScreen extends ConsumerWidget {
   const NotificationSettingsScreen({super.key});
 
@@ -18,6 +27,9 @@ class NotificationSettingsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final async = ref.watch(notificationSettingsProvider);
+    final pushGranted =
+        ref.watch(pushPermissionGrantedProvider).asData?.value ?? false;
+
     return Scaffold(
       backgroundColor: context.colors.background,
       appBar: AppBar(title: Text(l10n.notifSettingsTitle)),
@@ -29,10 +41,13 @@ class NotificationSettingsScreen extends ConsumerWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text(e.toString().replaceFirst('Exception: ', ''),
-                    textAlign: TextAlign.center,
-                    style: KolabingTextStyles.bodySmall
-                        .copyWith(color: context.colors.onSurfaceVariant)),
+                Text(
+                  e.toString().replaceFirst('Exception: ', ''),
+                  textAlign: TextAlign.center,
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    color: context.colors.onSurfaceVariant,
+                  ),
+                ),
                 const SizedBox(height: KolabingSpacing.lg),
                 OutlinedButton(
                   onPressed: () =>
@@ -43,16 +58,19 @@ class NotificationSettingsScreen extends ConsumerWidget {
             ),
           ),
         ),
-        data: (prefs) => _Toggles(prefs: prefs),
+        data: (prefs) => _Toggles(prefs: prefs, pushGranted: pushGranted),
       ),
     );
   }
 }
 
 class _Toggles extends ConsumerWidget {
-  const _Toggles({required this.prefs});
+  const _Toggles({required this.prefs, required this.pushGranted});
 
   final NotificationPreferences prefs;
+
+  /// Whether iOS/Android will actually deliver a push right now.
+  final bool pushGranted;
 
   Future<void> _save(
     BuildContext context,
@@ -66,45 +84,158 @@ class _Toggles extends ConsumerWidget {
     } catch (_) {
       if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context).notifSettingsSaveError)),
+        SnackBar(
+          content: Text(AppLocalizations.of(context).notifSettingsSaveError),
+        ),
       );
     }
+  }
+
+  /// Raises the system prompt and reports whether the user accepted.
+  ///
+  /// Nothing is stored and no token is registered unless they do. A permission
+  /// the OS will no longer prompt for sends the user to Settings instead.
+  Future<bool> _requestPushPermission(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    final status = await PermissionService.instance
+        .requestNotificationPermission();
+
+    if (status.isGranted) {
+      await ref.read(authProvider.notifier).syncPushPermissionGrant();
+    }
+    ref.invalidate(pushPermissionGrantedProvider);
+
+    if (!status.isGranted && status.isPermanentlyDenied && context.mounted) {
+      await PermissionService.instance.openSettings();
+    }
+
+    return status.isGranted;
+  }
+
+  /// One switch changed.
+  ///
+  /// Without the OS permission the switch is the opt-in: prompt first, and only
+  /// write the preference once the user has actually said yes.
+  Future<void> _onToggle(
+    BuildContext context,
+    WidgetRef ref, {
+    required NotificationPreferences Function({required bool value}) update,
+    required bool value,
+  }) async {
+    if (!pushGranted) {
+      final granted = await _requestPushPermission(context, ref);
+      if (!granted || !context.mounted) return;
+      await _save(context, ref, update(value: true));
+      return;
+    }
+
+    await _save(context, ref, update(value: value));
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
+
     return ListView(
       children: [
+        if (!pushGranted)
+          _PushOffBanner(onEnable: () => _requestPushPermission(context, ref)),
         SwitchListTile(
-          value: prefs.messagesEnabled,
+          value: pushGranted && prefs.messagesEnabled,
           title: Text(l10n.notifSettingsMessages),
           subtitle: Text(l10n.notifSettingsMessagesSubtitle),
-          onChanged: (v) =>
-              _save(context, ref, prefs.copyWith(messagesEnabled: v)),
+          onChanged: (v) => _onToggle(
+            context,
+            ref,
+            update: ({required bool value}) =>
+                prefs.copyWith(messagesEnabled: value),
+            value: v,
+          ),
         ),
         SwitchListTile(
-          value: prefs.applicationsEnabled,
+          value: pushGranted && prefs.applicationsEnabled,
           title: Text(l10n.notifSettingsApplications),
           subtitle: Text(l10n.notifSettingsApplicationsSubtitle),
-          onChanged: (v) =>
-              _save(context, ref, prefs.copyWith(applicationsEnabled: v)),
+          onChanged: (v) => _onToggle(
+            context,
+            ref,
+            update: ({required bool value}) =>
+                prefs.copyWith(applicationsEnabled: value),
+            value: v,
+          ),
         ),
         SwitchListTile(
-          value: prefs.collaborationsEnabled,
+          value: pushGranted && prefs.collaborationsEnabled,
           title: Text(l10n.notifSettingsCollaborations),
           subtitle: Text(l10n.notifSettingsCollaborationsSubtitle),
-          onChanged: (v) =>
-              _save(context, ref, prefs.copyWith(collaborationsEnabled: v)),
+          onChanged: (v) => _onToggle(
+            context,
+            ref,
+            update: ({required bool value}) =>
+                prefs.copyWith(collaborationsEnabled: value),
+            value: v,
+          ),
         ),
         SwitchListTile(
-          value: prefs.marketingEnabled,
+          value: pushGranted && prefs.marketingEnabled,
           title: Text(l10n.notifSettingsMarketing),
           subtitle: Text(l10n.notifSettingsMarketingSubtitle),
-          onChanged: (v) =>
-              _save(context, ref, prefs.copyWith(marketingEnabled: v)),
+          onChanged: (v) => _onToggle(
+            context,
+            ref,
+            update: ({required bool value}) =>
+                prefs.copyWith(marketingEnabled: value),
+            value: v,
+          ),
         ),
       ],
+    );
+  }
+}
+
+class _PushOffBanner extends StatelessWidget {
+  const _PushOffBanner({required this.onEnable});
+
+  final VoidCallback onEnable;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.all(KolabingSpacing.md),
+      child: Container(
+        padding: const EdgeInsets.all(KolabingSpacing.md),
+        decoration: BoxDecoration(
+          color: context.colors.surfaceVariant,
+          borderRadius: BorderRadius.circular(KolabingRadius.md),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l10n.notifSettingsPushOffTitle,
+              style: KolabingTextStyles.bodyMedium.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: KolabingSpacing.xs),
+            Text(
+              l10n.notifSettingsPushOffBody,
+              style: KolabingTextStyles.bodySmall.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: KolabingSpacing.sm),
+            OutlinedButton(
+              onPressed: onEnable,
+              child: Text(l10n.notifSettingsPushOffCta),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -1641,6 +1641,9 @@
   "notifSettingsMarketing": "Consells i novetats",
   "notifSettingsMarketingSubtitle": "Consells de producte i notícies ocasionals",
   "notifSettingsSaveError": "No s'ha pogut desar la teva preferència. Torna-ho a provar.",
+  "notifSettingsPushOffTitle": "Les notificacions estan desactivades",
+  "notifSettingsPushOffBody": "Activa les notificacions per assabentar-te de missatges nous, sol·licituds i novetats de les teves col·laboracions.",
+  "notifSettingsPushOffCta": "Activa les notificacions",
 
   "chatsTitle": "Xats",
   "chatInboxTooltip": "Xats",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6588,6 +6588,12 @@
   "@notifSettingsMarketingSubtitle": { "description": "Notification settings: marketing subtitle" },
   "notifSettingsSaveError": "Could not save your preference. Try again.",
   "@notifSettingsSaveError": { "description": "Notification settings: save failure message" },
+  "notifSettingsPushOffTitle": "Notifications are off",
+  "@notifSettingsPushOffTitle": { "description": "Notification settings: banner title shown while the OS notification permission is not granted." },
+  "notifSettingsPushOffBody": "Turn on notifications to hear about new messages, applications and collaboration updates.",
+  "@notifSettingsPushOffBody": { "description": "Notification settings: banner body shown while the OS notification permission is not granted." },
+  "notifSettingsPushOffCta": "Turn on notifications",
+  "@notifSettingsPushOffCta": { "description": "Notification settings: action that raises the system notification permission prompt." },
 
   "chatsTitle": "Chats",
   "@chatsTitle": { "description": "Chat inbox screen app-bar title." },

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1641,6 +1641,9 @@
   "notifSettingsMarketing": "Consejos y novedades",
   "notifSettingsMarketingSubtitle": "Consejos de producto y noticias ocasionales",
   "notifSettingsSaveError": "No se pudo guardar tu preferencia. Inténtalo de nuevo.",
+  "notifSettingsPushOffTitle": "Las notificaciones están desactivadas",
+  "notifSettingsPushOffBody": "Activa las notificaciones para enterarte de mensajes nuevos, solicitudes y novedades de tus colaboraciones.",
+  "notifSettingsPushOffCta": "Activar notificaciones",
 
   "chatsTitle": "Chats",
   "chatInboxTooltip": "Chats",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -9866,6 +9866,24 @@ abstract class AppLocalizations {
   /// **'Could not save your preference. Try again.'**
   String get notifSettingsSaveError;
 
+  /// Notification settings: banner title shown while the OS notification permission is not granted.
+  ///
+  /// In en, this message translates to:
+  /// **'Notifications are off'**
+  String get notifSettingsPushOffTitle;
+
+  /// Notification settings: banner body shown while the OS notification permission is not granted.
+  ///
+  /// In en, this message translates to:
+  /// **'Turn on notifications to hear about new messages, applications and collaboration updates.'**
+  String get notifSettingsPushOffBody;
+
+  /// Notification settings: action that raises the system notification permission prompt.
+  ///
+  /// In en, this message translates to:
+  /// **'Turn on notifications'**
+  String get notifSettingsPushOffCta;
+
   /// Chat inbox screen app-bar title.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -5625,6 +5625,17 @@ class AppLocalizationsCa extends AppLocalizations {
       'No s\'ha pogut desar la teva preferència. Torna-ho a provar.';
 
   @override
+  String get notifSettingsPushOffTitle =>
+      'Les notificacions estan desactivades';
+
+  @override
+  String get notifSettingsPushOffBody =>
+      'Activa les notificacions per assabentar-te de missatges nous, sol·licituds i novetats de les teves col·laboracions.';
+
+  @override
+  String get notifSettingsPushOffCta => 'Activa les notificacions';
+
+  @override
   String get chatsTitle => 'Xats';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5535,6 +5535,16 @@ class AppLocalizationsEn extends AppLocalizations {
       'Could not save your preference. Try again.';
 
   @override
+  String get notifSettingsPushOffTitle => 'Notifications are off';
+
+  @override
+  String get notifSettingsPushOffBody =>
+      'Turn on notifications to hear about new messages, applications and collaboration updates.';
+
+  @override
+  String get notifSettingsPushOffCta => 'Turn on notifications';
+
+  @override
   String get chatsTitle => 'Chats';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -5598,6 +5598,17 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se pudo guardar tu preferencia. Inténtalo de nuevo.';
 
   @override
+  String get notifSettingsPushOffTitle =>
+      'Las notificaciones están desactivadas';
+
+  @override
+  String get notifSettingsPushOffBody =>
+      'Activa las notificaciones para enterarte de mensajes nuevos, solicitudes y novedades de tus colaboraciones.';
+
+  @override
+  String get notifSettingsPushOffCta => 'Activar notificaciones';
+
+  @override
   String get chatsTitle => 'Chats';
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: kolabing_app
 description: "Kolabing - Collaboration marketplace connecting businesses and communities"
 publish_to: 'none'
 
-version: 1.5.1+37
+version: 1.5.1+38
 
 environment:
   sdk: ^3.10.7

--- a/test/features/settings/screens/notification_settings_screen_test.dart
+++ b/test/features/settings/screens/notification_settings_screen_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kolabing_app/features/business/models/notification_preferences.dart';
+import 'package:kolabing_app/features/settings/providers/notification_settings_provider.dart';
+import 'package:kolabing_app/features/settings/providers/push_permission_provider.dart';
+import 'package:kolabing_app/features/settings/screens/notification_settings_screen.dart';
+import 'package:kolabing_app/l10n/app_localizations.dart';
+
+void main() {
+  // Everything the backend defaults to "on" for a brand-new account.
+  const allOn = NotificationPreferences();
+
+  Future<void> pumpScreen(
+    WidgetTester tester, {
+    required bool pushGranted,
+    NotificationPreferences prefs = allOn,
+  }) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          notificationSettingsProvider.overrideWith(
+            () => _FakeSettingsNotifier(prefs),
+          ),
+          pushPermissionGrantedProvider.overrideWith((ref) async => pushGranted),
+        ],
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: NotificationSettingsScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  List<bool> switchValues(WidgetTester tester) => tester
+      .widgetList<SwitchListTile>(find.byType(SwitchListTile))
+      .map((tile) => tile.value)
+      .toList();
+
+  testWidgets(
+    'every toggle reads off while the OS permission is missing (Apple 4.5.4)',
+    (tester) async {
+      // The rejection: "the toggle in the app settings was pre-set to enable
+      // notifications". Stored prefs say on, the OS says nothing is delivered —
+      // the UI must not claim otherwise.
+      await pumpScreen(tester, pushGranted: false);
+
+      expect(switchValues(tester), <bool>[false, false, false, false]);
+    },
+  );
+
+  testWidgets('the off-state explains itself and offers the opt-in', (
+    tester,
+  ) async {
+    await pumpScreen(tester, pushGranted: false);
+
+    expect(find.text('Notifications are off'), findsOneWidget);
+    expect(find.text('Turn on notifications'), findsOneWidget);
+  });
+
+  testWidgets('stored preferences show through once permission is granted', (
+    tester,
+  ) async {
+    await pumpScreen(
+      tester,
+      pushGranted: true,
+      prefs: const NotificationPreferences(
+        messagesEnabled: true,
+        applicationsEnabled: false,
+        collaborationsEnabled: true,
+        marketingEnabled: false,
+      ),
+    );
+
+    expect(switchValues(tester), <bool>[true, false, true, false]);
+    expect(find.text('Notifications are off'), findsNothing);
+  });
+
+  testWidgets('a granted permission never forces a toggle on', (tester) async {
+    await pumpScreen(
+      tester,
+      pushGranted: true,
+      prefs: const NotificationPreferences(
+        messagesEnabled: false,
+        applicationsEnabled: false,
+        collaborationsEnabled: false,
+        marketingEnabled: false,
+      ),
+    );
+
+    expect(switchValues(tester), <bool>[false, false, false, false]);
+  });
+}
+
+class _FakeSettingsNotifier extends NotificationSettingsNotifier {
+  _FakeSettingsNotifier(this._prefs);
+
+  final NotificationPreferences _prefs;
+
+  @override
+  AsyncValue<NotificationPreferences> build() => AsyncData(_prefs);
+}


### PR DESCRIPTION
Closes #128

## What Apple actually objected to

The rejection notice carried one line that pins it:

> **Specifically, the toggle in the app settings was pre-set to enable notifications.**

#126 fixed the *registration* half of 4.5.4 — nothing reaches OneSignal or our
backend before consent. This is the other half, and it is what the reviewer
literally saw on screen.

`notification_settings_screen.dart` bound its four switches straight to the
stored preferences:

```dart
SwitchListTile(
  value: prefs.messagesEnabled,   // ← true for every fresh account
  ...
)
```

And the stored values default to enabled on both sides:

- `NotificationPreferences` constructor + `fromJson` fallbacks — `messagesEnabled`,
  `applicationsEnabled`, `collaborationsEnabled` all `true`.
- Backend `notification_preferences` — `new_application_alerts`,
  `collaboration_updates`, `message_notifications` are each `->default(true)`.

So an account that had never seen the system prompt showed three push toggles
switched **on**. The screen never consulted the OS permission at all, which also
made it factually wrong: iOS was suppressing every push while the UI claimed
they were enabled.

## Changes

The push toggles now read through the OS permission rather than the stored value
alone.

- **New `pushPermissionGrantedProvider`** — exposes the live permission state, so
  the screen can describe reality. Invalidated after any prompt.
- **`value: pushGranted && stored`** — nothing renders as enabled until the user
  has actually granted the permission.
- **The switch is the opt-in.** With the permission missing, flipping a toggle
  raises the system prompt and writes the preference *only* if the user accepts.
  Declining leaves it off and stores nothing. A permanently-denied permission
  opens iOS Settings, since the OS will not prompt a second time.
- **Granting here registers the token** via `syncPushPermissionGrant()`, matching
  what the permission screen already does — consent and registration happen at
  the same moment, in that order.
- **An explanatory banner** ("Notifications are off" + "Turn on notifications")
  covers the case where the user wants push but every toggle is off.
- **New strings** `notifSettingsPushOff{Title,Body,Cta}` in `en` / `es` / `ca`.

### What I deliberately did not change

The backend column defaults stay `true`. With this gate in place an "on" stored
value can only ever be shown to someone who accepted the OS prompt, so it is not
pre-set consent any more. Flipping the columns would mean a migration plus every
existing user silently losing notifications. Recorded in #128 as the fallback
lever if review pushes back a third time.

## Testing

- `flutter analyze` — **0 errors**. The one info on the touched file
  (`avoid_catches_without_on_clauses`) is pre-existing.
- `flutter test` — **324 passed / 10 failed**. Same 10 pre-existing failures as
  `master`, names unchanged (referral banner, opportunity cards, welcome hero,
  kolab form provider, disabled attendee card, community options). Baseline
  before this branch was 320 / 10.
- **4 new widget tests** in
  `test/features/settings/screens/notification_settings_screen_test.dart`:
  - every toggle reads off while the OS permission is missing — the exact thing
    the reviewer saw
  - the off-state explains itself and offers the opt-in
  - stored preferences show through once permission is granted
  - a granted permission never forces a toggle on

### Device QA before resubmitting
- [ ] Fresh install, **decline** the permission prompt → Settings → Notifications
      shows all four toggles **off** plus the banner.
- [ ] Tap a toggle in that state → system prompt appears; accept → toggle turns
      on and the preference persists across a reload.
- [ ] Decline instead → toggle stays off, nothing written.
- [ ] Deny permanently, then tap a toggle → iOS Settings opens.
- [ ] Fresh install, **accept** the prompt → toggles reflect stored prefs
      (messages / applications / collaborations on, marketing off).
- [ ] Confirm on an **iPad** as well — that is the review device.

## Mobile impact (kolabing-app)

Mobile-only. **No API contract change** — `GET`/`PUT /me/notification-preferences`
is untouched and the backend column defaults are unchanged. No `kolabing-v2` PR
required.

Note for the backend team: combined with #126, devices that never granted
permission no longer register a token, so `device_tokens` will be smaller and
more accurate. Nothing to change server-side.

## Docs & rules updated

- [x] Tracking issue #128 opened with the full diagnosis and the rejected
      alternative (flipping column defaults).
- [ ] `BACKLOG.md` — still not touched: the working tree carries an uncommitted
      FX-46 entry from a concurrent session. Needs its own entry once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
