### PR TITLE
fix(dashboard): read the role from auth, not from the payload's keys

### DIFF
--- a/lib/features/dashboard/providers/dashboard_provider.dart
+++ b/lib/features/dashboard/providers/dashboard_provider.dart
@@ -110,7 +110,12 @@ class DashboardNotifier extends Notifier<DashboardState>
     state = state.copyWith(isLoading: true, clearError: true);
 
     try {
-      final response = await _dashboardService.getDashboard();
+      // The role must come from auth: the two dashboard payloads are no
+      // longer distinguishable by their keys (kolabing-v2#227 gave
+      // communities an `opportunities` block too).
+      final response = await _dashboardService.getDashboard(
+        userType: ref.read(authProvider).user?.userType,
+      );
       if (isStaleAuthSession(sessionVersion)) {
         return;
       }

--- a/lib/features/dashboard/services/dashboard_service.dart
+++ b/lib/features/dashboard/services/dashboard_service.dart
@@ -7,6 +7,7 @@ import '../../auth/models/auth_response.dart';
 import '../../auth/services/auth_service.dart';
 import '../models/dashboard_model.dart';
 import '../../../config/constants/api.dart';
+import '../../auth/models/user_model.dart';
 
 /// API base URL
 const String _baseUrl = ApiConfig.baseUrl;
@@ -63,13 +64,25 @@ class DashboardService {
   /// Fetch dashboard data for the current user.
   ///
   /// The API returns different payloads depending on user type:
-  /// - Business users: contains `opportunities` key
-  /// - Community users: contains `applications_sent` key
-  Future<DashboardResponse> getDashboard() async {
-    return _getDashboard(allowRetry: true);
+  /// [userType] decides which shape to parse. It must come from the signed-in
+  /// user, NOT from the payload: the previous version keyed off
+  /// `data.containsKey('opportunities')`, and when the backend gave communities
+  /// an `opportunities` block for parity (kolabing-v2#227) every community
+  /// started being parsed as a business. `communityDashboard` came back null,
+  /// the screen showed "Unable to load dashboard data", and because the request
+  /// was a clean 200 with valid JSON there was no exception anywhere — nothing
+  /// in either Sentry project, nothing in the backend logs.
+  ///
+  /// Sniffing is kept only as a fallback for a null [userType], so a role we
+  /// cannot read still renders something.
+  Future<DashboardResponse> getDashboard({UserType? userType}) async {
+    return _getDashboard(allowRetry: true, userType: userType);
   }
 
-  Future<DashboardResponse> _getDashboard({required bool allowRetry}) async {
+  Future<DashboardResponse> _getDashboard({
+    required bool allowRetry,
+    UserType? userType,
+  }) async {
     final uri = Uri.parse('$_baseUrl/me/dashboard');
     debugPrint('DashboardService: GET $uri');
 
@@ -89,14 +102,29 @@ class DashboardService {
           throw const NetworkException('Invalid response format');
         }
 
-        // Determine user type from the response payload
-        if (data.containsKey('opportunities')) {
+        // The signed-in role decides, because the two payloads are no longer
+        // distinguishable by their keys.
+        if (userType == UserType.business) {
           return DashboardResponse(
             businessDashboard: BusinessDashboard.fromJson(data),
           );
-        } else if (data.containsKey('applications_sent')) {
+        }
+        if (userType == UserType.community) {
           return DashboardResponse(
             communityDashboard: CommunityDashboard.fromJson(data),
+          );
+        }
+
+        // Role unknown — fall back to shape. `applications_sent` is checked
+        // FIRST because it is the community marker that businesses never send,
+        // while `opportunities` is now sent to both.
+        if (data.containsKey('applications_sent')) {
+          return DashboardResponse(
+            communityDashboard: CommunityDashboard.fromJson(data),
+          );
+        } else if (data.containsKey('opportunities')) {
+          return DashboardResponse(
+            businessDashboard: BusinessDashboard.fromJson(data),
           );
         } else {
           // Fallback: try to parse as business first, then community


### PR DESCRIPTION
## 🎯 What does this PR do?

The durable half of the production outage that `kolabing-v2#238` unbroke.

`DashboardService` chose which dashboard to parse by **sniffing a key**:

```dart
if (data.containsKey('opportunities'))          -> BusinessDashboard
else if (data.containsKey('applications_sent'))  -> CommunityDashboard
```

The role now comes from the **signed-in user** (`authProvider.user?.userType`). Sniffing survives only as a fallback for an unknown role, and in that fallback `applications_sent` is checked **first** — it is the community marker a business never sends, while `opportunities` may now be sent to both.

## 🐞 What problem does it solve?

A community reported a dead Home screen in production: *"Unable to load dashboard data"*.

When the backend gave communities an `opportunities` block for parity (`kolabing-v2#227`), every community started parsing as a **business**: `communityDashboard` came back `null` and `community_dashboard_screen` fell through to its error state.

**It was invisible.** A clean `200` with valid JSON, nothing thrown — so no exception in either Sentry project and nothing in the backend logs. I searched both projects: `php-laravel` had 3 unresolved issues, none dashboard-related, and the newest event in 48h predated the report.

`kolabing-v2#238` (merged) removes the key from the community payload, which unbreaks **every already-installed build** today. This PR is what makes the app immune, so the backend can put `opportunities` back later without another outage.

## 🚀 What's needed for this to work in production?

- [ ] New env var / secret: **N/A**
- [ ] Backend deploy: **already done** — `kolabing-v2#238`. This PR does not depend on it and does not conflict with it.
- [ ] New App Store / Play Store build: **yes**, in the next release. Not urgent: the backend fix already restored the installed builds.
- [ ] Feature flag: **N/A**
- [ ] Third-party setup: **N/A**

## 📱 Which branch should be merged for this work?

- Base branch: `master`
- Dependent branch(es): **None.** Branched off `master`; two files, no overlap with `feat/multi-kolab-mobile`.

## 🧪 How to test this merge (reviewer must be able to reproduce)

- **Affected role:** **Community** (primary) and **Business** (must not regress)
- **Test account / data:** one community account and one business account on dev.
- **Steps:**
  1. Sign in as the **community** account → Home. The Community dashboard renders (title "Community dashboard", the applications/collaborations tiles), **not** the error state.
  2. Sign in as the **business** account → Home. The Business dashboard renders as before.
  3. To prove the original break is now impossible, have the backend include `opportunities` in a community response (temporarily, on dev). Before this change the community Home showed "Unable to load dashboard data"; after it, the dashboard renders regardless.
- **Expected result:** the parser follows the signed-in role, so no server-side key change can reroute it.

## 📸 Screenshots / screen recording

- [x] This PR has **no UI/design change** (no screenshot needed)

No widget, layout or copy is touched — the change is which model the service constructs. The visible difference is a dashboard rendering instead of an error state, which is the bug being fixed rather than a design change.

## ✅ Definition of Done
- [x] `flutter analyze` clean — 0 errors
- [x] `dart format` applied (a `dart format` sweep pulled in 3 unrelated dashboard widgets; I verified by token diff they were comma-only reformats and reverted them, so the diff is exactly 2 files)
- [ ] Tested on **iOS** — the dev-API build was verified running as a community account; the specific regression needs the backend to send the key, so it is argued from source rather than exercised
- [ ] Tested on **Android** — not done
- [x] Screenshots — N/A, see above
- [x] i18n — no new strings
- [x] No hardcoded values
- [ ] `BACKLOG.md` — not updated here; the incident is recorded in `kolabing-v2#238`. Say the word and I will add an FX entry.

## 🤖 Was AI used?

Yes — Claude Code (Opus 5). It traced the outage from the user's screenshot: ruled out the app's parsers (all tolerant), searched both Sentry projects and found nothing, then found the key-sniffing branch and matched it against what `kolabing-v2#227` had added the previous day. It wrote both this fix and the backend hotfix. Ownership stays with me.