### PR TITLE
fix(community): the photo strip sat directly on the band below it

### DIFF
--- a/lib/features/community/screens/attendee_community_profile_screen.dart
+++ b/lib/features/community/screens/attendee_community_profile_screen.dart
@@ -149,23 +149,16 @@ class AttendeeCommunityProfileScreen extends ConsumerWidget {
             // is asked by the bottom CTA instead, so no row.
             SliverToBoxAdapter(child: _MembershipRow(community: community)),
 
-            // Its photographs — curated, or drawn from its own events.
+            // Its photographs — curated, or drawn from its own events. The
+            // strip carries its own padding (#185).
             SliverToBoxAdapter(
               child: Consumer(
-                builder: (context, ref, _) => Padding(
-                  padding: const EdgeInsets.fromLTRB(
-                    KolabingSpacing.md,
-                    KolabingSpacing.md,
-                    0,
-                    0,
-                  ),
-                  child: CommunityPhotoStrip(
-                    photos: ref.watch(
-                      communityPhotosProvider((
-                        communityId: community.id,
-                        ownerProfileId: community.ownerProfileId,
-                      )),
-                    ),
+                builder: (context, ref, _) => CommunityPhotoStrip(
+                  photos: ref.watch(
+                    communityPhotosProvider((
+                      communityId: community.id,
+                      ownerProfileId: community.ownerProfileId,
+                    )),
                   ),
                 ),
               ),

--- a/lib/features/community/screens/community_detail_screen.dart
+++ b/lib/features/community/screens/community_detail_screen.dart
@@ -169,27 +169,34 @@ class _CommunityDetailScreenState extends ConsumerState<CommunityDetailScreen> {
             SliverToBoxAdapter(child: _Identity(community: c)),
 
             // The community's photographs: curated when the leader curated
-            // some, its own event photos when not.
+            // some, its own event photos when not. The strip carries its own
+            // padding (#185).
             SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(
-                  KolabingSpacing.md,
-                  KolabingSpacing.md,
-                  0,
-                  0,
-                ),
-                child: CommunityPhotoStrip(
-                  photos: ref.watch(communityPhotosProvider(_mediaKey)),
-                ),
+              child: CommunityPhotoStrip(
+                photos: ref.watch(communityPhotosProvider(_mediaKey)),
               ),
             ),
 
             // Where the viewer stands in this community: a member sees points +
             // tier, a manager gets into the roster.
+            //
+            // Both are full-bleed bands with a hairline at the top, and the
+            // photo strip above them ends at its last photo — so without a gap
+            // of their own the photos sat directly on that hairline (#185).
             if (!_canManage)
-              SliverToBoxAdapter(child: _StandingNavRow(community: c)),
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.only(top: KolabingSpacing.lg),
+                  child: _StandingNavRow(community: c),
+                ),
+              ),
             if (_showMembers)
-              SliverToBoxAdapter(child: _RosterNavRow(community: c)),
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.only(top: KolabingSpacing.lg),
+                  child: _RosterNavRow(community: c),
+                ),
+              ),
 
             // Events, grouped by day.
             SliverToBoxAdapter(

--- a/lib/features/community/widgets/community_page_sections.dart
+++ b/lib/features/community/widgets/community_page_sections.dart
@@ -575,45 +575,64 @@ class CommunityPhotoStrip extends StatelessWidget {
   Widget build(BuildContext context) {
     if (photos.isEmpty) return const SizedBox.shrink();
     final l10n = AppLocalizations.of(context);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        CommunitySectionLabel(l10n.communityPagePhotosTitle),
-        SizedBox(
-          height: 104,
-          child: ListView.separated(
-            scrollDirection: Axis.horizontal,
-            itemCount: photos.length,
-            separatorBuilder: (_, _) =>
-                const SizedBox(width: KolabingSpacing.xs),
-            itemBuilder: (_, i) => GestureDetector(
-              onTap: () => PhotoViewerDialog.show(
-                context,
-                photos: photos,
-                initialIndex: i,
-              ),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(KolabingRadius.md),
-                child: Image.network(
-                  photos[i].url,
-                  width: 104,
-                  height: 104,
-                  fit: BoxFit.cover,
-                  errorBuilder: (_, _, _) => Container(
+    // The section owns its padding, and it sits INSIDE the empty check: both
+    // call sites used to wrap it, so a community with no photos still paid for
+    // padding around a zero-height child (#185).
+    //
+    // TOP only, on purpose. If this owned a bottom gap it would take it away
+    // with it when there are no photos, and whatever follows would cram against
+    // the block above — the same bug moved one section down. Everything on this
+    // page owns its own top gap for that reason.
+    //
+    // The right edge is deliberately 0: the strip scrolls, and stopping it at
+    // the page margin makes it look like it ends there.
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        KolabingSpacing.md,
+        KolabingSpacing.md,
+        0,
+        0,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          CommunitySectionLabel(l10n.communityPagePhotosTitle),
+          SizedBox(
+            height: 104,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              itemCount: photos.length,
+              separatorBuilder: (_, _) =>
+                  const SizedBox(width: KolabingSpacing.xs),
+              itemBuilder: (_, i) => GestureDetector(
+                onTap: () => PhotoViewerDialog.show(
+                  context,
+                  photos: photos,
+                  initialIndex: i,
+                ),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(KolabingRadius.md),
+                  child: Image.network(
+                    photos[i].url,
                     width: 104,
                     height: 104,
-                    color: context.colors.surfaceContainerHigh,
-                    child: Icon(
-                      LucideIcons.image,
-                      color: context.colors.onSurfaceVariant,
+                    fit: BoxFit.cover,
+                    errorBuilder: (_, _, _) => Container(
+                      width: 104,
+                      height: 104,
+                      color: context.colors.surfaceContainerHigh,
+                      child: Icon(
+                        LucideIcons.image,
+                        color: context.colors.onSurfaceVariant,
+                      ),
                     ),
                   ),
                 ),
               ),
             ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/test/features/community/widgets/community_page_sections_test.dart
+++ b/test/features/community/widgets/community_page_sections_test.dart
@@ -333,6 +333,50 @@ void main() {
     },
   );
 
+  // #185: on the member's community page the photos sat directly on the
+  // hairline of the "0 pts / Member" band below them. Both call sites wrapped
+  // the strip in `fromLTRB(md, md, 0, 0)` — no bottom gap — and the full-bleed
+  // band that followed had none of its own either.
+  //
+  // The fix put the padding inside the widget, TOP ONLY, and gave the band its
+  // own top gap. These two tests hold both halves of that: the strip must own a
+  // top gap, and it must NOT own a bottom one, because a strip that renders
+  // nothing would take a bottom gap away with it and the same crush would
+  // reappear one section further down.
+  testWidgets('the photo strip owns a top gap and no bottom gap', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      const CommunityPhotoStrip(
+        photos: [GalleryPhoto(id: '1', url: 'https://example.test/1.jpg')],
+      ),
+    );
+
+    final strip = tester.getRect(find.byType(CommunityPhotoStrip));
+    final label = tester.getRect(find.text('PHOTOS'));
+    expect(
+      label.top - strip.top,
+      greaterThanOrEqualTo(12),
+      reason: 'the section needs air above its label',
+    );
+
+    final photos = tester.getRect(find.byType(ListView));
+    expect(
+      strip.bottom - photos.bottom,
+      lessThan(1),
+      reason: 'the strip must end with its photos, owning no bottom gap',
+    );
+  });
+
+  testWidgets('an empty photo strip takes no vertical space', (tester) async {
+    await _pump(tester, const CommunityPhotoStrip(photos: []));
+
+    // The padding used to live at the call site, outside the empty check, so a
+    // community with no photos still paid 16dp for a zero-height child.
+    expect(tester.getSize(find.byType(CommunityPhotoStrip)).height, 0);
+  });
+
   testWidgets('the hero back button actually goes back', (tester) async {
     // It did not. `Navigator.maybePop()` on a page entered cold from a deep
     // link has nothing to pop, so the button was silently dead.


### PR DESCRIPTION
## 🎯 What does this PR do?

- Moves `CommunityPhotoStrip`'s padding **inside the widget**, after its `photos.isEmpty` early return.
- Keeps that padding **top-only**, and gives the two full-bleed nav rows (`_StandingNavRow`, `_RosterNavRow`) their own top gap.
- Two tests: the strip owns a top gap and no bottom gap; an empty strip takes zero height.

## 🐞 What problem does it solve?

Reported by @olucvolkan with a screenshot of Real Run Club: *"photos kisminda spacing hatasi var dipdibe girmis"* — on the member's community page the photos sat **directly on the hairline** of the "0 pts / Member" band, with no gap at all.

Both call sites wrapped the strip in the same padding, with no bottom:

```dart
Padding(
  padding: const EdgeInsets.fromLTRB(md, md, 0, 0),   // bottom: 0
  child: CommunityPhotoStrip(photos: ...),
),
if (!_canManage) SliverToBoxAdapter(child: _StandingNavRow(community: c)),
```

`_StandingNavRow` is a `CommunityNavRow`: a full-bleed surface band with a hairline top and bottom and **no outer margin**, because inside the Manage block it has to stack flush with its siblings. So neither side contributed a gap and they met exactly.

Two smaller things in the same place, fixed on the way through:

- The padding lived **outside** the empty check, so a community with no photos still paid 16dp for a zero-height child.
- The wrapper was duplicated at both call sites, so a third caller would have had to remember it.

**Why top-only** — this is the part worth reviewing. A section that owns a *bottom* gap takes that gap away with it when it renders nothing, which just moves the crush one section down: on the attendee page the strip can be preceded by a full-bleed membership row and followed by the events list, and an empty strip would then have crushed those two together instead. Every section on these two pages owns its **top** gap, so a missing section can never collapse one.

Closes #185

## 🚀 What's needed for this to work in production?

Nothing extra. Layout only — no env var, no backend, no migration, no new build requirement beyond the usual release.

## 📱 Which branch should be merged for this work?

- Base branch: `master`
- Dependent branch(es): none — this branch only.

## 🧪 How to test this merge (reviewer must be able to reproduce)

- **Affected role:** Community/Attendee — the **member's** view of a community they belong to (not the leader's own page).
- **Test account / data:** an account that is a *member* (not owner) of a community that has photos — Real Run Club in the screenshot.
- **Steps:**
  1. Open that community from My communities.
  2. Look between the PHOTOS strip and the "0 pts / … " band: there is now a 24dp gap where the photos used to touch the hairline.
  3. Open a community with **no** photos: no empty space where the strip would be, and the band still has its gap.
  4. Attendee view of a public community (`AttendeeCommunityProfileScreen`): photos → upcoming events spacing unchanged.
- **Expected result:** a real gap under the photos in every case, and no phantom gap when there are no photos.

## 📸 Screenshots / screen recording

- [ ] This PR has **no UI/design change** (no screenshot needed)

**Before** — @olucvolkan's screenshot, the photos flush against the "0 pts / Member" band. **After — not photographed, and I want to be straight about why:** the only account on this simulator is the *owner* of its community, so it takes the `_canManage` branch and never renders that band; and its community has no photos, so the strip does not render either. Reproducing the exact screen needs a member account of a community with photos, which I do not have credentials for.

What is verified instead, mechanically, in `community_page_sections_test.dart` (15/15 passing):

```
the photo strip owns a top gap and no bottom gap   ✓
an empty photo strip takes no vertical space       ✓
```

The first asserts `strip.bottom - photos.bottom < 1` (no bottom gap, so the rule holds) and a ≥12dp gap above the label; the second asserts a rendered height of exactly 0. The 24dp the band now adds is a plain `EdgeInsets.only(top: lg)` at the two sliver sites.

## ✅ Definition of Done (check before requesting review)
- [x] `flutter analyze lib test` clean (0 errors)
- [x] `dart format` applied to changed files
- [ ] Tested on **iOS** simulator/device — **not the affected screen**, for the account reason above. `flutter analyze` and the widget tests are what stands behind this one.
- [ ] Tested on **Android** emulator/device — not run. Pure Flutter layout, no platform code.
- [ ] **Screenshots** — before only; see above.
- [x] i18n — no new strings
- [x] No hardcoded values — `KolabingSpacing` throughout
- [x] `BACKLOG.md` — N/A: closes its issue, nothing outstanding

## 🤖 Was AI used?

Yes — Claude Code (Opus 5) found the cause, made the fix and wrote the two tests.