### PR TITLE
feat(challenges): set from the app whether a challenge opens the camera

### DIFF
--- a/lib/config/constants/analytics.dart
+++ b/lib/config/constants/analytics.dart
@@ -13,7 +13,8 @@ class AnalyticsConfig {
   const AnalyticsConfig._();
 
   /// PostHog project API key (EU cloud, project "Default project" / 195047).
-  static const String apiKey = 'phc_zAYyMCY78gWCrTFepwk2fXXhpXBYmjV2w67hV54u67wK';
+  static const String apiKey =
+      'phc_zAYyMCY78gWCrTFepwk2fXXhpXBYmjV2w67hV54u67wK';
 
   /// EU ingestion host. PostHog cloud region is `eu.posthog.com`; the SDK
   /// ingestion endpoint for that region is `https://eu.i.posthog.com`.

--- a/lib/config/constants/layout.dart
+++ b/lib/config/constants/layout.dart
@@ -16,9 +16,7 @@ abstract final class KolabingLayout {
   );
 
   /// Screen padding with vertical spacing
-  static const EdgeInsets screenPaddingAll = EdgeInsets.all(
-    KolabingSpacing.md,
-  );
+  static const EdgeInsets screenPaddingAll = EdgeInsets.all(KolabingSpacing.md);
 
   // ---------------------------------------------------------------------------
   // Navigation
@@ -35,14 +33,10 @@ abstract final class KolabingLayout {
   // ---------------------------------------------------------------------------
 
   /// Standard card internal padding
-  static const EdgeInsets cardPadding = EdgeInsets.all(
-    KolabingSpacing.md,
-  );
+  static const EdgeInsets cardPadding = EdgeInsets.all(KolabingSpacing.md);
 
   /// Large card internal padding
-  static const EdgeInsets cardPaddingLarge = EdgeInsets.all(
-    KolabingSpacing.lg,
-  );
+  static const EdgeInsets cardPaddingLarge = EdgeInsets.all(KolabingSpacing.lg);
 
   // ---------------------------------------------------------------------------
   // List & Grid Spacing
@@ -150,55 +144,43 @@ abstract final class KolabingShadows {
   /// FAB shadow — soft drop shadow beneath the floating action button.
   /// Matches inline definition in kolabing_fab.dart.
   static List<BoxShadow> get fab => [
-        BoxShadow(
-          color: Colors.black.withValues(alpha: 0.12),
-          blurRadius: 20,
-          spreadRadius: 0,
-          offset: const Offset(0, 4),
-        ),
-      ];
+    BoxShadow(
+      color: Colors.black.withValues(alpha: 0.12),
+      blurRadius: 20,
+      spreadRadius: 0,
+      offset: const Offset(0, 4),
+    ),
+  ];
 
   /// Overlay card shadow — depth behind glass/dark overlay cards on images.
   /// Matches inline definition in explore_swipe_card.dart.
   static List<BoxShadow> get overlayCard => [
-        BoxShadow(
-          color: Colors.black.withValues(alpha: 0.12),
-          blurRadius: 18,
-          offset: const Offset(0, 10),
-        ),
-      ];
+    BoxShadow(
+      color: Colors.black.withValues(alpha: 0.12),
+      blurRadius: 18,
+      offset: const Offset(0, 10),
+    ),
+  ];
 
   /// Modal top shadow — upward shadow on sticky bottom action bars in sheets.
   /// Matches inline definition in explore_detail_sheet.dart.
   static List<BoxShadow> get modalTop => [
-        BoxShadow(
-          color: Colors.black.withValues(alpha: 0.05),
-          blurRadius: 8,
-          offset: const Offset(0, -2),
-        ),
-      ];
+    BoxShadow(
+      color: Colors.black.withValues(alpha: 0.05),
+      blurRadius: 8,
+      offset: const Offset(0, -2),
+    ),
+  ];
 
   /// Design handoff card shadow — multi-layer ambient + elevated effect
   static const List<BoxShadow> designCardShadow = [
-    BoxShadow(
-      color: Color(0x0A19150F),
-      blurRadius: 8,
-      offset: Offset(0, 2),
-    ),
-    BoxShadow(
-      color: Color(0x0619150F),
-      blurRadius: 24,
-      offset: Offset(0, 8),
-    ),
+    BoxShadow(color: Color(0x0A19150F), blurRadius: 8, offset: Offset(0, 2)),
+    BoxShadow(color: Color(0x0619150F), blurRadius: 24, offset: Offset(0, 8)),
   ];
 
   /// Design handoff button shadow — warm dark drop shadow beneath yellow buttons
   static const List<BoxShadow> designButtonShadow = [
-    BoxShadow(
-      color: Color(0x1F141210),
-      blurRadius: 26,
-      offset: Offset(0, 12),
-    ),
+    BoxShadow(color: Color(0x1F141210), blurRadius: 26, offset: Offset(0, 12)),
   ];
 
   // ---------------------------------------------------------------------------

--- a/lib/config/constants/radius.dart
+++ b/lib/config/constants/radius.dart
@@ -69,13 +69,15 @@ abstract final class KolabingRadius {
   static BorderRadius get borderRadiusCard => BorderRadius.circular(card);
 
   /// Option card BorderRadius - 20px all corners
-  static BorderRadius get borderRadiusOptionCard => BorderRadius.circular(optionCard);
+  static BorderRadius get borderRadiusOptionCard =>
+      BorderRadius.circular(optionCard);
 
   /// Input BorderRadius - 16px all corners
   static BorderRadius get borderRadiusInput => BorderRadius.circular(input);
 
   /// Thumbnail BorderRadius - 18px all corners
-  static BorderRadius get borderRadiusThumbnail => BorderRadius.circular(thumbnail);
+  static BorderRadius get borderRadiusThumbnail =>
+      BorderRadius.circular(thumbnail);
 
   /// Pill BorderRadius - fully rounded
   static BorderRadius get borderRadiusPill => BorderRadius.circular(pill);

--- a/lib/config/routes/routes.dart
+++ b/lib/config/routes/routes.dart
@@ -407,6 +407,16 @@ abstract final class KolabingRoutes {
   static const String createChallenge =
       '/attendee/events/:eventId/challenges/create';
 
+  /// Edit a custom challenge (for organizers). `EventChallengesScreen` has
+  /// pushed this path since it shipped and nothing was registered for it, so the
+  /// tap landed on the not-found page (#188).
+  static const String editChallenge =
+      '/attendee/events/:eventId/challenges/:challengeId/edit';
+
+  /// Path to [editChallenge].
+  static String buildEditChallengePath(String eventId, String challengeId) =>
+      '/attendee/events/$eventId/challenges/$challengeId/edit';
+
   // ---------------------------------------------------------------------------
   /// Permission request screen
   static const String permissions = '/permissions';
@@ -1180,6 +1190,25 @@ final GoRouter kolabingRouter = GoRouter(
         final eventId = state.pathParameters['eventId'] ?? '';
         return CreateChallengeScreen(eventId: eventId);
       },
+    ),
+    GoRoute(
+      path: KolabingRoutes.editChallenge,
+      name: 'editChallenge',
+      // The challenge travels in `extra`: the list already holds the object and
+      // there is no single-challenge endpoint to hydrate one from. A cold deep
+      // link therefore has nothing to edit — send it to the list rather than
+      // open an empty form that would create a SECOND challenge on save.
+      redirect: (BuildContext context, GoRouterState state) =>
+          state.extra is Challenge
+          ? null
+          : KolabingRoutes.buildEventChallengesPath(
+              state.pathParameters['eventId'] ?? '',
+            ),
+      builder: (BuildContext context, GoRouterState state) =>
+          CreateChallengeScreen(
+            eventId: state.pathParameters['eventId'] ?? '',
+            challenge: state.extra as Challenge,
+          ),
     ),
   ],
 

--- a/lib/config/theme/colors.dart
+++ b/lib/config/theme/colors.dart
@@ -350,9 +350,6 @@ abstract final class KolabingColors {
   static const LinearGradient primaryGradient = LinearGradient(
     begin: Alignment.topLeft,
     end: Alignment.bottomRight,
-    colors: [
-      Color(0xFFFFE28C),
-      Color(0xFFFFF4C2),
-    ],
+    colors: [Color(0xFFFFE28C), Color(0xFFFFF4C2)],
   );
 }

--- a/lib/config/theme/theme.dart
+++ b/lib/config/theme/theme.dart
@@ -17,248 +17,244 @@ abstract final class KolabingTheme {
 
   /// Light theme for the main application screens
   static ThemeData get lightTheme => ThemeData(
-        useMaterial3: true,
-        brightness: Brightness.light,
+    useMaterial3: true,
+    brightness: Brightness.light,
 
-        // Color scheme
-        colorScheme: const ColorScheme.light(
-          primary: KolabingColors.primary,
-          onPrimary: KolabingColors.onPrimary,
-          primaryContainer: KolabingColors.softYellow,
-          onPrimaryContainer: KolabingColors.onSurface,
-          secondary: KolabingColors.secondary,
-          onSecondary: KolabingColors.textOnDark,
-          surface: KolabingColors.surface,
-          onSurface: KolabingColors.onSurface,
-          surfaceContainerHighest: KolabingColors.surfaceVariant,
-          error: KolabingColors.error,
-          onError: KolabingColors.textOnDark,
-          outline: KolabingColors.darkBorder,
-          outlineVariant: KolabingColors.darkBorder,
+    // Color scheme
+    colorScheme: const ColorScheme.light(
+      primary: KolabingColors.primary,
+      onPrimary: KolabingColors.onPrimary,
+      primaryContainer: KolabingColors.softYellow,
+      onPrimaryContainer: KolabingColors.onSurface,
+      secondary: KolabingColors.secondary,
+      onSecondary: KolabingColors.textOnDark,
+      surface: KolabingColors.surface,
+      onSurface: KolabingColors.onSurface,
+      surfaceContainerHighest: KolabingColors.surfaceVariant,
+      error: KolabingColors.error,
+      onError: KolabingColors.textOnDark,
+      outline: KolabingColors.darkBorder,
+      outlineVariant: KolabingColors.darkBorder,
+    ),
+
+    // Scaffold — warm beige
+    scaffoldBackgroundColor: KolabingColors.background,
+
+    // AppBar — yellow, no elevation
+    appBarTheme: AppBarTheme(
+      elevation: 0,
+      scrolledUnderElevation: 0,
+      centerTitle: true,
+      backgroundColor: KolabingColors.navBarBackground,
+      foregroundColor: KolabingColors.charcoal,
+      surfaceTintColor: Colors.transparent,
+      shadowColor: Colors.transparent,
+      systemOverlayStyle: const SystemUiOverlayStyle(
+        statusBarColor: Colors.transparent,
+        statusBarIconBrightness: Brightness.dark,
+        statusBarBrightness: Brightness.light,
+      ),
+      titleTextStyle: KolabingTextStyles.labelLarge.copyWith(
+        color: KolabingColors.charcoal,
+        letterSpacing: 1.5,
+      ),
+      iconTheme: const IconThemeData(color: KolabingColors.charcoal, size: 24),
+    ),
+
+    // Bottom Navigation — yellow bar, charcoal active, muted inactive
+    bottomNavigationBarTheme: BottomNavigationBarThemeData(
+      backgroundColor: KolabingColors.navBarBackground,
+      selectedItemColor: KolabingColors.charcoal,
+      unselectedItemColor: KolabingColors.navInactive,
+      type: BottomNavigationBarType.fixed,
+      elevation: 0,
+      selectedLabelStyle: KolabingTextStyles.labelSmall,
+      unselectedLabelStyle: KolabingTextStyles.labelSmall,
+    ),
+
+    // Card — contrasting surface, no elevation, no border
+    cardTheme: CardThemeData(
+      color: KolabingColors.surfaceContainer,
+      elevation: 0,
+      shadowColor: Colors.transparent,
+      shape: RoundedRectangleBorder(
+        borderRadius: KolabingRadius.borderRadiusXl,
+        side: BorderSide.none,
+      ),
+      margin: EdgeInsets.zero,
+    ),
+
+    // Elevated Button (Primary) — pill shape, yellow, ink label, drop shadow
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+        backgroundColor: KolabingColors.primary,
+        foregroundColor: KolabingColors.onPrimary,
+        disabledBackgroundColor: KolabingColors.primary.withValues(alpha: 0.5),
+        disabledForegroundColor: KolabingColors.onPrimary.withValues(
+          alpha: 0.5,
         ),
+        elevation: 0,
+        shadowColor: Colors.transparent,
+        minimumSize: const Size(double.infinity, KolabingLayout.buttonHeight),
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+        shape: const StadiumBorder(),
+        textStyle: KolabingTextStyles.button,
+      ),
+    ),
 
-        // Scaffold — warm beige
-        scaffoldBackgroundColor: KolabingColors.background,
+    // Filled Button (Secondary) — pill shape, warm mist fill
+    filledButtonTheme: FilledButtonThemeData(
+      style: FilledButton.styleFrom(
+        backgroundColor: KolabingColors.buttonSecondary,
+        foregroundColor: KolabingColors.onButtonSecondary,
+        elevation: 0,
+        shadowColor: Colors.transparent,
+        minimumSize: const Size(double.infinity, KolabingLayout.buttonHeight),
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+        shape: const StadiumBorder(),
+        textStyle: KolabingTextStyles.button,
+      ),
+    ),
 
-        // AppBar — yellow, no elevation
-        appBarTheme: AppBarTheme(
-          elevation: 0,
-          scrolledUnderElevation: 0,
-          centerTitle: true,
-          backgroundColor: KolabingColors.navBarBackground,
-          foregroundColor: KolabingColors.charcoal,
-          surfaceTintColor: Colors.transparent,
-          shadowColor: Colors.transparent,
-          systemOverlayStyle: const SystemUiOverlayStyle(
-            statusBarColor: Colors.transparent,
-            statusBarIconBrightness: Brightness.dark,
-            statusBarBrightness: Brightness.light,
-          ),
-          titleTextStyle: KolabingTextStyles.labelLarge.copyWith(color: KolabingColors.charcoal, letterSpacing: 1.5),
-          iconTheme: const IconThemeData(
-            color: KolabingColors.charcoal,
-            size: 24,
-          ),
+    // Outlined Button (Secondary) — pill shape, charcoal border
+    outlinedButtonTheme: OutlinedButtonThemeData(
+      style: OutlinedButton.styleFrom(
+        foregroundColor: KolabingColors.charcoal,
+        elevation: 0,
+        minimumSize: const Size(double.infinity, KolabingLayout.buttonHeight),
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+        shape: const StadiumBorder(),
+        side: const BorderSide(color: KolabingColors.charcoal, width: 1),
+        textStyle: KolabingTextStyles.button,
+      ),
+    ),
+
+    // Text Button — purple for links
+    textButtonTheme: TextButtonThemeData(
+      style: TextButton.styleFrom(
+        foregroundColor: KolabingColors.secondary,
+        textStyle: KolabingTextStyles.labelLarge,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      ),
+    ),
+
+    // Input Decoration — pure white fill, subtle border, black on focus
+    inputDecorationTheme: InputDecorationTheme(
+      filled: true,
+      fillColor: KolabingColors.surfaceVariant,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      border: OutlineInputBorder(
+        borderRadius: KolabingRadius.borderRadiusMd,
+        borderSide: const BorderSide(color: KolabingColors.darkBorder),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: KolabingRadius.borderRadiusMd,
+        borderSide: const BorderSide(color: KolabingColors.darkBorder),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: KolabingRadius.borderRadiusMd,
+        borderSide: const BorderSide(
+          color: KolabingColors.borderFocus,
+          width: 1.5,
         ),
-
-        // Bottom Navigation — yellow bar, charcoal active, muted inactive
-        bottomNavigationBarTheme: BottomNavigationBarThemeData(
-          backgroundColor: KolabingColors.navBarBackground,
-          selectedItemColor: KolabingColors.charcoal,
-          unselectedItemColor: KolabingColors.navInactive,
-          type: BottomNavigationBarType.fixed,
-          elevation: 0,
-          selectedLabelStyle: KolabingTextStyles.labelSmall,
-          unselectedLabelStyle: KolabingTextStyles.labelSmall,
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: KolabingRadius.borderRadiusMd,
+        borderSide: const BorderSide(color: KolabingColors.borderError),
+      ),
+      focusedErrorBorder: OutlineInputBorder(
+        borderRadius: KolabingRadius.borderRadiusMd,
+        borderSide: const BorderSide(
+          color: KolabingColors.borderError,
+          width: 1.5,
         ),
+      ),
+      hintStyle: KolabingTextStyles.bodyMedium.copyWith(
+        color: KolabingColors.textTertiary,
+      ),
+      labelStyle: KolabingTextStyles.bodyMedium.copyWith(
+        color: KolabingColors.onSurfaceVariant,
+      ),
+      floatingLabelStyle: KolabingTextStyles.bodySmall.copyWith(
+        color: KolabingColors.onSurfaceVariant,
+      ),
+      errorStyle: KolabingTextStyles.bodySmall.copyWith(
+        color: KolabingColors.error,
+      ),
+    ),
 
-        // Card — contrasting surface, no elevation, no border
-        cardTheme: CardThemeData(
-          color: KolabingColors.surfaceContainer,
-          elevation: 0,
-          shadowColor: Colors.transparent,
-          shape: RoundedRectangleBorder(
-            borderRadius: KolabingRadius.borderRadiusXl,
-            side: BorderSide.none,
-          ),
-          margin: EdgeInsets.zero,
+    // Chip — sage fill, pill shape, no border
+    chipTheme: ChipThemeData(
+      backgroundColor: KolabingColors.tertiaryContainer,
+      labelStyle: KolabingTextStyles.labelMedium.copyWith(
+        color: KolabingColors.onSurface,
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      shape: const StadiumBorder(side: BorderSide.none),
+      elevation: 0,
+      pressElevation: 0,
+    ),
+
+    // Divider — warm grey
+    dividerTheme: const DividerThemeData(
+      color: KolabingColors.darkBorder,
+      thickness: 1,
+      space: 1,
+    ),
+
+    // Dialog — white surface
+    dialogTheme: DialogThemeData(
+      backgroundColor: KolabingColors.surface,
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: KolabingRadius.borderRadiusLg,
+        side: const BorderSide(color: KolabingColors.darkBorder),
+      ),
+      titleTextStyle: KolabingTextStyles.headlineMedium.copyWith(
+        color: KolabingColors.onSurface,
+      ),
+      contentTextStyle: KolabingTextStyles.bodyMedium.copyWith(
+        color: KolabingColors.onSurfaceVariant,
+      ),
+    ),
+
+    // Bottom Sheet — white, no heavy shadow
+    bottomSheetTheme: const BottomSheetThemeData(
+      backgroundColor: KolabingColors.surface,
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(KolabingRadius.xl),
         ),
+      ),
+      showDragHandle: true,
+      dragHandleColor: KolabingColors.darkBorder,
+    ),
 
-        // Elevated Button (Primary) — pill shape, yellow, ink label, drop shadow
-        elevatedButtonTheme: ElevatedButtonThemeData(
-          style: ElevatedButton.styleFrom(
-            backgroundColor: KolabingColors.primary,
-            foregroundColor: KolabingColors.onPrimary,
-            disabledBackgroundColor: KolabingColors.primary.withValues(alpha: 0.5),
-            disabledForegroundColor: KolabingColors.onPrimary.withValues(alpha: 0.5),
-            elevation: 0,
-            shadowColor: Colors.transparent,
-            minimumSize: const Size(double.infinity, KolabingLayout.buttonHeight),
-            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-            shape: const StadiumBorder(),
-            textStyle: KolabingTextStyles.button,
-          ),
-        ),
+    // Snackbar — near-black (the one place we use dark fill)
+    snackBarTheme: SnackBarThemeData(
+      backgroundColor: KolabingColors.onSurface,
+      contentTextStyle: KolabingTextStyles.bodyMedium.copyWith(
+        color: KolabingColors.textOnDark,
+      ),
+      behavior: SnackBarBehavior.floating,
+      shape: RoundedRectangleBorder(
+        borderRadius: KolabingRadius.borderRadiusSm,
+      ),
+    ),
 
-        // Filled Button (Secondary) — pill shape, warm mist fill
-        filledButtonTheme: FilledButtonThemeData(
-          style: FilledButton.styleFrom(
-            backgroundColor: KolabingColors.buttonSecondary,
-            foregroundColor: KolabingColors.onButtonSecondary,
-            elevation: 0,
-            shadowColor: Colors.transparent,
-            minimumSize: const Size(double.infinity, KolabingLayout.buttonHeight),
-            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
-            shape: const StadiumBorder(),
-            textStyle: KolabingTextStyles.button,
-          ),
-        ),
+    // Icon
+    iconTheme: const IconThemeData(color: KolabingColors.onSurface, size: 24),
 
-        // Outlined Button (Secondary) — pill shape, charcoal border
-        outlinedButtonTheme: OutlinedButtonThemeData(
-          style: OutlinedButton.styleFrom(
-            foregroundColor: KolabingColors.charcoal,
-            elevation: 0,
-            minimumSize: const Size(double.infinity, KolabingLayout.buttonHeight),
-            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-            shape: const StadiumBorder(),
-            side: const BorderSide(color: KolabingColors.charcoal, width: 1),
-            textStyle: KolabingTextStyles.button,
-          ),
-        ),
+    // Text Theme
+    textTheme: _buildTextTheme(KolabingColors.onSurface),
 
-        // Text Button — purple for links
-        textButtonTheme: TextButtonThemeData(
-          style: TextButton.styleFrom(
-            foregroundColor: KolabingColors.secondary,
-            textStyle: KolabingTextStyles.labelLarge,
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          ),
-        ),
+    // Font — Inter everywhere
+    fontFamily: KolabingTypography.fontBody,
 
-        // Input Decoration — pure white fill, subtle border, black on focus
-        inputDecorationTheme: InputDecorationTheme(
-          filled: true,
-          fillColor: KolabingColors.surfaceVariant,
-          contentPadding: const EdgeInsets.symmetric(
-            horizontal: 16,
-            vertical: 14,
-          ),
-          border: OutlineInputBorder(
-            borderRadius: KolabingRadius.borderRadiusMd,
-            borderSide: const BorderSide(color: KolabingColors.darkBorder),
-          ),
-          enabledBorder: OutlineInputBorder(
-            borderRadius: KolabingRadius.borderRadiusMd,
-            borderSide: const BorderSide(color: KolabingColors.darkBorder),
-          ),
-          focusedBorder: OutlineInputBorder(
-            borderRadius: KolabingRadius.borderRadiusMd,
-            borderSide: const BorderSide(
-              color: KolabingColors.borderFocus,
-              width: 1.5,
-            ),
-          ),
-          errorBorder: OutlineInputBorder(
-            borderRadius: KolabingRadius.borderRadiusMd,
-            borderSide: const BorderSide(color: KolabingColors.borderError),
-          ),
-          focusedErrorBorder: OutlineInputBorder(
-            borderRadius: KolabingRadius.borderRadiusMd,
-            borderSide: const BorderSide(
-              color: KolabingColors.borderError,
-              width: 1.5,
-            ),
-          ),
-          hintStyle: KolabingTextStyles.bodyMedium.copyWith(
-            color: KolabingColors.textTertiary,
-          ),
-          labelStyle: KolabingTextStyles.bodyMedium.copyWith(
-            color: KolabingColors.onSurfaceVariant,
-          ),
-          floatingLabelStyle: KolabingTextStyles.bodySmall.copyWith(
-            color: KolabingColors.onSurfaceVariant,
-          ),
-          errorStyle: KolabingTextStyles.bodySmall.copyWith(
-            color: KolabingColors.error,
-          ),
-        ),
-
-        // Chip — sage fill, pill shape, no border
-        chipTheme: ChipThemeData(
-          backgroundColor: KolabingColors.tertiaryContainer,
-          labelStyle: KolabingTextStyles.labelMedium.copyWith(
-            color: KolabingColors.onSurface,
-          ),
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-          shape: const StadiumBorder(side: BorderSide.none),
-          elevation: 0,
-          pressElevation: 0,
-        ),
-
-        // Divider — warm grey
-        dividerTheme: const DividerThemeData(
-          color: KolabingColors.darkBorder,
-          thickness: 1,
-          space: 1,
-        ),
-
-        // Dialog — white surface
-        dialogTheme: DialogThemeData(
-          backgroundColor: KolabingColors.surface,
-          elevation: 0,
-          shape: RoundedRectangleBorder(
-            borderRadius: KolabingRadius.borderRadiusLg,
-            side: const BorderSide(color: KolabingColors.darkBorder),
-          ),
-          titleTextStyle: KolabingTextStyles.headlineMedium.copyWith(
-            color: KolabingColors.onSurface,
-          ),
-          contentTextStyle: KolabingTextStyles.bodyMedium.copyWith(
-            color: KolabingColors.onSurfaceVariant,
-          ),
-        ),
-
-        // Bottom Sheet — white, no heavy shadow
-        bottomSheetTheme: const BottomSheetThemeData(
-          backgroundColor: KolabingColors.surface,
-          elevation: 0,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.vertical(
-              top: Radius.circular(KolabingRadius.xl),
-            ),
-          ),
-          showDragHandle: true,
-          dragHandleColor: KolabingColors.darkBorder,
-        ),
-
-        // Snackbar — near-black (the one place we use dark fill)
-        snackBarTheme: SnackBarThemeData(
-          backgroundColor: KolabingColors.onSurface,
-          contentTextStyle: KolabingTextStyles.bodyMedium.copyWith(
-            color: KolabingColors.textOnDark,
-          ),
-          behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(
-            borderRadius: KolabingRadius.borderRadiusSm,
-          ),
-        ),
-
-        // Icon
-        iconTheme: const IconThemeData(
-          color: KolabingColors.onSurface,
-          size: 24,
-        ),
-
-        // Text Theme
-        textTheme: _buildTextTheme(KolabingColors.onSurface),
-
-        // Font — Inter everywhere
-        fontFamily: KolabingTypography.fontBody,
-
-        // Runtime color tokens (light set) — resolved via context.colors.xxx
-        extensions: const [KolabingColorTokens.light],
-      );
+    // Runtime color tokens (light set) — resolved via context.colors.xxx
+    extensions: const [KolabingColorTokens.light],
+  );
 
   // ---------------------------------------------------------------------------
   // Night Theme (dark mode — primary/default theme)
@@ -306,7 +302,9 @@ abstract final class KolabingTheme {
           statusBarIconBrightness: Brightness.light,
           statusBarBrightness: Brightness.dark,
         ),
-        titleTextStyle: KolabingTextStyles.titleLarge.copyWith(color: n.onSurface),
+        titleTextStyle: KolabingTextStyles.titleLarge.copyWith(
+          color: n.onSurface,
+        ),
         iconTheme: IconThemeData(color: n.onSurface, size: 24),
       ),
 
@@ -339,8 +337,12 @@ abstract final class KolabingTheme {
         style: ElevatedButton.styleFrom(
           backgroundColor: n.primary,
           foregroundColor: n.onPrimary,
-          disabledBackgroundColor: const Color(0xFFFFE28C).withValues(alpha: 0.5),
-          disabledForegroundColor: const Color(0xFF19150F).withValues(alpha: 0.5),
+          disabledBackgroundColor: const Color(
+            0xFFFFE28C,
+          ).withValues(alpha: 0.5),
+          disabledForegroundColor: const Color(
+            0xFF19150F,
+          ).withValues(alpha: 0.5),
           elevation: 0,
           shadowColor: Colors.transparent,
           minimumSize: const Size(double.infinity, KolabingLayout.buttonHeight),
@@ -390,7 +392,10 @@ abstract final class KolabingTheme {
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
         fillColor: n.surfaceVariant,
-        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 14,
+        ),
         border: OutlineInputBorder(
           borderRadius: KolabingRadius.borderRadiusMd,
           borderSide: BorderSide(color: n.outline),
@@ -411,9 +416,15 @@ abstract final class KolabingTheme {
           borderRadius: KolabingRadius.borderRadiusMd,
           borderSide: BorderSide(color: n.borderError, width: 1.5),
         ),
-        hintStyle: KolabingTextStyles.bodyMedium.copyWith(color: n.textTertiary),
-        labelStyle: KolabingTextStyles.bodyMedium.copyWith(color: n.onSurfaceVariant),
-        floatingLabelStyle: KolabingTextStyles.bodySmall.copyWith(color: n.onSurfaceVariant),
+        hintStyle: KolabingTextStyles.bodyMedium.copyWith(
+          color: n.textTertiary,
+        ),
+        labelStyle: KolabingTextStyles.bodyMedium.copyWith(
+          color: n.onSurfaceVariant,
+        ),
+        floatingLabelStyle: KolabingTextStyles.bodySmall.copyWith(
+          color: n.onSurfaceVariant,
+        ),
         errorStyle: KolabingTextStyles.bodySmall.copyWith(color: n.error),
       ),
 
@@ -438,8 +449,12 @@ abstract final class KolabingTheme {
           borderRadius: KolabingRadius.borderRadiusLg,
           side: BorderSide(color: n.outlineVariant),
         ),
-        titleTextStyle: KolabingTextStyles.headlineMedium.copyWith(color: n.onSurface),
-        contentTextStyle: KolabingTextStyles.bodyMedium.copyWith(color: n.onSurfaceVariant),
+        titleTextStyle: KolabingTextStyles.headlineMedium.copyWith(
+          color: n.onSurface,
+        ),
+        contentTextStyle: KolabingTextStyles.bodyMedium.copyWith(
+          color: n.onSurfaceVariant,
+        ),
       ),
 
       // Bottom Sheet
@@ -447,7 +462,9 @@ abstract final class KolabingTheme {
         backgroundColor: n.surfaceContainer,
         elevation: 0,
         shape: const RoundedRectangleBorder(
-          borderRadius: BorderRadius.vertical(top: Radius.circular(KolabingRadius.xl)),
+          borderRadius: BorderRadius.vertical(
+            top: Radius.circular(KolabingRadius.xl),
+          ),
         ),
         showDragHandle: true,
         dragHandleColor: n.outlineVariant,
@@ -456,9 +473,13 @@ abstract final class KolabingTheme {
       // Snackbar — inverse surface
       snackBarTheme: SnackBarThemeData(
         backgroundColor: n.inverseSurface,
-        contentTextStyle: KolabingTextStyles.bodyMedium.copyWith(color: n.inverseOnSurface),
+        contentTextStyle: KolabingTextStyles.bodyMedium.copyWith(
+          color: n.inverseOnSurface,
+        ),
         behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(borderRadius: KolabingRadius.borderRadiusSm),
+        shape: RoundedRectangleBorder(
+          borderRadius: KolabingRadius.borderRadiusSm,
+        ),
       ),
 
       // Icon
@@ -481,24 +502,22 @@ abstract final class KolabingTheme {
 
   /// Build text theme with appropriate text color
   static TextTheme _buildTextTheme(Color textColor) => TextTheme(
-        displayLarge: KolabingTextStyles.displayLarge.copyWith(color: textColor),
-        displayMedium:
-            KolabingTextStyles.displayMedium.copyWith(color: textColor),
-        displaySmall: KolabingTextStyles.displaySmall.copyWith(color: textColor),
-        headlineLarge:
-            KolabingTextStyles.headlineLarge.copyWith(color: textColor),
-        headlineMedium:
-            KolabingTextStyles.headlineMedium.copyWith(color: textColor),
-        headlineSmall:
-            KolabingTextStyles.headlineSmall.copyWith(color: textColor),
-        titleLarge: KolabingTextStyles.titleLarge.copyWith(color: textColor),
-        titleMedium: KolabingTextStyles.titleMedium.copyWith(color: textColor),
-        titleSmall: KolabingTextStyles.titleSmall.copyWith(color: textColor),
-        bodyLarge: KolabingTextStyles.bodyLarge.copyWith(color: textColor),
-        bodyMedium: KolabingTextStyles.bodyMedium.copyWith(color: textColor),
-        bodySmall: KolabingTextStyles.bodySmall.copyWith(color: textColor),
-        labelLarge: KolabingTextStyles.labelLarge.copyWith(color: textColor),
-        labelMedium: KolabingTextStyles.labelMedium.copyWith(color: textColor),
-        labelSmall: KolabingTextStyles.labelSmall.copyWith(color: textColor),
-      );
+    displayLarge: KolabingTextStyles.displayLarge.copyWith(color: textColor),
+    displayMedium: KolabingTextStyles.displayMedium.copyWith(color: textColor),
+    displaySmall: KolabingTextStyles.displaySmall.copyWith(color: textColor),
+    headlineLarge: KolabingTextStyles.headlineLarge.copyWith(color: textColor),
+    headlineMedium: KolabingTextStyles.headlineMedium.copyWith(
+      color: textColor,
+    ),
+    headlineSmall: KolabingTextStyles.headlineSmall.copyWith(color: textColor),
+    titleLarge: KolabingTextStyles.titleLarge.copyWith(color: textColor),
+    titleMedium: KolabingTextStyles.titleMedium.copyWith(color: textColor),
+    titleSmall: KolabingTextStyles.titleSmall.copyWith(color: textColor),
+    bodyLarge: KolabingTextStyles.bodyLarge.copyWith(color: textColor),
+    bodyMedium: KolabingTextStyles.bodyMedium.copyWith(color: textColor),
+    bodySmall: KolabingTextStyles.bodySmall.copyWith(color: textColor),
+    labelLarge: KolabingTextStyles.labelLarge.copyWith(color: textColor),
+    labelMedium: KolabingTextStyles.labelMedium.copyWith(color: textColor),
+    labelSmall: KolabingTextStyles.labelSmall.copyWith(color: textColor),
+  );
 }

--- a/lib/features/application/screens/application_review_screen.dart
+++ b/lib/features/application/screens/application_review_screen.dart
@@ -21,10 +21,7 @@ import '../../../widgets/profile_link.dart';
 /// availability, and Accept / Decline actions.
 /// After accepting, navigates to the chat screen.
 class ApplicationReviewScreen extends ConsumerStatefulWidget {
-  const ApplicationReviewScreen({
-    super.key,
-    required this.applicationId,
-  });
+  const ApplicationReviewScreen({super.key, required this.applicationId});
 
   final String applicationId;
 
@@ -40,8 +37,9 @@ class _ApplicationReviewScreenState
 
   @override
   Widget build(BuildContext context) {
-    final asyncApplication =
-        ref.watch(applicationDetailProvider(widget.applicationId));
+    final asyncApplication = ref.watch(
+      applicationDetailProvider(widget.applicationId),
+    );
 
     return Scaffold(
       backgroundColor: context.colors.background,
@@ -50,8 +48,7 @@ class _ApplicationReviewScreenState
         elevation: 0,
         centerTitle: true,
         leading: IconButton(
-          icon: Icon(LucideIcons.arrowLeft,
-              color: context.colors.onSurface),
+          icon: Icon(LucideIcons.arrowLeft, color: context.colors.onSurface),
           onPressed: () => context.pop(),
         ),
         title: Text(
@@ -73,8 +70,11 @@ class _ApplicationReviewScreenState
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Icon(LucideIcons.alertCircle,
-                    size: 48, color: context.colors.error),
+                Icon(
+                  LucideIcons.alertCircle,
+                  size: 48,
+                  color: context.colors.error,
+                ),
                 const SizedBox(height: KolabingSpacing.md),
                 Text(
                   AppLocalizations.of(context).applicationReviewLoadError,
@@ -87,10 +87,14 @@ class _ApplicationReviewScreenState
                 const SizedBox(height: KolabingSpacing.sm),
                 TextButton(
                   onPressed: () => ref.invalidate(
-                      applicationDetailProvider(widget.applicationId)),
-                  child: Text(AppLocalizations.of(context).commonRetry,
-                      style: KolabingTextStyles.labelLarge.copyWith(
-                          color: context.colors.primary)),
+                    applicationDetailProvider(widget.applicationId),
+                  ),
+                  child: Text(
+                    AppLocalizations.of(context).commonRetry,
+                    style: KolabingTextStyles.labelLarge.copyWith(
+                      color: context.colors.primary,
+                    ),
+                  ),
                 ),
               ],
             ),
@@ -99,7 +103,10 @@ class _ApplicationReviewScreenState
         data: (application) {
           if (application == null) {
             return Center(
-                child: Text(AppLocalizations.of(context).applicationReviewNotFound));
+              child: Text(
+                AppLocalizations.of(context).applicationReviewNotFound,
+              ),
+            );
           }
           return _buildContent(application);
         },
@@ -130,11 +137,15 @@ class _ApplicationReviewScreenState
                 // Application message
                 _buildSection(
                   icon: LucideIcons.messageSquare,
-                  title: AppLocalizations.of(context).applicationReviewMessageLabel,
+                  title: AppLocalizations.of(
+                    context,
+                  ).applicationReviewMessageLabel,
                   child: Text(
                     application.message.isNotEmpty
                         ? application.message
-                        : AppLocalizations.of(context).applicationReviewNoMessage,
+                        : AppLocalizations.of(
+                            context,
+                          ).applicationReviewNoMessage,
                     style: KolabingTextStyles.bodySmall.copyWith(
                       color: application.message.isNotEmpty
                           ? context.colors.onSurface
@@ -148,11 +159,15 @@ class _ApplicationReviewScreenState
                 // Availability
                 _buildSection(
                   icon: LucideIcons.calendar,
-                  title: AppLocalizations.of(context).applicationReviewAvailabilityLabel,
+                  title: AppLocalizations.of(
+                    context,
+                  ).applicationReviewAvailabilityLabel,
                   child: Text(
                     application.availability.isNotEmpty
                         ? application.availability
-                        : AppLocalizations.of(context).applicationReviewNotSpecified,
+                        : AppLocalizations.of(
+                            context,
+                          ).applicationReviewNotSpecified,
                     style: KolabingTextStyles.bodySmall.copyWith(
                       color: application.availability.isNotEmpty
                           ? context.colors.onSurface
@@ -166,7 +181,9 @@ class _ApplicationReviewScreenState
                 // Applied date
                 _buildSection(
                   icon: LucideIcons.clock,
-                  title: AppLocalizations.of(context).applicationReviewAppliedLabel,
+                  title: AppLocalizations.of(
+                    context,
+                  ).applicationReviewAppliedLabel,
                   child: Text(
                     application.createdAtDisplay,
                     style: KolabingTextStyles.bodySmall.copyWith(
@@ -203,12 +220,18 @@ class _ApplicationReviewScreenState
       ),
       child: Row(
         children: [
-          Icon(LucideIcons.briefcase, size: 18, color: context.colors.onPrimary),
+          Icon(
+            LucideIcons.briefcase,
+            size: 18,
+            color: context.colors.onPrimary,
+          ),
           const SizedBox(width: KolabingSpacing.xs),
           Expanded(
             child: Text(
               opportunity?.title ??
-                  AppLocalizations.of(context).applicationReviewUnknownOpportunity,
+                  AppLocalizations.of(
+                    context,
+                  ).applicationReviewUnknownOpportunity,
               style: KolabingTextStyles.bodySmall.copyWith(
                 fontWeight: FontWeight.w600,
                 color: context.colors.onSurface,
@@ -223,7 +246,9 @@ class _ApplicationReviewScreenState
   }
 
   Widget _buildApplicantCard(
-      ApplicantProfile? profile, Application application) {
+    ApplicantProfile? profile,
+    Application application,
+  ) {
     return Container(
       padding: const EdgeInsets.all(KolabingSpacing.lg),
       decoration: BoxDecoration(
@@ -307,8 +332,11 @@ class _ApplicationReviewScreenState
             Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Icon(LucideIcons.mapPin,
-                    size: 14, color: context.colors.textTertiary),
+                Icon(
+                  LucideIcons.mapPin,
+                  size: 14,
+                  color: context.colors.textTertiary,
+                ),
                 const SizedBox(width: 4),
                 Text(
                   profile.city!,
@@ -404,31 +432,33 @@ class _ApplicationReviewScreenState
     final l10n = AppLocalizations.of(context);
     final (icon, color, label, description) = switch (application.status) {
       ApplicationStatus.accepted => (
-          LucideIcons.checkCircle,
-          context.colors.success,
-          l10n.applicationReviewStatusAccepted,
-          l10n.applicationReviewStatusAcceptedDesc,
-        ),
+        LucideIcons.checkCircle,
+        context.colors.success,
+        l10n.applicationReviewStatusAccepted,
+        l10n.applicationReviewStatusAcceptedDesc,
+      ),
       ApplicationStatus.declined => (
-          LucideIcons.xCircle,
-          context.colors.error,
-          l10n.applicationReviewStatusDeclined,
-          application.declineReason != null
-              ? l10n.applicationReviewStatusDeclinedReason(application.declineReason!)
-              : l10n.applicationReviewStatusDeclinedDesc,
-        ),
+        LucideIcons.xCircle,
+        context.colors.error,
+        l10n.applicationReviewStatusDeclined,
+        application.declineReason != null
+            ? l10n.applicationReviewStatusDeclinedReason(
+                application.declineReason!,
+              )
+            : l10n.applicationReviewStatusDeclinedDesc,
+      ),
       ApplicationStatus.withdrawn => (
-          LucideIcons.minusCircle,
-          context.colors.textTertiary,
-          l10n.applicationReviewStatusWithdrawn,
-          l10n.applicationReviewStatusWithdrawnDesc,
-        ),
+        LucideIcons.minusCircle,
+        context.colors.textTertiary,
+        l10n.applicationReviewStatusWithdrawn,
+        l10n.applicationReviewStatusWithdrawnDesc,
+      ),
       _ => (
-          LucideIcons.clock,
-          context.colors.pendingText,
-          l10n.applicationReviewStatusPending,
-          '',
-        ),
+        LucideIcons.clock,
+        context.colors.pendingText,
+        l10n.applicationReviewStatusPending,
+        '',
+      ),
     };
 
     return Container(
@@ -498,10 +528,9 @@ class _ApplicationReviewScreenState
             child: SizedBox(
               height: 52,
               child: OutlinedButton.icon(
-                onPressed:
-                    _isDeclining || _isAccepting
-                        ? null
-                        : () => _showDeclineDialog(application),
+                onPressed: _isDeclining || _isAccepting
+                    ? null
+                    : () => _showDeclineDialog(application),
                 style: OutlinedButton.styleFrom(
                   foregroundColor: context.colors.error,
                   side: BorderSide(color: context.colors.error),
@@ -511,7 +540,9 @@ class _ApplicationReviewScreenState
                         width: 16,
                         height: 16,
                         child: CircularProgressIndicator(
-                            strokeWidth: 2, color: context.colors.error),
+                          strokeWidth: 2,
+                          color: context.colors.error,
+                        ),
                       )
                     : const Icon(LucideIcons.x, size: 18),
                 label: FittedBox(
@@ -537,7 +568,9 @@ class _ApplicationReviewScreenState
             flex: 3,
             child: KolabingButton(
               label: AppLocalizations.of(context).applicationReviewAccept,
-              onPressed: _isAccepting || _isDeclining ? null : () => _handleAccept(application),
+              onPressed: _isAccepting || _isDeclining
+                  ? null
+                  : () => _handleAccept(application),
               variant: KolabingButtonVariant.primary,
               size: KolabingButtonSize.compact,
               icon: const Icon(LucideIcons.check),
@@ -609,7 +642,9 @@ class _ApplicationReviewScreenState
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              l10n.applicationReviewDeclineDialogBody(application.applicantName),
+              l10n.applicationReviewDeclineDialogBody(
+                application.applicantName,
+              ),
               style: KolabingTextStyles.bodySmall.copyWith(
                 color: context.colors.onSurfaceVariant,
               ),
@@ -633,8 +668,7 @@ class _ApplicationReviewScreenState
                 ),
                 focusedBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(8),
-                  borderSide:
-                      BorderSide(color: context.colors.borderFocus),
+                  borderSide: BorderSide(color: context.colors.borderFocus),
                 ),
               ),
             ),
@@ -645,7 +679,9 @@ class _ApplicationReviewScreenState
             onPressed: () => Navigator.of(ctx).pop(false),
             child: Text(
               l10n.commonCancel,
-              style: KolabingTextStyles.labelLarge.copyWith(color: context.colors.onSurfaceVariant),
+              style: KolabingTextStyles.labelLarge.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
             ),
           ),
           ElevatedButton(
@@ -668,8 +704,9 @@ class _ApplicationReviewScreenState
 
     setState(() => _isDeclining = true);
 
-    final reason =
-        reasonController.text.trim().isNotEmpty ? reasonController.text.trim() : null;
+    final reason = reasonController.text.trim().isNotEmpty
+        ? reasonController.text.trim()
+        : null;
 
     try {
       await ref
@@ -687,7 +724,9 @@ class _ApplicationReviewScreenState
         SnackBar(
           content: Text(
             l10n.applicationReviewDeclinedSnack,
-            style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.textOnDark),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              color: context.colors.textOnDark,
+            ),
           ),
           backgroundColor: context.colors.onSurfaceVariant,
           behavior: SnackBarBehavior.floating,
@@ -703,7 +742,9 @@ class _ApplicationReviewScreenState
         SnackBar(
           content: Text(
             _parseError(e),
-            style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.textOnDark),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              color: context.colors.textOnDark,
+            ),
           ),
           backgroundColor: context.colors.error,
           behavior: SnackBarBehavior.floating,
@@ -758,8 +799,9 @@ class _AcceptFormSheetState extends State<_AcceptFormSheet> {
 
     final start = DateUtils.dateOnly(opportunity.availabilityStart);
     final end = DateUtils.dateOnly(opportunity.availabilityEnd);
-    final tomorrow =
-        DateUtils.dateOnly(DateTime.now()).add(const Duration(days: 1));
+    final tomorrow = DateUtils.dateOnly(
+      DateTime.now(),
+    ).add(const Duration(days: 1));
     final effectiveStart = start.isBefore(tomorrow) ? tomorrow : start;
 
     if (effectiveStart.isAfter(end)) return [];
@@ -772,13 +814,14 @@ class _AcceptFormSheetState extends State<_AcceptFormSheet> {
     }
 
     // Recurring: publisher picked specific weekdays. Filter the daily walk.
-    final filterByWeekday = modeName == 'recurring' &&
-        opportunity.recurringDays.isNotEmpty;
+    final filterByWeekday =
+        modeName == 'recurring' && opportunity.recurringDays.isNotEmpty;
 
     final dates = <DateTime>[];
     var current = effectiveStart;
     while (!current.isAfter(end)) {
-      if (!filterByWeekday || opportunity.recurringDays.contains(current.weekday)) {
+      if (!filterByWeekday ||
+          opportunity.recurringDays.contains(current.weekday)) {
         dates.add(current);
       }
       current = current.add(const Duration(days: 1));
@@ -882,7 +925,8 @@ class _AcceptFormSheetState extends State<_AcceptFormSheet> {
                         const SizedBox(width: KolabingSpacing.xs),
                     itemBuilder: (_, index) {
                       final date = dates[index];
-                      final isSelected = _selectedDate != null &&
+                      final isSelected =
+                          _selectedDate != null &&
                           DateUtils.isSameDay(_selectedDate!, date);
                       return _buildDateTile(date, isSelected);
                     },
@@ -930,8 +974,18 @@ class _AcceptFormSheetState extends State<_AcceptFormSheet> {
   Widget _buildDateTile(DateTime date, bool isSelected) {
     const dayNames = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
     const monthNames = [
-      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
     ];
 
     return GestureDetector(
@@ -1019,7 +1073,9 @@ class _AcceptFormSheetState extends State<_AcceptFormSheet> {
         SnackBar(
           content: Text(
             l10n.acceptFormAcceptedSnack,
-            style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.textOnDark),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              color: context.colors.textOnDark,
+            ),
           ),
           backgroundColor: context.colors.success,
           behavior: SnackBarBehavior.floating,

--- a/lib/features/application/widgets/apply_success_sheet.dart
+++ b/lib/features/application/widgets/apply_success_sheet.dart
@@ -26,18 +26,17 @@ class ApplySuccessSheet extends StatefulWidget {
     BuildContext context, {
     required Opportunity opportunity,
     required VoidCallback onViewApplications,
-  }) =>
-      showModalBottomSheet<void>(
-        context: context,
-        isScrollControlled: true,
-        isDismissible: true,
-        enableDrag: true,
-        backgroundColor: Colors.transparent,
-        builder: (_) => ApplySuccessSheet(
-          opportunity: opportunity,
-          onViewApplications: onViewApplications,
-        ),
-      );
+  }) => showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    isDismissible: true,
+    enableDrag: true,
+    backgroundColor: Colors.transparent,
+    builder: (_) => ApplySuccessSheet(
+      opportunity: opportunity,
+      onViewApplications: onViewApplications,
+    ),
+  );
 
   @override
   State<ApplySuccessSheet> createState() => _ApplySuccessSheetState();
@@ -130,13 +129,22 @@ class _ApplySuccessSheetState extends State<ApplySuccessSheet>
                 Text(
                   'Application sent!',
                   textAlign: TextAlign.center,
-                  style: KolabingTextStyles.bodyLarge.copyWith(fontSize: 24, fontWeight: FontWeight.w700, color: context.colors.onSurface, height: 1.2),
+                  style: KolabingTextStyles.bodyLarge.copyWith(
+                    fontSize: 24,
+                    fontWeight: FontWeight.w700,
+                    color: context.colors.onSurface,
+                    height: 1.2,
+                  ),
                 ),
                 const SizedBox(height: KolabingSpacing.xs),
                 Text(
                   'Your application is on its way to $creatorName.',
                   textAlign: TextAlign.center,
-                  style: KolabingTextStyles.bodySmall.copyWith(fontSize: 15, color: context.colors.onSurfaceVariant, height: 1.5),
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    fontSize: 15,
+                    color: context.colors.onSurfaceVariant,
+                    height: 1.5,
+                  ),
                 ),
               ],
             ),
@@ -194,11 +202,13 @@ class _ApplySuccessSheetState extends State<ApplySuccessSheet>
               icon: const Icon(LucideIcons.fileText, size: 18),
               label: Text(
                 'VIEW MY APPLICATIONS',
-                style: KolabingTextStyles.bodySmall.copyWith(fontSize: 15, fontWeight: FontWeight.w600, letterSpacing: 1.0),
+                style: KolabingTextStyles.bodySmall.copyWith(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 1.0,
+                ),
               ),
-              style: ElevatedButton.styleFrom(
-                elevation: 0,
-              ),
+              style: ElevatedButton.styleFrom(elevation: 0),
             ),
           ),
 
@@ -214,7 +224,9 @@ class _ApplySuccessSheetState extends State<ApplySuccessSheet>
               ),
               child: Text(
                 'Keep exploring',
-                style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w600),
+                style: KolabingTextStyles.bodySmall.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
               ),
             ),
           ),
@@ -272,11 +284,7 @@ class _Hero extends StatelessWidget {
           // Animated check mark
           ScaleTransition(
             scale: check,
-            child: const Icon(
-              LucideIcons.check,
-              size: 38,
-              color: Colors.white,
-            ),
+            child: const Icon(LucideIcons.check, size: 38, color: Colors.white),
           ),
         ],
       ),
@@ -285,11 +293,7 @@ class _Hero extends StatelessWidget {
 }
 
 class _InfoRow extends StatelessWidget {
-  const _InfoRow({
-    required this.icon,
-    required this.title,
-    required this.body,
-  });
+  const _InfoRow({required this.icon, required this.title, required this.body});
 
   final IconData icon;
   final String title;
@@ -297,38 +301,45 @@ class _InfoRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Container(
-            width: 36,
-            height: 36,
-            decoration: BoxDecoration(
-              color: context.colors.surface,
-              borderRadius: BorderRadius.circular(10),
-              border: Border.all(
-                color: context.colors.primary.withValues(alpha: 0.25),
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Container(
+        width: 36,
+        height: 36,
+        decoration: BoxDecoration(
+          color: context.colors.surface,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(
+            color: context.colors.primary.withValues(alpha: 0.25),
+          ),
+        ),
+        alignment: Alignment.center,
+        child: Icon(icon, size: 18, color: context.colors.onSurface),
+      ),
+      const SizedBox(width: KolabingSpacing.sm),
+      Expanded(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: KolabingTextStyles.bodySmall.copyWith(
+                fontWeight: FontWeight.w700,
+                color: context.colors.onSurface,
+                height: 1.3,
               ),
             ),
-            alignment: Alignment.center,
-            child: Icon(icon, size: 18, color: context.colors.onSurface),
-          ),
-          const SizedBox(width: KolabingSpacing.sm),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  title,
-                  style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurface, height: 1.3),
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  body,
-                  style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant, height: 1.5),
-                ),
-              ],
+            const SizedBox(height: 2),
+            Text(
+              body,
+              style: KolabingTextStyles.captionSecondary.copyWith(
+                color: context.colors.onSurfaceVariant,
+                height: 1.5,
+              ),
             ),
-          ),
-        ],
-      );
+          ],
+        ),
+      ),
+    ],
+  );
 }

--- a/lib/features/auth/screens/sign_in_screen.dart
+++ b/lib/features/auth/screens/sign_in_screen.dart
@@ -314,51 +314,55 @@ class _SignInScreenState extends ConsumerState<SignInScreen>
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
                 child: Column(
-              children: [
-                const Spacer(flex: 2),
+                  children: [
+                    const Spacer(flex: 2),
 
-                // Logo
-                _AnimatedElement(
-                  animation: _logoAnimation,
-                  child: const KolabingLogo(
-                    width: 220,
-                    variant: KolabingLogoVariant.yellowTransparent,
-                  ),
+                    // Logo
+                    _AnimatedElement(
+                      animation: _logoAnimation,
+                      child: const KolabingLogo(
+                        width: 220,
+                        variant: KolabingLogoVariant.yellowTransparent,
+                      ),
+                    ),
+
+                    const SizedBox(height: 48),
+
+                    // Google Sign In Button
+                    _AnimatedElement(
+                      animation: _buttonAnimation,
+                      slideUp: true,
+                      child: GoogleSignInButton(
+                        onPressed: _handleGoogleSignIn,
+                        buttonText: AppLocalizations.of(
+                          context,
+                        ).signInWithGoogle,
+                        isLoading: _isLoading,
+                        showSuccess: _showSuccess,
+                        isEnabled: !_isLoading && !_showSuccess,
+                      ),
+                    ),
+
+                    const SizedBox(height: 24),
+
+                    // Sign Up Link
+                    _AnimatedElement(
+                      animation: _linkAnimation,
+                      child: AuthLink(
+                        leadingText: AppLocalizations.of(
+                          context,
+                        ).signInNoAccount,
+                        actionText: AppLocalizations.of(context).signInSignUp,
+                        onTap: _navigateToSignUp,
+                        isEnabled: !_isLoading && !_showSuccess,
+                      ),
+                    ),
+
+                    const Spacer(flex: 3),
+                  ],
                 ),
-
-                const SizedBox(height: 48),
-
-                // Google Sign In Button
-                _AnimatedElement(
-                  animation: _buttonAnimation,
-                  slideUp: true,
-                  child: GoogleSignInButton(
-                    onPressed: _handleGoogleSignIn,
-                    buttonText: AppLocalizations.of(context).signInWithGoogle,
-                    isLoading: _isLoading,
-                    showSuccess: _showSuccess,
-                    isEnabled: !_isLoading && !_showSuccess,
-                  ),
-                ),
-
-                const SizedBox(height: 24),
-
-                // Sign Up Link
-                _AnimatedElement(
-                  animation: _linkAnimation,
-                  child: AuthLink(
-                    leadingText: AppLocalizations.of(context).signInNoAccount,
-                    actionText: AppLocalizations.of(context).signInSignUp,
-                    onTap: _navigateToSignUp,
-                    isEnabled: !_isLoading && !_showSuccess,
-                  ),
-                ),
-
-                const Spacer(flex: 3),
-              ],
+              ),
             ),
-          ),
-        ),
           ],
         ),
       ),

--- a/lib/features/auth/screens/welcome_screen.dart
+++ b/lib/features/auth/screens/welcome_screen.dart
@@ -105,9 +105,7 @@ class _WelcomeScreenState extends State<WelcomeScreen>
                 left: 0,
                 right: 0,
                 height: waveHeight,
-                child: CustomPaint(
-                  painter: _WavePainter(color: _kCream),
-                ),
+                child: CustomPaint(painter: _WavePainter(color: _kCream)),
               ),
 
               // Main layout
@@ -225,10 +223,7 @@ class _WelcomeHeadline extends StatelessWidget {
 
 /// Renders text with a yellow swash underline behind the baseline.
 class _YellowUnderlineText extends StatelessWidget {
-  const _YellowUnderlineText({
-    required this.text,
-    required this.style,
-  });
+  const _YellowUnderlineText({required this.text, required this.style});
 
   final String text;
   final TextStyle style;
@@ -274,17 +269,27 @@ class _TaglineRow extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        Text(l10n.welcomeTaglineMatch, style: baseStyle.copyWith(color: _kMuted)),
+        Text(
+          l10n.welcomeTaglineMatch,
+          style: baseStyle.copyWith(color: _kMuted),
+        ),
         const SizedBox(width: 6),
-        Text(l10n.welcomeTaglineDot,
-            style: baseStyle.copyWith(color: const Color(0xFFB5914A))),
+        Text(
+          l10n.welcomeTaglineDot,
+          style: baseStyle.copyWith(color: const Color(0xFFB5914A)),
+        ),
         const SizedBox(width: 6),
         Text(l10n.welcomeTaglineKolab, style: baseStyle.copyWith(color: _kInk)),
         const SizedBox(width: 6),
-        Text(l10n.welcomeTaglineDot,
-            style: baseStyle.copyWith(color: const Color(0xFFB5914A))),
+        Text(
+          l10n.welcomeTaglineDot,
+          style: baseStyle.copyWith(color: const Color(0xFFB5914A)),
+        ),
         const SizedBox(width: 6),
-        Text(l10n.welcomeTaglineGrow, style: baseStyle.copyWith(color: _kMuted)),
+        Text(
+          l10n.welcomeTaglineGrow,
+          style: baseStyle.copyWith(color: _kMuted),
+        ),
       ],
     );
   }
@@ -359,16 +364,8 @@ class _WavePainter extends CustomPainter {
     final path = Path()
       ..moveTo(0, 130 * sy)
       ..lineTo(0, 66 * sy)
-      ..cubicTo(
-        72 * sx, 22 * sy,
-        150 * sx, 52 * sy,
-        230 * sx, 60 * sy,
-      )
-      ..cubicTo(
-        300 * sx, 67 * sy,
-        352 * sx, 34 * sy,
-        402 * sx, 50 * sy,
-      )
+      ..cubicTo(72 * sx, 22 * sy, 150 * sx, 52 * sy, 230 * sx, 60 * sy)
+      ..cubicTo(300 * sx, 67 * sy, 352 * sx, 34 * sy, 402 * sx, 50 * sy)
       ..lineTo(402 * sx, 130 * sy)
       ..close();
 

--- a/lib/features/auth/widgets/auth_fade_slide.dart
+++ b/lib/features/auth/widgets/auth_fade_slide.dart
@@ -22,7 +22,8 @@ class AuthFadeSlide extends StatelessWidget {
     opacity: opacity,
     child: AnimatedBuilder(
       animation: offset,
-      builder: (context, c) => Transform.translate(offset: offset.value, child: c),
+      builder: (context, c) =>
+          Transform.translate(offset: offset.value, child: c),
       child: child,
     ),
   );
@@ -30,15 +31,12 @@ class AuthFadeSlide extends StatelessWidget {
 
 /// Simplified variant — opacity fade only, no translation.
 class AuthFadeOnly extends StatelessWidget {
-  const AuthFadeOnly({
-    required this.opacity,
-    required this.child,
-    super.key,
-  });
+  const AuthFadeOnly({required this.opacity, required this.child, super.key});
 
   final Animation<double> opacity;
   final Widget child;
 
   @override
-  Widget build(BuildContext context) => FadeTransition(opacity: opacity, child: child);
+  Widget build(BuildContext context) =>
+      FadeTransition(opacity: opacity, child: child);
 }

--- a/lib/features/auth/widgets/auth_link.dart
+++ b/lib/features/auth/widgets/auth_link.dart
@@ -64,54 +64,49 @@ class _AuthLinkState extends State<AuthLink> {
 
   @override
   Widget build(BuildContext context) => Semantics(
-        button: true,
-        enabled: widget.isEnabled,
-        label: AppLocalizations.of(context).authLinkSemanticLabel(
-          widget.leadingText,
-          widget.actionText,
-        ),
-        child: GestureDetector(
-          onTapDown: _handleTapDown,
-          onTapUp: _handleTapUp,
-          onTapCancel: _handleTapCancel,
-          onTap: _handleTap,
-          behavior: HitTestBehavior.opaque,
-          child: AnimatedOpacity(
-            duration: const Duration(milliseconds: 100),
-            opacity: widget.isEnabled ? 1.0 : 0.5,
-            child: AnimatedScale(
-              duration: const Duration(milliseconds: 100),
-              scale: _isPressed ? 0.98 : 1.0,
-              child: Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 12,
+    button: true,
+    enabled: widget.isEnabled,
+    label: AppLocalizations.of(
+      context,
+    ).authLinkSemanticLabel(widget.leadingText, widget.actionText),
+    child: GestureDetector(
+      onTapDown: _handleTapDown,
+      onTapUp: _handleTapUp,
+      onTapCancel: _handleTapCancel,
+      onTap: _handleTap,
+      behavior: HitTestBehavior.opaque,
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 100),
+        opacity: widget.isEnabled ? 1.0 : 0.5,
+        child: AnimatedScale(
+          duration: const Duration(milliseconds: 100),
+          scale: _isPressed ? 0.98 : 1.0,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            constraints: const BoxConstraints(minHeight: 48),
+            child: RichText(
+              textAlign: TextAlign.center,
+              text: TextSpan(
+                style: KolabingTextStyles.bodyMedium.copyWith(
+                  color: context.colors.textOnDark,
                 ),
-                constraints: const BoxConstraints(minHeight: 48),
-                child: RichText(
-                  textAlign: TextAlign.center,
-                  text: TextSpan(
+                children: [
+                  TextSpan(text: '${widget.leadingText} '),
+                  TextSpan(
+                    text: widget.actionText,
                     style: KolabingTextStyles.bodyMedium.copyWith(
-                      color: context.colors.textOnDark,
+                      color: context.colors.primary,
+                      fontWeight: FontWeight.w600,
+                      decoration: _isPressed ? TextDecoration.underline : null,
+                      decorationColor: context.colors.primary,
                     ),
-                    children: [
-                      TextSpan(text: '${widget.leadingText} '),
-                      TextSpan(
-                        text: widget.actionText,
-                        style: KolabingTextStyles.bodyMedium.copyWith(
-                          color: context.colors.primary,
-                          fontWeight: FontWeight.w600,
-                          decoration:
-                              _isPressed ? TextDecoration.underline : null,
-                          decorationColor: context.colors.primary,
-                        ),
-                      ),
-                    ],
                   ),
-                ),
+                ],
               ),
             ),
           ),
         ),
-      );
+      ),
+    ),
+  );
 }

--- a/lib/features/auth/widgets/kolabing_logo.dart
+++ b/lib/features/auth/widgets/kolabing_logo.dart
@@ -43,12 +43,8 @@ class KolabingLogo extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Semantics(
-        label: AppLocalizations.of(context).kolabingLogoSemanticLabel,
-        image: true,
-        child: Image.asset(
-          variant.assetPath,
-          width: width,
-          fit: BoxFit.contain,
-        ),
-      );
+    label: AppLocalizations.of(context).kolabingLogoSemanticLabel,
+    image: true,
+    child: Image.asset(variant.assetPath, width: width, fit: BoxFit.contain),
+  );
 }

--- a/lib/features/auth/widgets/selection_card.dart
+++ b/lib/features/auth/widgets/selection_card.dart
@@ -135,9 +135,7 @@ class _SelectionCardState extends State<SelectionCard> {
           ]
         : [
             BoxShadow(
-              color: Colors.black.withValues(
-                alpha: _isPressed ? 0.08 : 0.06,
-              ),
+              color: Colors.black.withValues(alpha: _isPressed ? 0.08 : 0.06),
               blurRadius: 16,
               offset: const Offset(0, 3),
             ),
@@ -152,10 +150,9 @@ class _SelectionCardState extends State<SelectionCard> {
       button: true,
       enabled: widget.isEnabled,
       selected: widget.isSelected,
-      label: AppLocalizations.of(context).selectionCardSemanticLabel(
-        _title(context),
-        _description(context),
-      ),
+      label: AppLocalizations.of(
+        context,
+      ).selectionCardSemanticLabel(_title(context), _description(context)),
       child: GestureDetector(
         onTapDown: _handleTapDown,
         onTapUp: _handleTapUp,
@@ -237,8 +234,9 @@ class _SelectionCardState extends State<SelectionCard> {
                                   fontSize: 9,
                                   fontWeight: FontWeight.w700,
                                   letterSpacing: 0.6,
-                                  color: context.colors.onSurface
-                                      .withValues(alpha: 0.7),
+                                  color: context.colors.onSurface.withValues(
+                                    alpha: 0.7,
+                                  ),
                                 ),
                               ),
                             ),
@@ -251,8 +249,9 @@ class _SelectionCardState extends State<SelectionCard> {
                         style: KolabingTextStyles.bodySmall.copyWith(
                           fontSize: 12,
                           color: isDisabled
-                              ? context.colors.onSurfaceVariant
-                                  .withValues(alpha: 0.5)
+                              ? context.colors.onSurfaceVariant.withValues(
+                                  alpha: 0.5,
+                                )
                               : context.colors.onSurfaceVariant,
                           height: 1.35,
                         ),

--- a/lib/features/auth/widgets/user_type_toggle.dart
+++ b/lib/features/auth/widgets/user_type_toggle.dart
@@ -47,13 +47,13 @@ class _UserTypeToggleState extends State<UserTypeToggle>
       vsync: this,
     );
 
-    _positionAnimation = Tween<double>(
-      begin: widget.selectedType == UserType.business ? 0.0 : 1.0,
-      end: widget.selectedType == UserType.business ? 0.0 : 1.0,
-    ).animate(CurvedAnimation(
-      parent: _animationController,
-      curve: Curves.easeOut,
-    ));
+    _positionAnimation =
+        Tween<double>(
+          begin: widget.selectedType == UserType.business ? 0.0 : 1.0,
+          end: widget.selectedType == UserType.business ? 0.0 : 1.0,
+        ).animate(
+          CurvedAnimation(parent: _animationController, curve: Curves.easeOut),
+        );
   }
 
   @override
@@ -74,13 +74,13 @@ class _UserTypeToggleState extends State<UserTypeToggle>
   void _animateToType(UserType type) {
     final targetValue = type == UserType.business ? 0.0 : 1.0;
 
-    _positionAnimation = Tween<double>(
-      begin: _positionAnimation.value,
-      end: targetValue,
-    ).animate(CurvedAnimation(
-      parent: _animationController,
-      curve: Curves.easeOut,
-    ));
+    _positionAnimation =
+        Tween<double>(
+          begin: _positionAnimation.value,
+          end: targetValue,
+        ).animate(
+          CurvedAnimation(parent: _animationController, curve: Curves.easeOut),
+        );
 
     _animationController
       ..reset()
@@ -98,77 +98,69 @@ class _UserTypeToggleState extends State<UserTypeToggle>
 
   @override
   Widget build(BuildContext context) => Semantics(
-        label:
-            'Select account type. Two options: Business or Community. Currently selected: ${widget.selectedType.label}. Double tap to switch.',
-        child: AnimatedOpacity(
-          duration: const Duration(milliseconds: 200),
-          opacity: widget.isEnabled ? 1.0 : 0.6,
-          child: Container(
-            height: 48,
-            decoration: BoxDecoration(
-              color: Colors.transparent,
-              border: Border.all(
-                color: context.colors.darkBorder,
-              ),
-              borderRadius: BorderRadius.circular(12),
-            ),
-            padding: const EdgeInsets.all(4),
-            child: LayoutBuilder(
-              builder: (context, constraints) {
-                final segmentWidth = (constraints.maxWidth - 4) / 2;
+    label:
+        'Select account type. Two options: Business or Community. Currently selected: ${widget.selectedType.label}. Double tap to switch.',
+    child: AnimatedOpacity(
+      duration: const Duration(milliseconds: 200),
+      opacity: widget.isEnabled ? 1.0 : 0.6,
+      child: Container(
+        height: 48,
+        decoration: BoxDecoration(
+          color: Colors.transparent,
+          border: Border.all(color: context.colors.darkBorder),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        padding: const EdgeInsets.all(4),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final segmentWidth = (constraints.maxWidth - 4) / 2;
 
-                return Stack(
-                  children: [
-                    // Animated selection pill
-                    AnimatedBuilder(
-                      animation: _positionAnimation,
-                      builder: (context, child) => Positioned(
-                        left: _positionAnimation.value * (segmentWidth + 4),
-                        top: 0,
-                        bottom: 0,
-                        width: segmentWidth,
-                        child: Container(
-                          decoration: BoxDecoration(
-                            color: context.colors.primary,
-                            borderRadius: BorderRadius.circular(10),
-                            boxShadow: [
-                              BoxShadow(
-                                color: Colors.black.withValues(alpha: 0.2),
-                                blurRadius: 2,
-                                offset: const Offset(0, 1),
-                              ),
-                            ],
+            return Stack(
+              children: [
+                // Animated selection pill
+                AnimatedBuilder(
+                  animation: _positionAnimation,
+                  builder: (context, child) => Positioned(
+                    left: _positionAnimation.value * (segmentWidth + 4),
+                    top: 0,
+                    bottom: 0,
+                    width: segmentWidth,
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: context.colors.primary,
+                        borderRadius: BorderRadius.circular(10),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withValues(alpha: 0.2),
+                            blurRadius: 2,
+                            offset: const Offset(0, 1),
                           ),
-                        ),
+                        ],
                       ),
                     ),
+                  ),
+                ),
 
-                    // Segment buttons
-                    Row(
-                      children: [
-                        _buildSegment(
-                          type: UserType.business,
-                          width: segmentWidth,
-                        ),
-                        const SizedBox(width: 4),
-                        _buildSegment(
-                          type: UserType.community,
-                          width: segmentWidth,
-                        ),
-                      ],
+                // Segment buttons
+                Row(
+                  children: [
+                    _buildSegment(type: UserType.business, width: segmentWidth),
+                    const SizedBox(width: 4),
+                    _buildSegment(
+                      type: UserType.community,
+                      width: segmentWidth,
                     ),
                   ],
-                );
-              },
-            ),
-          ),
+                ),
+              ],
+            );
+          },
         ),
-      );
+      ),
+    ),
+  );
 
-  Widget _buildSegment({
-    required UserType type,
-    required double width,
-  }) {
+  Widget _buildSegment({required UserType type, required double width}) {
     final isSelected = widget.selectedType == type;
 
     return GestureDetector(

--- a/lib/features/business/models/notification_preferences.dart
+++ b/lib/features/business/models/notification_preferences.dart
@@ -19,7 +19,8 @@ class NotificationPreferences {
         whatsappNotifications: json['whatsapp_notifications'] as bool? ?? true,
         // NF-16 B3: `message_notifications` is the field the backend adds in
         // parallel; fall back to the legacy `messages_enabled` key, default on.
-        messagesEnabled: json['message_notifications'] as bool? ??
+        messagesEnabled:
+            json['message_notifications'] as bool? ??
             json['messages_enabled'] as bool? ??
             true,
         applicationsEnabled:
@@ -59,20 +60,20 @@ class NotificationPreferences {
   bool get messageNotifications => messagesEnabled;
 
   Map<String, dynamic> toJson() => {
-        'email_notifications': emailNotifications,
-        'whatsapp_notifications': whatsappNotifications,
-        // Write both keys so the prefs round-trip whether or not the backend
-        // has shipped `message_notifications` yet.
-        'message_notifications': messagesEnabled,
-        'messages_enabled': messagesEnabled,
-        'applications_enabled': applicationsEnabled,
-        'collaborations_enabled': collaborationsEnabled,
-        'rewards_enabled': rewardsEnabled,
-        'marketing_enabled': marketingEnabled,
-        'quiet_hours_start': quietHoursStart,
-        'quiet_hours_end': quietHoursEnd,
-        'timezone': timezone,
-      };
+    'email_notifications': emailNotifications,
+    'whatsapp_notifications': whatsappNotifications,
+    // Write both keys so the prefs round-trip whether or not the backend
+    // has shipped `message_notifications` yet.
+    'message_notifications': messagesEnabled,
+    'messages_enabled': messagesEnabled,
+    'applications_enabled': applicationsEnabled,
+    'collaborations_enabled': collaborationsEnabled,
+    'rewards_enabled': rewardsEnabled,
+    'marketing_enabled': marketingEnabled,
+    'quiet_hours_start': quietHoursStart,
+    'quiet_hours_end': quietHoursEnd,
+    'timezone': timezone,
+  };
 
   NotificationPreferences copyWith({
     bool? emailNotifications,
@@ -85,19 +86,16 @@ class NotificationPreferences {
     String? quietHoursStart,
     String? quietHoursEnd,
     String? timezone,
-  }) =>
-      NotificationPreferences(
-        emailNotifications: emailNotifications ?? this.emailNotifications,
-        whatsappNotifications:
-            whatsappNotifications ?? this.whatsappNotifications,
-        messagesEnabled: messagesEnabled ?? this.messagesEnabled,
-        applicationsEnabled: applicationsEnabled ?? this.applicationsEnabled,
-        collaborationsEnabled:
-            collaborationsEnabled ?? this.collaborationsEnabled,
-        rewardsEnabled: rewardsEnabled ?? this.rewardsEnabled,
-        marketingEnabled: marketingEnabled ?? this.marketingEnabled,
-        quietHoursStart: quietHoursStart ?? this.quietHoursStart,
-        quietHoursEnd: quietHoursEnd ?? this.quietHoursEnd,
-        timezone: timezone ?? this.timezone,
-      );
+  }) => NotificationPreferences(
+    emailNotifications: emailNotifications ?? this.emailNotifications,
+    whatsappNotifications: whatsappNotifications ?? this.whatsappNotifications,
+    messagesEnabled: messagesEnabled ?? this.messagesEnabled,
+    applicationsEnabled: applicationsEnabled ?? this.applicationsEnabled,
+    collaborationsEnabled: collaborationsEnabled ?? this.collaborationsEnabled,
+    rewardsEnabled: rewardsEnabled ?? this.rewardsEnabled,
+    marketingEnabled: marketingEnabled ?? this.marketingEnabled,
+    quietHoursStart: quietHoursStart ?? this.quietHoursStart,
+    quietHoursEnd: quietHoursEnd ?? this.quietHoursEnd,
+    timezone: timezone ?? this.timezone,
+  );
 }

--- a/lib/features/chat/models/chat_message.dart
+++ b/lib/features/chat/models/chat_message.dart
@@ -7,23 +7,23 @@ class ChatSender {
   });
 
   factory ChatSender.fromJson(Map<String, dynamic> json) => ChatSender(
-        // Tolerate ProfileSummaryResource (`id`) and a flat `profile_id`.
-        profileId: (json['profile_id'] ?? json['id']) as String? ?? '',
-        // ProfileSummaryResource exposes the name as `display_name`; tolerate a
-        // flat `name` too. Reading only `name` left the sender label blank.
-        name: (json['display_name'] ?? json['name'])?.toString() ?? '',
-        avatarUrl: (json['avatar_url'] ?? json['profile_photo'])?.toString(),
-      );
+    // Tolerate ProfileSummaryResource (`id`) and a flat `profile_id`.
+    profileId: (json['profile_id'] ?? json['id']) as String? ?? '',
+    // ProfileSummaryResource exposes the name as `display_name`; tolerate a
+    // flat `name` too. Reading only `name` left the sender label blank.
+    name: (json['display_name'] ?? json['name'])?.toString() ?? '',
+    avatarUrl: (json['avatar_url'] ?? json['profile_photo'])?.toString(),
+  );
 
   final String profileId;
   final String name;
   final String? avatarUrl;
 
   Map<String, dynamic> toJson() => {
-        'profile_id': profileId,
-        'name': name,
-        if (avatarUrl != null) 'avatar_url': avatarUrl,
-      };
+    'profile_id': profileId,
+    'name': name,
+    if (avatarUrl != null) 'avatar_url': avatarUrl,
+  };
 }
 
 /// A single message in a chat thread.
@@ -38,19 +38,20 @@ class ChatMessage {
   });
 
   factory ChatMessage.fromJson(Map<String, dynamic> json) => ChatMessage(
-        id: json['id'] as String,
-        // thread_id (generic) or application_id (existing collaboration resource).
-        threadId: (json['thread_id'] ?? json['application_id']) as String? ?? '',
-        // sender_profile (ChatMessageResource) or a flat sender.
-        sender: ChatSender.fromJson(
-            (json['sender_profile'] ?? json['sender'] ?? const <String, dynamic>{})
-                as Map<String, dynamic>),
-        // content (ChatMessageResource) or body.
-        body: (json['content'] ?? json['body']) as String? ?? '',
-        createdAt: DateTime.parse(json['created_at'] as String),
-        // is_own (ChatMessageResource) or is_mine.
-        isMine: (json['is_own'] ?? json['is_mine']) as bool? ?? false,
-      );
+    id: json['id'] as String,
+    // thread_id (generic) or application_id (existing collaboration resource).
+    threadId: (json['thread_id'] ?? json['application_id']) as String? ?? '',
+    // sender_profile (ChatMessageResource) or a flat sender.
+    sender: ChatSender.fromJson(
+      (json['sender_profile'] ?? json['sender'] ?? const <String, dynamic>{})
+          as Map<String, dynamic>,
+    ),
+    // content (ChatMessageResource) or body.
+    body: (json['content'] ?? json['body']) as String? ?? '',
+    createdAt: DateTime.parse(json['created_at'] as String),
+    // is_own (ChatMessageResource) or is_mine.
+    isMine: (json['is_own'] ?? json['is_mine']) as bool? ?? false,
+  );
 
   final String id;
   final String threadId;
@@ -62,13 +63,13 @@ class ChatMessage {
   final bool isMine;
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'thread_id': threadId,
-        'sender': sender.toJson(),
-        'body': body,
-        'created_at': createdAt.toIso8601String(),
-        'is_mine': isMine,
-      };
+    'id': id,
+    'thread_id': threadId,
+    'sender': sender.toJson(),
+    'body': body,
+    'created_at': createdAt.toIso8601String(),
+    'is_mine': isMine,
+  };
 
   ChatMessage copyWith({
     String? id,
@@ -77,13 +78,12 @@ class ChatMessage {
     String? body,
     DateTime? createdAt,
     bool? isMine,
-  }) =>
-      ChatMessage(
-        id: id ?? this.id,
-        threadId: threadId ?? this.threadId,
-        sender: sender ?? this.sender,
-        body: body ?? this.body,
-        createdAt: createdAt ?? this.createdAt,
-        isMine: isMine ?? this.isMine,
-      );
+  }) => ChatMessage(
+    id: id ?? this.id,
+    threadId: threadId ?? this.threadId,
+    sender: sender ?? this.sender,
+    body: body ?? this.body,
+    createdAt: createdAt ?? this.createdAt,
+    isMine: isMine ?? this.isMine,
+  );
 }

--- a/lib/features/chat/models/chat_thread.dart
+++ b/lib/features/chat/models/chat_thread.dart
@@ -69,10 +69,10 @@ class ChatParticipant {
   final String? avatarUrl;
 
   Map<String, dynamic> toJson() => {
-        'name': name,
-        if (profileId != null) 'profile_id': profileId,
-        if (avatarUrl != null) 'avatar_url': avatarUrl,
-      };
+    'name': name,
+    if (profileId != null) 'profile_id': profileId,
+    if (avatarUrl != null) 'avatar_url': avatarUrl,
+  };
 }
 
 /// A minimal event summary attached to an [ChatThreadType.event] thread, so the
@@ -94,10 +94,10 @@ class ChatThreadEvent {
   final DateTime? date;
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        if (name != null) 'name': name,
-        if (date != null) 'date': date!.toIso8601String(),
-      };
+    'id': id,
+    if (name != null) 'name': name,
+    if (date != null) 'date': date!.toIso8601String(),
+  };
 }
 
 /// A chat thread (conversation). One of [communityId] / [collaborationId] is
@@ -132,7 +132,9 @@ class ChatThread {
     final eventJson = json['event'];
     return ChatThread(
       id: json['id'] as String,
-      type: ChatThreadType.fromString(json['type'] as String? ?? 'community_custom'),
+      type: ChatThreadType.fromString(
+        json['type'] as String? ?? 'community_custom',
+      ),
       name: json['name'] as String?,
       slug: json['slug'] as String?,
       applicationId: json['application_id'] as String?,
@@ -150,7 +152,8 @@ class ChatThread {
           ? DateTime.parse(json['last_message_at'] as String)
           : null,
       lastMessagePreview:
-          (json['last_message'] as Map<String, dynamic>?)?['content'] as String?,
+          (json['last_message'] as Map<String, dynamic>?)?['content']
+              as String?,
       unreadCount: json['unread_count'] as int? ?? 0,
       participants: parts,
       createdAt: DateTime.parse(json['created_at'] as String),
@@ -217,27 +220,27 @@ class ChatThread {
   bool get canJoin => isOpen && !isParticipant;
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'type': type.toApiValue(),
-        if (name != null) 'name': name,
-        if (slug != null) 'slug': slug,
-        if (applicationId != null) 'application_id': applicationId,
-        if (communityId != null) 'community_id': communityId,
-        if (collaborationId != null) 'collaboration_id': collaborationId,
-        if (eventId != null) 'event_id': eventId,
-        if (event != null) 'event': event!.toJson(),
-        'is_open': isOpen,
-        'can_manage': canManage,
-        'is_member': isMember,
-        'is_participant': isParticipant,
-        if (lastMessageAt != null)
-          'last_message_at': lastMessageAt!.toIso8601String(),
-        if (lastMessagePreview != null)
-          'last_message': {'content': lastMessagePreview},
-        'unread_count': unreadCount,
-        'participant_summary': participants.map((p) => p.toJson()).toList(),
-        'created_at': createdAt.toIso8601String(),
-      };
+    'id': id,
+    'type': type.toApiValue(),
+    if (name != null) 'name': name,
+    if (slug != null) 'slug': slug,
+    if (applicationId != null) 'application_id': applicationId,
+    if (communityId != null) 'community_id': communityId,
+    if (collaborationId != null) 'collaboration_id': collaborationId,
+    if (eventId != null) 'event_id': eventId,
+    if (event != null) 'event': event!.toJson(),
+    'is_open': isOpen,
+    'can_manage': canManage,
+    'is_member': isMember,
+    'is_participant': isParticipant,
+    if (lastMessageAt != null)
+      'last_message_at': lastMessageAt!.toIso8601String(),
+    if (lastMessagePreview != null)
+      'last_message': {'content': lastMessagePreview},
+    'unread_count': unreadCount,
+    'participant_summary': participants.map((p) => p.toJson()).toList(),
+    'created_at': createdAt.toIso8601String(),
+  };
 
   ChatThread copyWith({
     String? id,
@@ -258,25 +261,24 @@ class ChatThread {
     int? unreadCount,
     List<ChatParticipant>? participants,
     DateTime? createdAt,
-  }) =>
-      ChatThread(
-        id: id ?? this.id,
-        type: type ?? this.type,
-        name: name ?? this.name,
-        slug: slug ?? this.slug,
-        applicationId: applicationId ?? this.applicationId,
-        communityId: communityId ?? this.communityId,
-        collaborationId: collaborationId ?? this.collaborationId,
-        eventId: eventId ?? this.eventId,
-        event: event ?? this.event,
-        isOpen: isOpen ?? this.isOpen,
-        canManage: canManage ?? this.canManage,
-        isMember: isMember ?? this.isMember,
-        isParticipant: isParticipant ?? this.isParticipant,
-        lastMessageAt: lastMessageAt ?? this.lastMessageAt,
-        lastMessagePreview: lastMessagePreview ?? this.lastMessagePreview,
-        unreadCount: unreadCount ?? this.unreadCount,
-        participants: participants ?? this.participants,
-        createdAt: createdAt ?? this.createdAt,
-      );
+  }) => ChatThread(
+    id: id ?? this.id,
+    type: type ?? this.type,
+    name: name ?? this.name,
+    slug: slug ?? this.slug,
+    applicationId: applicationId ?? this.applicationId,
+    communityId: communityId ?? this.communityId,
+    collaborationId: collaborationId ?? this.collaborationId,
+    eventId: eventId ?? this.eventId,
+    event: event ?? this.event,
+    isOpen: isOpen ?? this.isOpen,
+    canManage: canManage ?? this.canManage,
+    isMember: isMember ?? this.isMember,
+    isParticipant: isParticipant ?? this.isParticipant,
+    lastMessageAt: lastMessageAt ?? this.lastMessageAt,
+    lastMessagePreview: lastMessagePreview ?? this.lastMessagePreview,
+    unreadCount: unreadCount ?? this.unreadCount,
+    participants: participants ?? this.participants,
+    createdAt: createdAt ?? this.createdAt,
+  );
 }

--- a/lib/features/chat/providers/chat_providers.dart
+++ b/lib/features/chat/providers/chat_providers.dart
@@ -25,13 +25,15 @@ class ChatThreadsNotifier extends Notifier<AsyncValue<List<ChatThread>>> {
   Future<void> reload() async {
     state = const AsyncLoading();
     state = await AsyncValue.guard(
-        () => ref.read(chatServiceProvider).getThreads());
+      () => ref.read(chatServiceProvider).getThreads(),
+    );
   }
 }
 
 final chatThreadsProvider =
     NotifierProvider<ChatThreadsNotifier, AsyncValue<List<ChatThread>>>(
-        ChatThreadsNotifier.new);
+      ChatThreadsNotifier.new,
+    );
 
 /// Total unread message count — feeds the app-bar inbox badge.
 class ChatUnreadNotifier extends Notifier<int> {
@@ -50,5 +52,6 @@ class ChatUnreadNotifier extends Notifier<int> {
   }
 }
 
-final chatUnreadProvider =
-    NotifierProvider<ChatUnreadNotifier, int>(ChatUnreadNotifier.new);
+final chatUnreadProvider = NotifierProvider<ChatUnreadNotifier, int>(
+  ChatUnreadNotifier.new,
+);

--- a/lib/features/chat/services/chat_service.dart
+++ b/lib/features/chat/services/chat_service.dart
@@ -33,11 +33,9 @@ class ChatException implements Exception {
 /// docs/tickets/2026-06-04-chat-feature-spec.md. Built tolerant since the
 /// backend is still forming; envelopes/nesting are handled defensively.
 class ChatService {
-  ChatService({
-    required AuthService authService,
-    http.Client? httpClient,
-  })  : _authService = authService,
-        _httpClient = httpClient ?? http.Client();
+  ChatService({required AuthService authService, http.Client? httpClient})
+    : _authService = authService,
+      _httpClient = httpClient ?? http.Client();
 
   final AuthService _authService;
   final http.Client _httpClient;
@@ -91,42 +89,41 @@ class ChatService {
   /// `GET /chats` — threads visible to the viewer (backend role-scopes them;
   /// business is pre-filtered to active threads).
   Future<List<ChatThread>> getThreads() => _guard(() async {
-        final res = await _httpClient.get(
-          Uri.parse('$_baseUrl/chats'),
-          headers: await _headers(),
-        );
-        return _list(_unwrap(res), 'threads').map(ChatThread.fromJson).toList();
-      }, 'getThreads');
+    final res = await _httpClient.get(
+      Uri.parse('$_baseUrl/chats'),
+      headers: await _headers(),
+    );
+    return _list(_unwrap(res), 'threads').map(ChatThread.fromJson).toList();
+  }, 'getThreads');
 
   /// `GET /chats/unread-count` — total unread across visible threads.
   Future<int> getUnreadCount() => _guard(() async {
-        final res = await _httpClient.get(
-          Uri.parse('$_baseUrl/chats/unread-count'),
-          headers: await _headers(),
-        );
-        final data = _unwrap(res);
-        if (data is int) return data;
-        // Backend returns { total: N }; keep count/unread as tolerant fallbacks.
-        if (data is Map) {
-          return (data['total'] ?? data['count'] ?? data['unread'] ?? 0) as int;
-        }
-        return 0;
-      }, 'getUnreadCount');
+    final res = await _httpClient.get(
+      Uri.parse('$_baseUrl/chats/unread-count'),
+      headers: await _headers(),
+    );
+    final data = _unwrap(res);
+    if (data is int) return data;
+    // Backend returns { total: N }; keep count/unread as tolerant fallbacks.
+    if (data is Map) {
+      return (data['total'] ?? data['count'] ?? data['unread'] ?? 0) as int;
+    }
+    return 0;
+  }, 'getUnreadCount');
 
   /// `POST /communities/{community}/chats` — create a custom community chat
   /// (≤5 cap → `chat_limit_reached`).
   Future<ChatThread> createCommunityChat(
     String communityId, {
     required String name,
-  }) =>
-      _guard(() async {
-        final res = await _httpClient.post(
-          Uri.parse('$_baseUrl/communities/$communityId/chats'),
-          headers: await _headers(),
-          body: jsonEncode({'name': name}),
-        );
-        return ChatThread.fromJson(_unwrap(res) as Map<String, dynamic>);
-      }, 'createCommunityChat');
+  }) => _guard(() async {
+    final res = await _httpClient.post(
+      Uri.parse('$_baseUrl/communities/$communityId/chats'),
+      headers: await _headers(),
+      body: jsonEncode({'name': name}),
+    );
+    return ChatThread.fromJson(_unwrap(res) as Map<String, dynamic>);
+  }, 'createCommunityChat');
 
   /// `PATCH /chats/{thread}` — rename a custom community chat (manager only).
   /// Slug is preserved server-side so tier grants stay valid.
@@ -142,21 +139,21 @@ class ChatService {
 
   /// `DELETE /chats/{thread}` — delete a custom community chat (manager only).
   Future<void> deleteCommunityChat(String threadId) => _guard(() async {
-        final res = await _httpClient.delete(
-          Uri.parse('$_baseUrl/chats/$threadId'),
-          headers: await _headers(),
-        );
-        _unwrap(res);
-      }, 'deleteCommunityChat');
+    final res = await _httpClient.delete(
+      Uri.parse('$_baseUrl/chats/$threadId'),
+      headers: await _headers(),
+    );
+    _unwrap(res);
+  }, 'deleteCommunityChat');
 
   /// `GET /chats/{thread}/bans` — profile ids blocked from this chat (manager).
   Future<List<String>> getChatBans(String threadId) => _guard(() async {
-        final res = await _httpClient.get(
-          Uri.parse('$_baseUrl/chats/$threadId/bans'),
-          headers: await _headers(),
-        );
-        return _bannedIds(_unwrap(res));
-      }, 'getChatBans');
+    final res = await _httpClient.get(
+      Uri.parse('$_baseUrl/chats/$threadId/bans'),
+      headers: await _headers(),
+    );
+    return _bannedIds(_unwrap(res));
+  }, 'getChatBans');
 
   /// `POST /chats/{thread}/bans` — block a member (manager). Returns banned ids.
   Future<List<String>> blockChatMember(String threadId, String profileId) =>
@@ -199,21 +196,21 @@ class ChatService {
   /// `POST /chats/{thread}/join` — self-join an open chat (active member, not
   /// banned). Returns the refreshed thread.
   Future<ChatThread> joinThread(String threadId) => _guard(() async {
-        final res = await _httpClient.post(
-          Uri.parse('$_baseUrl/chats/$threadId/join'),
-          headers: await _headers(),
-        );
-        return ChatThread.fromJson(_unwrap(res) as Map<String, dynamic>);
-      }, 'joinThread');
+    final res = await _httpClient.post(
+      Uri.parse('$_baseUrl/chats/$threadId/join'),
+      headers: await _headers(),
+    );
+    return ChatThread.fromJson(_unwrap(res) as Map<String, dynamic>);
+  }, 'joinThread');
 
   /// `POST /chats/{thread}/read` — mark the viewer's read pointer.
   Future<void> markRead(String threadId) => _guard(() async {
-        final res = await _httpClient.post(
-          Uri.parse('$_baseUrl/chats/$threadId/read'),
-          headers: await _headers(),
-        );
-        _unwrap(res);
-      }, 'markRead');
+    final res = await _httpClient.post(
+      Uri.parse('$_baseUrl/chats/$threadId/read'),
+      headers: await _headers(),
+    );
+    _unwrap(res);
+  }, 'markRead');
 
   // ---------------------------------------------------------------------------
   // Messages
@@ -226,9 +223,10 @@ class ChatService {
           Uri.parse('$_baseUrl/chats/$threadId/messages?page=$page'),
           headers: await _headers(),
         );
-        return _list(_unwrap(res), 'messages')
-            .map(ChatMessage.fromJson)
-            .toList();
+        return _list(
+          _unwrap(res),
+          'messages',
+        ).map(ChatMessage.fromJson).toList();
       }, 'getMessages');
 
   /// `POST /chats/{thread}/messages` — send a message. The backend field is

--- a/lib/features/chat/services/realtime_chat_service.dart
+++ b/lib/features/chat/services/realtime_chat_service.dart
@@ -61,14 +61,13 @@ class RealtimeChatService {
       final channel = client.privateChannel(
         channelName,
         authorizationDelegate:
-            EndpointAuthorizableChannelTokenAuthorizationDelegate
-                .forPrivateChannel(
-          authorizationEndpoint: Uri.parse(RealtimeConfig.authEndpoint),
-          headers: {
-            'Authorization': 'Bearer $token',
-            'Accept': 'application/json',
-          },
-        ),
+            EndpointAuthorizableChannelTokenAuthorizationDelegate.forPrivateChannel(
+              authorizationEndpoint: Uri.parse(RealtimeConfig.authEndpoint),
+              headers: {
+                'Authorization': 'Bearer $token',
+                'Accept': 'application/json',
+              },
+            ),
       );
 
       final eventSubs = <StreamSubscription<ChannelReadEvent>>[
@@ -90,7 +89,9 @@ class RealtimeChatService {
         }
         try {
           channel.unsubscribe();
-        } on Object catch (_) {/* best-effort */}
+        } on Object catch (_) {
+          /* best-effort */
+        }
         _channels.remove(channelName);
         if (_channels.isEmpty) {
           await _teardownClient();
@@ -136,7 +137,9 @@ class RealtimeChatService {
     _connectionSub = null;
     try {
       _client?.dispose();
-    } on Object catch (_) {/* best-effort */}
+    } on Object catch (_) {
+      /* best-effort */
+    }
     _client = null;
   }
 

--- a/lib/features/chat/widgets/chat_management.dart
+++ b/lib/features/chat/widgets/chat_management.dart
@@ -175,7 +175,8 @@ class ChatManagement {
   }
 
   static void _snack(BuildContext context, String message) {
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
   }
 }

--- a/lib/features/collaboration/models/collaboration.dart
+++ b/lib/features/collaboration/models/collaboration.dart
@@ -279,7 +279,8 @@ class Collaboration {
           : true,
       ownFeedbackSubmitted: json['own_feedback'] != null,
       partnerFeedbackSubmitted: json['partner_feedback'] != null,
-      pendingFeedbackFrom: (json['pending_feedback_from'] as List<dynamic>?)
+      pendingFeedbackFrom:
+          (json['pending_feedback_from'] as List<dynamic>?)
               ?.map((e) => e.toString())
               .toList() ??
           const [],
@@ -289,17 +290,17 @@ class Collaboration {
       // owes a confirmation, so the Confirm CTA never disappears.
       viewerMustConfirmCompletion:
           json.containsKey('viewer_must_confirm_completion')
-              ? _parseBool(json['viewer_must_confirm_completion'])
-              : true,
+          ? _parseBool(json['viewer_must_confirm_completion'])
+          : true,
       ownCompletionStatus:
           (json['own_completion'] as Map<String, dynamic>?)?['status']
               as String?,
       partnerCompletionStatus: json['partner_completion_status'] as String?,
       pendingCompletionFrom:
           (json['pending_completion_from'] as List<dynamic>?)
-                  ?.map((e) => e.toString())
-                  .toList() ??
-              const [],
+              ?.map((e) => e.toString())
+              .toList() ??
+          const [],
     );
   }
 

--- a/lib/features/collaboration/providers/collaborations_list_provider.dart
+++ b/lib/features/collaboration/providers/collaborations_list_provider.dart
@@ -77,7 +77,11 @@ Future<List<Collaboration>> _fetchCollaborations({
 
   if (response.statusCode == 401 && allowRetry) {
     await authService.refreshSession();
-    return _fetchCollaborations(allowRetry: false, authService: authService, perPage: perPage);
+    return _fetchCollaborations(
+      allowRetry: false,
+      authService: authService,
+      perPage: perPage,
+    );
   }
 
   final body = response.body.isEmpty
@@ -105,28 +109,32 @@ final collaborationsListProvider = FutureProvider<List<Collaboration>>(
 final activeCollaborationsProvider = Provider<AsyncValue<List<Collaboration>>>((
   ref,
 ) {
-  return ref.watch(collaborationsListProvider).whenData(
-    (all) => all
-        .where(
-          (c) =>
-              c.status == CollaborationStatus.scheduled ||
-              c.status == CollaborationStatus.inProgress ||
-              c.status == CollaborationStatus.pendingConfirmation,
-        )
-        .toList(),
-  );
+  return ref
+      .watch(collaborationsListProvider)
+      .whenData(
+        (all) => all
+            .where(
+              (c) =>
+                  c.status == CollaborationStatus.scheduled ||
+                  c.status == CollaborationStatus.inProgress ||
+                  c.status == CollaborationStatus.pendingConfirmation,
+            )
+            .toList(),
+      );
 });
 
 /// Finished = completed or cancelled collaborations.
 final finishedCollaborationsProvider =
     Provider<AsyncValue<List<Collaboration>>>((ref) {
-      return ref.watch(collaborationsListProvider).whenData(
-        (all) => all
-            .where(
-              (c) =>
-                  c.status == CollaborationStatus.completed ||
-                  c.status == CollaborationStatus.cancelled,
-            )
-            .toList(),
-      );
+      return ref
+          .watch(collaborationsListProvider)
+          .whenData(
+            (all) => all
+                .where(
+                  (c) =>
+                      c.status == CollaborationStatus.completed ||
+                      c.status == CollaborationStatus.cancelled,
+                )
+                .toList(),
+          );
     });

--- a/lib/features/community/providers/community_media_provider.dart
+++ b/lib/features/community/providers/community_media_provider.dart
@@ -66,8 +66,9 @@ final communityPhotosProvider =
     });
 
 /// The single photo the cover band should paint, if any.
-final communityCoverPhotoProvider =
-    Provider.family<String?, CommunityMediaKey>((ref, key) {
-      final photos = ref.watch(communityPhotosProvider(key));
-      return photos.isEmpty ? null : photos.first.url;
-    });
+final communityCoverPhotoProvider = Provider.family<String?, CommunityMediaKey>(
+  (ref, key) {
+    final photos = ref.watch(communityPhotosProvider(key));
+    return photos.isEmpty ? null : photos.first.url;
+  },
+);

--- a/lib/features/dashboard/widgets/dashboard_stat_card.dart
+++ b/lib/features/dashboard/widgets/dashboard_stat_card.dart
@@ -16,7 +16,9 @@ extension _StatCardAccentColors on StatCardAccent {
   Color circleFill(BuildContext context) {
     switch (this) {
       case StatCardAccent.pending:
-        return context.colors.surfaceContainerHigh; // warm neutral (was lavender)
+        return context
+            .colors
+            .surfaceContainerHigh; // warm neutral (was lavender)
       case StatCardAccent.accepted:
         return context.colors.softYellow; // soft yellow (was sage green)
       case StatCardAccent.active:
@@ -74,74 +76,74 @@ class DashboardStatCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Container(
-      padding: const EdgeInsets.all(KolabingSpacing.lg),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: KolabingRadius.borderRadiusXl,
-        border: Border.all(color: context.colors.hairline),
-        boxShadow: const [KolabingShadows.card],
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          // Label
+    padding: const EdgeInsets.all(KolabingSpacing.lg),
+    decoration: BoxDecoration(
+      color: Colors.white,
+      borderRadius: KolabingRadius.borderRadiusXl,
+      border: Border.all(color: context.colors.hairline),
+      boxShadow: const [KolabingShadows.card],
+    ),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // Label
+        Text(
+          title.toUpperCase(),
+          style: KolabingTextStyles.labelSmall.copyWith(
+            color: context.colors.textTertiary,
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        const SizedBox(height: KolabingSpacing.sm),
+
+        // Count + icon circle row
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text(
+              count.toString(),
+              style: KolabingTextStyles.displaySmall.copyWith(
+                fontSize: 38,
+                fontWeight: FontWeight.w600,
+                letterSpacing: -0.5,
+                color: context.colors.onSurface,
+              ),
+            ),
+            Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                color: accent.circleFill(context),
+                shape: BoxShape.circle,
+              ),
+              child: Center(
+                child: iconSlug != null
+                    ? UiIcon(
+                        icon: iconSlug!,
+                        size: 20,
+                        color: accent.iconColor(context),
+                      )
+                    : Icon(icon, size: 20, color: accent.iconColor(context)),
+              ),
+            ),
+          ],
+        ),
+
+        if (subtitle != null) ...[
+          const SizedBox(height: KolabingSpacing.xxs),
           Text(
-            title.toUpperCase(),
-            style: KolabingTextStyles.labelSmall.copyWith(
-              color: context.colors.textTertiary,
+            subtitle!,
+            style: KolabingTextStyles.captionSecondary.copyWith(
+              color: context.colors.onSurfaceVariant,
             ),
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
           ),
-          const SizedBox(height: KolabingSpacing.sm),
-
-          // Count + icon circle row
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Text(
-                count.toString(),
-                style: KolabingTextStyles.displaySmall.copyWith(
-                  fontSize: 38,
-                  fontWeight: FontWeight.w600,
-                  letterSpacing: -0.5,
-                  color: context.colors.onSurface,
-                ),
-              ),
-              Container(
-                width: 40,
-                height: 40,
-                decoration: BoxDecoration(
-                  color: accent.circleFill(context),
-                  shape: BoxShape.circle,
-                ),
-                child: Center(
-                  child: iconSlug != null
-                      ? UiIcon(
-                          icon: iconSlug!,
-                          size: 20,
-                          color: accent.iconColor(context),
-                        )
-                      : Icon(icon, size: 20, color: accent.iconColor(context)),
-                ),
-              ),
-            ],
-          ),
-
-          if (subtitle != null) ...[
-            const SizedBox(height: KolabingSpacing.xxs),
-            Text(
-              subtitle!,
-              style: KolabingTextStyles.captionSecondary.copyWith(
-                color: context.colors.onSurfaceVariant,
-              ),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ],
         ],
-      ),
-    );
+      ],
+    ),
+  );
 }

--- a/lib/features/dashboard/widgets/upcoming_collaboration_card.dart
+++ b/lib/features/dashboard/widgets/upcoming_collaboration_card.dart
@@ -48,50 +48,52 @@ class UpcomingCollaborationCard extends StatelessWidget {
 
   Widget _content(BuildContext context, bool isDark) {
     return Row(
-          children: [
-            // Partner avatar
-            _PartnerAvatar(partner: collaboration.partner),
-            const SizedBox(width: KolabingSpacing.sm),
+      children: [
+        // Partner avatar
+        _PartnerAvatar(partner: collaboration.partner),
+        const SizedBox(width: KolabingSpacing.sm),
 
-            // Details column
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // Partner name
-                  Text(
-                    collaboration.partner.name ?? 'Unknown Partner',
-                    style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w600, color: isDark
-                          ? context.colors.textOnDark
-                          : context.colors.onSurface),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  const SizedBox(height: KolabingSpacing.xxxs),
-
-                  // Opportunity title
-                  Text(
-                    collaboration.opportunity.title,
-                    style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  const SizedBox(height: KolabingSpacing.xs),
-
-                  // Date chip
-                  _DateChip(
-                    dateText: collaboration.dateDisplay,
-                    isDark: isDark,
-                  ),
-                ],
+        // Details column
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Partner name
+              Text(
+                collaboration.partner.name ?? 'Unknown Partner',
+                style: KolabingTextStyles.bodySmall.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: isDark
+                      ? context.colors.textOnDark
+                      : context.colors.onSurface,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
               ),
-            ),
-            const SizedBox(width: KolabingSpacing.xs),
+              const SizedBox(height: KolabingSpacing.xxxs),
 
-            // Status badge
-            _StatusBadge(status: collaboration.status),
-          ],
-        );
+              // Opportunity title
+              Text(
+                collaboration.opportunity.title,
+                style: KolabingTextStyles.captionSecondary.copyWith(
+                  color: context.colors.onSurfaceVariant,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: KolabingSpacing.xs),
+
+              // Date chip
+              _DateChip(dateText: collaboration.dateDisplay, isDark: isDark),
+            ],
+          ),
+        ),
+        const SizedBox(width: KolabingSpacing.xs),
+
+        // Status badge
+        _StatusBadge(status: collaboration.status),
+      ],
+    );
   }
 }
 
@@ -113,7 +115,10 @@ class _PartnerAvatar extends StatelessWidget {
       alignment: Alignment.center,
       child: Text(
         partner.initial,
-        style: KolabingTextStyles.bodyMedium.copyWith(fontWeight: FontWeight.w600, color: context.colors.onPrimary),
+        style: KolabingTextStyles.bodyMedium.copyWith(
+          fontWeight: FontWeight.w600,
+          color: context.colors.onPrimary,
+        ),
       ),
     );
   }
@@ -141,7 +146,9 @@ class _DateChip extends StatelessWidget {
       ),
       child: Text(
         dateText,
-        style: KolabingTextStyles.labelSmall.copyWith(color: context.colors.onSurfaceVariant),
+        style: KolabingTextStyles.labelSmall.copyWith(
+          color: context.colors.onSurfaceVariant,
+        ),
       ),
     );
   }
@@ -173,7 +180,9 @@ class _StatusBadge extends StatelessWidget {
         style: KolabingTextStyles.labelSmall.copyWith(
           fontSize: 10,
           fontWeight: FontWeight.w700,
-          color: isActive ? context.colors.charcoal : context.colors.categoryOrangeText,
+          color: isActive
+              ? context.colors.charcoal
+              : context.colors.categoryOrangeText,
           letterSpacing: 0.5,
         ),
       ),

--- a/lib/features/dashboard/widgets/xp_missions_section.dart
+++ b/lib/features/dashboard/widgets/xp_missions_section.dart
@@ -115,11 +115,11 @@ enum _MissionAccent {
   red;
 
   Color resolve(KolabingColorTokens c) => switch (this) {
-        _MissionAccent.mint => c.categoryMintBg,
-        _MissionAccent.amber => c.amberChipContainer,
-        _MissionAccent.lavender => c.categoryLavenderBg,
-        _MissionAccent.red => c.categoryRedBg,
-      };
+    _MissionAccent.mint => c.categoryMintBg,
+    _MissionAccent.amber => c.amberChipContainer,
+    _MissionAccent.lavender => c.categoryLavenderBg,
+    _MissionAccent.red => c.categoryRedBg,
+  };
 }
 
 class _MissionData {

--- a/lib/features/discovery/widgets/discovery_quick_filters.dart
+++ b/lib/features/discovery/widgets/discovery_quick_filters.dart
@@ -166,7 +166,10 @@ class DiscoveryQuickFilters extends StatelessWidget {
     final chips = isCommunityViewer
         ? <_QuickChipData>[
             _QuickChipData(
-              label: _singleValue(filters.city, fallback: l10n.discoveryQuickFilterCity),
+              label: _singleValue(
+                filters.city,
+                fallback: l10n.discoveryQuickFilterCity,
+              ),
               isActive: filters.city != null,
             ),
             _QuickChipData(
@@ -186,13 +189,19 @@ class DiscoveryQuickFilters extends StatelessWidget {
               isActive: filters.offerTypes.isNotEmpty,
             ),
             _QuickChipData(
-              label: _availabilityLabel(filters.availabilityMode, l10n.discoveryQuickFilterAvailability),
+              label: _availabilityLabel(
+                filters.availabilityMode,
+                l10n.discoveryQuickFilterAvailability,
+              ),
               isActive: filters.availabilityMode != null,
             ),
           ]
         : <_QuickChipData>[
             _QuickChipData(
-              label: _singleValue(filters.city, fallback: l10n.discoveryQuickFilterCity),
+              label: _singleValue(
+                filters.city,
+                fallback: l10n.discoveryQuickFilterCity,
+              ),
               isActive: filters.city != null,
             ),
             _QuickChipData(
@@ -275,17 +284,14 @@ class _QuickChip extends StatelessWidget {
     onTap: onTap,
     child: AnimatedContainer(
       duration: const Duration(milliseconds: 180),
-      padding: const EdgeInsets.symmetric(
-        horizontal: 12,
-        vertical: 6,
-      ),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       decoration: BoxDecoration(
-        color: data.isActive
-            ? context.colors.softYellow
-            : Colors.white,
+        color: data.isActive ? context.colors.softYellow : Colors.white,
         borderRadius: BorderRadius.circular(KolabingRadius.round),
         border: Border.all(
-          color: data.isActive ? context.colors.softYellowBorder : context.colors.hairline,
+          color: data.isActive
+              ? context.colors.softYellowBorder
+              : context.colors.hairline,
         ),
       ),
       child: Row(
@@ -293,7 +299,11 @@ class _QuickChip extends StatelessWidget {
         children: [
           Text(
             data.label,
-            style: KolabingTextStyles.button.copyWith(fontSize: 13, fontWeight: FontWeight.w500, color: context.colors.onSurface),
+            style: KolabingTextStyles.button.copyWith(
+              fontSize: 13,
+              fontWeight: FontWeight.w500,
+              color: context.colors.onSurface,
+            ),
           ),
           const SizedBox(width: 6),
           Icon(

--- a/lib/features/event/models/event_signup.dart
+++ b/lib/features/event/models/event_signup.dart
@@ -15,8 +15,9 @@ class EventSignup {
 
   factory EventSignup.fromJson(Map<String, dynamic> json) {
     final profile = json['profile'];
-    final profileMap =
-        profile is Map<String, dynamic> ? profile : const <String, dynamic>{};
+    final profileMap = profile is Map<String, dynamic>
+        ? profile
+        : const <String, dynamic>{};
     return EventSignup(
       id: (json['id'] ?? '').toString(),
       profileId: (json['profile_id'] ?? profileMap['id'] ?? '').toString(),
@@ -51,10 +52,7 @@ class EventSignups {
             .whereType<Map<String, dynamic>>()
             .map(EventSignup.fromJson)
             .toList();
-    return EventSignups(
-      going: parse('going'),
-      waitlist: parse('waitlist'),
-    );
+    return EventSignups(going: parse('going'), waitlist: parse('waitlist'));
   }
 
   final List<EventSignup> going;

--- a/lib/features/event/providers/event_provider.dart
+++ b/lib/features/event/providers/event_provider.dart
@@ -41,20 +41,20 @@ class EventsState {
     int? currentPage,
     bool? hasMore,
     int? totalCount,
-  }) =>
-      EventsState(
-        events: events ?? this.events,
-        isLoading: isLoading ?? this.isLoading,
-        isLoadingMore: isLoadingMore ?? this.isLoadingMore,
-        error: error,
-        currentPage: currentPage ?? this.currentPage,
-        hasMore: hasMore ?? this.hasMore,
-        totalCount: totalCount ?? this.totalCount,
-      );
+  }) => EventsState(
+    events: events ?? this.events,
+    isLoading: isLoading ?? this.isLoading,
+    isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+    error: error,
+    currentPage: currentPage ?? this.currentPage,
+    hasMore: hasMore ?? this.hasMore,
+    totalCount: totalCount ?? this.totalCount,
+  );
 }
 
 /// Notifier for managing events state
-class EventsNotifier extends Notifier<EventsState> with AuthScopeGuard<EventsState> {
+class EventsNotifier extends Notifier<EventsState>
+    with AuthScopeGuard<EventsState> {
   late final EventService _service;
   int _activeRequestGeneration = 0;
 
@@ -101,10 +101,7 @@ class EventsNotifier extends Notifier<EventsState> with AuthScopeGuard<EventsSta
     state = state.copyWith(isLoading: true, error: null);
 
     try {
-      final result = await _service.getEvents(
-        page: 1,
-        profileId: profileId,
-      );
+      final result = await _service.getEvents(page: 1, profileId: profileId);
       if (requestGeneration != _activeRequestGeneration) {
         return;
       }
@@ -119,34 +116,22 @@ class EventsNotifier extends Notifier<EventsState> with AuthScopeGuard<EventsSta
       if (requestGeneration != _activeRequestGeneration) {
         return;
       }
-      state = state.copyWith(
-        isLoading: false,
-        error: e.message,
-      );
+      state = state.copyWith(isLoading: false, error: e.message);
     } on ApiException catch (e) {
       if (requestGeneration != _activeRequestGeneration) {
         return;
       }
-      state = state.copyWith(
-        isLoading: false,
-        error: e.error.message,
-      );
+      state = state.copyWith(isLoading: false, error: e.error.message);
     } on NetworkException catch (e) {
       if (requestGeneration != _activeRequestGeneration) {
         return;
       }
-      state = state.copyWith(
-        isLoading: false,
-        error: e.message,
-      );
+      state = state.copyWith(isLoading: false, error: e.message);
     } catch (e) {
       if (requestGeneration != _activeRequestGeneration) {
         return;
       }
-      state = state.copyWith(
-        isLoading: false,
-        error: e.toString(),
-      );
+      state = state.copyWith(isLoading: false, error: e.toString());
     }
   }
 
@@ -184,10 +169,7 @@ class EventsNotifier extends Notifier<EventsState> with AuthScopeGuard<EventsSta
       if (requestGeneration != _activeRequestGeneration) {
         return;
       }
-      state = state.copyWith(
-        isLoadingMore: false,
-        error: e.toString(),
-      );
+      state = state.copyWith(isLoadingMore: false, error: e.toString());
     }
   }
 
@@ -208,10 +190,7 @@ class EventsNotifier extends Notifier<EventsState> with AuthScopeGuard<EventsSta
     );
 
     try {
-      final result = await _service.getEvents(
-        page: 1,
-        profileId: profileId,
-      );
+      final result = await _service.getEvents(page: 1, profileId: profileId);
       if (requestGeneration != _activeRequestGeneration) {
         return;
       }
@@ -226,10 +205,7 @@ class EventsNotifier extends Notifier<EventsState> with AuthScopeGuard<EventsSta
       if (requestGeneration != _activeRequestGeneration) {
         return;
       }
-      state = state.copyWith(
-        isLoading: false,
-        error: e.toString(),
-      );
+      state = state.copyWith(isLoading: false, error: e.toString());
     }
   }
 
@@ -238,10 +214,7 @@ class EventsNotifier extends Notifier<EventsState> with AuthScopeGuard<EventsSta
     try {
       final newEvent = await _service.createEvent(request);
       final updated = [newEvent, ...state.events];
-      state = state.copyWith(
-        events: updated,
-        totalCount: updated.length,
-      );
+      state = state.copyWith(events: updated, totalCount: updated.length);
       return true;
     } catch (e) {
       state = state.copyWith(error: e.toString());
@@ -254,10 +227,7 @@ class EventsNotifier extends Notifier<EventsState> with AuthScopeGuard<EventsSta
     try {
       await _service.deleteEvent(eventId);
       final updated = state.events.where((e) => e.id != eventId).toList();
-      state = state.copyWith(
-        events: updated,
-        totalCount: updated.length,
-      );
+      state = state.copyWith(events: updated, totalCount: updated.length);
       return true;
     } catch (e) {
       state = state.copyWith(error: e.toString());
@@ -272,18 +242,23 @@ class EventsNotifier extends Notifier<EventsState> with AuthScopeGuard<EventsSta
 }
 
 /// Provider for events state (current user's events)
-final eventsProvider =
-    NotifierProvider<EventsNotifier, EventsState>(EventsNotifier.new);
+final eventsProvider = NotifierProvider<EventsNotifier, EventsState>(
+  EventsNotifier.new,
+);
 
-final eventDetailProvider =
-    FutureProvider.family<Event, String>((ref, eventId) async {
+final eventDetailProvider = FutureProvider.family<Event, String>((
+  ref,
+  eventId,
+) async {
   final service = ref.watch(eventServiceProvider);
   return service.getEvent(eventId);
 });
 
 /// Provider for loading another user's events by profile ID (read-only)
-final profileEventsProvider =
-    FutureProvider.family<List<Event>, String>((ref, profileId) async {
+final profileEventsProvider = FutureProvider.family<List<Event>, String>((
+  ref,
+  profileId,
+) async {
   final service = ref.watch(eventServiceProvider);
   final result = await service.getEvents(profileId: profileId);
   return result.events;
@@ -311,19 +286,20 @@ class CommunityUpcomingEventsNotifier
   Future<void> reload() async {
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final result = await ref.read(eventServiceProvider).getEvents(
-            communityId: communityId,
-            time: 'upcoming',
-          );
+      final result = await ref
+          .read(eventServiceProvider)
+          .getEvents(communityId: communityId, time: 'upcoming');
       return result.events;
     });
   }
 }
 
-final communityUpcomingEventsProvider = NotifierProvider.family<
-    CommunityUpcomingEventsNotifier, AsyncValue<List<Event>>, String>(
-  CommunityUpcomingEventsNotifier.new,
-);
+final communityUpcomingEventsProvider =
+    NotifierProvider.family<
+      CommunityUpcomingEventsNotifier,
+      AsyncValue<List<Event>>,
+      String
+    >(CommunityUpcomingEventsNotifier.new);
 
 /// A community's PAST events (`GET /events?community_id&time=past`), used by the
 /// community Details tab to show the gallery + past-events showcase. Mirrors
@@ -342,19 +318,20 @@ class CommunityPastEventsNotifier extends Notifier<AsyncValue<List<Event>>> {
   Future<void> reload() async {
     state = const AsyncValue.loading();
     state = await AsyncValue.guard(() async {
-      final result = await ref.read(eventServiceProvider).getEvents(
-            communityId: communityId,
-            time: 'past',
-          );
+      final result = await ref
+          .read(eventServiceProvider)
+          .getEvents(communityId: communityId, time: 'past');
       return result.events;
     });
   }
 }
 
-final communityPastEventsProvider = NotifierProvider.family<
-    CommunityPastEventsNotifier, AsyncValue<List<Event>>, String>(
-  CommunityPastEventsNotifier.new,
-);
+final communityPastEventsProvider =
+    NotifierProvider.family<
+      CommunityPastEventsNotifier,
+      AsyncValue<List<Event>>,
+      String
+    >(CommunityPastEventsNotifier.new);
 
 /// An event's attendee roster (`GET /events/{id}/signups`, leader-scoped).
 ///
@@ -375,9 +352,14 @@ class EventSignupsNotifier extends Notifier<AsyncValue<EventSignups>> {
   Future<void> reload() async {
     state = const AsyncLoading();
     state = await AsyncValue.guard(
-        () => ref.read(eventServiceProvider).getSignups(eventId));
+      () => ref.read(eventServiceProvider).getSignups(eventId),
+    );
   }
 }
 
-final eventSignupsProvider = NotifierProvider.family<EventSignupsNotifier,
-    AsyncValue<EventSignups>, String>(EventSignupsNotifier.new);
+final eventSignupsProvider =
+    NotifierProvider.family<
+      EventSignupsNotifier,
+      AsyncValue<EventSignups>,
+      String
+    >(EventSignupsNotifier.new);

--- a/lib/features/event/screens/create_event_screen.dart
+++ b/lib/features/event/screens/create_event_screen.dart
@@ -128,7 +128,8 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
       if (e.capacity != null) _capacity.text = e.capacity.toString();
       // Seed visibility from the existing event (#1). Older events without a
       // value default to members.
-      _visibility = (e.visibility == 'public' ||
+      _visibility =
+          (e.visibility == 'public' ||
               e.visibility == 'members' ||
               e.visibility == 'tier')
           ? e.visibility!
@@ -166,8 +167,9 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
     if (date == null || !mounted) return null;
     final time = await showTimePicker(
       context: context,
-      initialTime:
-          TimeOfDay.fromDateTime(initial ?? now.add(const Duration(hours: 1))),
+      initialTime: TimeOfDay.fromDateTime(
+        initial ?? now.add(const Duration(hours: 1)),
+      ),
     );
     if (time == null) return null;
     return DateTime(date.year, date.month, date.day, time.hour, time.minute);
@@ -220,8 +222,12 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
     // Gallery caps: up to [kEventGalleryMaxPerAdd] per add, [kEventGalleryMaxTotal]
     // total across existing + device + community-gallery photos.
     if (_totalPhotoCount >= kEventGalleryMaxTotal) {
-      _snack(_l10n.eventPhotosTotalCapReached(
-          _totalPhotoCount, kEventGalleryMaxTotal));
+      _snack(
+        _l10n.eventPhotosTotalCapReached(
+          _totalPhotoCount,
+          kEventGalleryMaxTotal,
+        ),
+      );
       return;
     }
     final picked = await ImagePicker().pickMultiImage(
@@ -236,7 +242,9 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
     }
     final remaining = kEventGalleryMaxTotal - _totalPhotoCount;
     if (toAdd.length > remaining) {
-      _snack(_l10n.eventPhotosTotalCapPartial(remaining, kEventGalleryMaxTotal));
+      _snack(
+        _l10n.eventPhotosTotalCapPartial(remaining, kEventGalleryMaxTotal),
+      );
       toAdd = toAdd.take(remaining).toList();
     }
     if (toAdd.isEmpty) return;
@@ -249,8 +257,12 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
   Future<void> _pickFromCommunityGallery(List<EventPhoto> gallery) async {
     final remaining = kEventGalleryMaxTotal - _totalPhotoCount;
     if (remaining <= 0) {
-      _snack(_l10n.eventPhotosTotalCapReached(
-          _totalPhotoCount, kEventGalleryMaxTotal));
+      _snack(
+        _l10n.eventPhotosTotalCapReached(
+          _totalPhotoCount,
+          kEventGalleryMaxTotal,
+        ),
+      );
       return;
     }
     final selected = await showModalBottomSheet<Map<String, String>>(
@@ -335,8 +347,7 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
         'chat_mode': _chatMode,
         'ends_mode': _endsMode,
         if (_endsMode == 'count') 'ends_count': endsCount,
-        if (_endsMode == 'until')
-          'ends_on': _endsOn!.toUtc().toIso8601String(),
+        if (_endsMode == 'until') 'ends_on': _endsOn!.toUtc().toIso8601String(),
       };
     }
 
@@ -424,7 +435,9 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
     return Scaffold(
       backgroundColor: context.colors.background,
       appBar: AppBar(
-        title: Text(_isEdit ? _l10n.eventFormEditTitle : _l10n.eventFormNewTitle),
+        title: Text(
+          _isEdit ? _l10n.eventFormEditTitle : _l10n.eventFormNewTitle,
+        ),
         actions: [
           TextButton(
             onPressed: _busy ? null : _submit,
@@ -435,9 +448,12 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
       body: ListView(
         padding: const EdgeInsets.all(KolabingSpacing.md),
         children: [
-          Text(widget.communityName,
-              style: KolabingTextStyles.bodySmall
-                  .copyWith(color: context.colors.onSurfaceVariant)),
+          Text(
+            widget.communityName,
+            style: KolabingTextStyles.bodySmall.copyWith(
+              color: context.colors.onSurfaceVariant,
+            ),
+          ),
           const SizedBox(height: KolabingSpacing.md),
           _label(_l10n.eventFormNameLabel),
           TextField(
@@ -460,8 +476,9 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
           _DateField(
             value: _endsAt,
             hint: _l10n.eventFormPickEnd,
-            onClear:
-                _endsAt == null ? null : () => setState(() => _endsAt = null),
+            onClear: _endsAt == null
+                ? null
+                : () => setState(() => _endsAt = null),
             onTap: () async {
               final picked = await _pickDateTime(_endsAt ?? _startsAt);
               if (picked != null) setState(() => _endsAt = picked);
@@ -488,9 +505,12 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
               decoration: _dec('30'),
             )
           else
-            Text(_l10n.eventHubUnlimited,
-                style: KolabingTextStyles.bodySmall
-                    .copyWith(color: context.colors.onSurfaceVariant)),
+            Text(
+              _l10n.eventHubUnlimited,
+              style: KolabingTextStyles.bodySmall.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+            ),
           const SizedBox(height: KolabingSpacing.lg),
           _label(_l10n.eventFormVisibilityLabel),
           _visibilityPicker(tiersAsync),
@@ -521,17 +541,22 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
                   ? const SizedBox(
                       width: 18,
                       height: 18,
-                      child: CircularProgressIndicator(strokeWidth: 2))
-                  : Icon(_isEdit ? LucideIcons.check : LucideIcons.calendarPlus,
-                      size: 18),
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Icon(
+                      _isEdit ? LucideIcons.check : LucideIcons.calendarPlus,
+                      size: 18,
+                    ),
               label: Text(
-                  _isEdit
-                      ? _l10n.eventFormSave
-                      : (_isRecurring
+                _isEdit
+                    ? _l10n.eventFormSave
+                    : (_isRecurring
                           ? _l10n.eventFormPublishSeries
                           : _l10n.eventFormPublish),
-                  style: KolabingTextStyles.bodyMedium
-                      .copyWith(fontWeight: FontWeight.w700)),
+                style: KolabingTextStyles.bodyMedium.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
             ),
           ),
         ],
@@ -549,9 +574,12 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
           groupValue: _visibility,
           onChanged: (v) => setState(() => _visibility = v ?? 'members'),
           title: Text(_l10n.eventFormVisibilityPublic),
-          subtitle: Text(_l10n.eventFormVisibilityPublicHint,
-              style: KolabingTextStyles.bodySmall
-                  .copyWith(color: KolabingColors.onSurfaceVariant)),
+          subtitle: Text(
+            _l10n.eventFormVisibilityPublicHint,
+            style: KolabingTextStyles.bodySmall.copyWith(
+              color: KolabingColors.onSurfaceVariant,
+            ),
+          ),
         ),
         RadioListTile<String>(
           contentPadding: EdgeInsets.zero,
@@ -559,9 +587,12 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
           groupValue: _visibility,
           onChanged: (v) => setState(() => _visibility = v ?? 'members'),
           title: Text(_l10n.eventFormVisibilityMembers),
-          subtitle: Text(_l10n.eventFormVisibilityMembersHint,
-              style: KolabingTextStyles.bodySmall
-                  .copyWith(color: KolabingColors.onSurfaceVariant)),
+          subtitle: Text(
+            _l10n.eventFormVisibilityMembersHint,
+            style: KolabingTextStyles.bodySmall.copyWith(
+              color: KolabingColors.onSurfaceVariant,
+            ),
+          ),
         ),
         RadioListTile<String>(
           contentPadding: EdgeInsets.zero,
@@ -569,9 +600,12 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
           groupValue: _visibility,
           onChanged: (v) => setState(() => _visibility = v ?? 'members'),
           title: Text(_l10n.eventFormVisibilityTier),
-          subtitle: Text(_l10n.eventFormVisibilityTierHint,
-              style: KolabingTextStyles.bodySmall
-                  .copyWith(color: KolabingColors.onSurfaceVariant)),
+          subtitle: Text(
+            _l10n.eventFormVisibilityTierHint,
+            style: KolabingTextStyles.bodySmall.copyWith(
+              color: KolabingColors.onSurfaceVariant,
+            ),
+          ),
         ),
         if (_visibility == 'tier')
           tiersAsync.when(
@@ -699,8 +733,10 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
                   ),
                 ),
                 const SizedBox(width: KolabingSpacing.sm),
-                Text(_l10n.eventFormRepeatEvents,
-                    style: KolabingTextStyles.bodyMedium),
+                Text(
+                  _l10n.eventFormRepeatEvents,
+                  style: KolabingTextStyles.bodyMedium,
+                ),
               ],
             ),
           ],
@@ -709,13 +745,15 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
             _DateField(
               value: _endsOn,
               hint: _l10n.eventFormRepeatOnDate,
-              onClear:
-                  _endsOn == null ? null : () => setState(() => _endsOn = null),
+              onClear: _endsOn == null
+                  ? null
+                  : () => setState(() => _endsOn = null),
               onTap: () async {
                 final now = DateTime.now();
                 final picked = await showDatePicker(
                   context: context,
-                  initialDate: _endsOn ??
+                  initialDate:
+                      _endsOn ??
                       (_startsAt ?? now).add(const Duration(days: 28)),
                   firstDate: _startsAt ?? now,
                   lastDate: now.add(const Duration(days: 365 * 2)),
@@ -748,7 +786,9 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
   Widget _photosPicker() {
     // The community's existing gallery = the union of its past events' photos.
     // Self-gated: only offer "Choose from community gallery" when some exist.
-    final pastEvents = ref.watch(communityPastEventsProvider(widget.communityId));
+    final pastEvents = ref.watch(
+      communityPastEventsProvider(widget.communityId),
+    );
     final galleryPhotos = pastEvents.maybeWhen(
       data: (events) {
         final seen = <String>{};
@@ -773,19 +813,24 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
         OutlinedButton.icon(
           onPressed: _busy ? null : _pickPhotos,
           icon: const Icon(LucideIcons.imagePlus, size: 18),
-          label: Text(_pickedPhotos.isEmpty
-              ? _l10n.eventFormAddFromGallery
-              : '${_l10n.eventFormAddFromGallery} (${_pickedPhotos.length})'),
+          label: Text(
+            _pickedPhotos.isEmpty
+                ? _l10n.eventFormAddFromGallery
+                : '${_l10n.eventFormAddFromGallery} (${_pickedPhotos.length})',
+          ),
         ),
         if (galleryPhotos.isNotEmpty) ...[
           const SizedBox(height: KolabingSpacing.sm),
           OutlinedButton.icon(
-            onPressed:
-                _busy ? null : () => _pickFromCommunityGallery(galleryPhotos),
+            onPressed: _busy
+                ? null
+                : () => _pickFromCommunityGallery(galleryPhotos),
             icon: const Icon(LucideIcons.image, size: 18),
-            label: Text(_pickedGalleryPhotos.isEmpty
-                ? _l10n.eventFormAddFromCommunity
-                : '${_l10n.eventFormAddFromCommunity} (${_pickedGalleryPhotos.length})'),
+            label: Text(
+              _pickedGalleryPhotos.isEmpty
+                  ? _l10n.eventFormAddFromCommunity
+                  : '${_l10n.eventFormAddFromCommunity} (${_pickedGalleryPhotos.length})',
+            ),
           ),
         ],
         if (_pickedPhotos.isNotEmpty || _pickedGalleryPhotos.isNotEmpty) ...[
@@ -820,8 +865,9 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
                         fit: BoxFit.cover,
                         errorBuilder: (_, __, ___) => _thumbFallback(),
                       ),
-                      onRemove: () =>
-                          setState(() => _pickedGalleryPhotos.remove(entry.key)),
+                      onRemove: () => setState(
+                        () => _pickedGalleryPhotos.remove(entry.key),
+                      ),
                     ),
                   ),
               ],
@@ -833,25 +879,25 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
   }
 
   Widget _photoThumb(Widget image, {required VoidCallback onRemove}) => Stack(
-        children: [
-          ClipRRect(borderRadius: BorderRadius.circular(8), child: image),
-          Positioned(
-            top: -8,
-            right: -8,
-            child: IconButton(
-              icon: const Icon(LucideIcons.x, size: 16),
-              onPressed: onRemove,
-            ),
-          ),
-        ],
-      );
+    children: [
+      ClipRRect(borderRadius: BorderRadius.circular(8), child: image),
+      Positioned(
+        top: -8,
+        right: -8,
+        child: IconButton(
+          icon: const Icon(LucideIcons.x, size: 16),
+          onPressed: onRemove,
+        ),
+      ),
+    ],
+  );
 
   Widget _thumbFallback() => Container(
-        width: 72,
-        height: 72,
-        color: KolabingColors.surfaceVariant,
-        child: const Icon(LucideIcons.image, color: KolabingColors.textTertiary),
-      );
+    width: 72,
+    height: 72,
+    color: KolabingColors.surfaceVariant,
+    child: const Icon(LucideIcons.image, color: KolabingColors.textTertiary),
+  );
 
   /// Google Places autocomplete location field (NF-20). Mirrors the business
   /// onboarding step-5 UX: type → suggestions → tap. On select the city is
@@ -881,17 +927,17 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
                     ),
                   )
                 : (_location.text.isNotEmpty
-                    ? IconButton(
-                        icon: const Icon(LucideIcons.x, size: 16),
-                        onPressed: () => setState(() {
-                          _location.clear();
-                          _placeQuery = '';
-                          _placeSelected = false;
-                          _cityId = null;
-                          _cityName = null;
-                        }),
-                      )
-                    : null),
+                      ? IconButton(
+                          icon: const Icon(LucideIcons.x, size: 16),
+                          onPressed: () => setState(() {
+                            _location.clear();
+                            _placeQuery = '';
+                            _placeSelected = false;
+                            _cityId = null;
+                            _cityName = null;
+                          }),
+                        )
+                      : null),
           ),
           onChanged: (v) => setState(() {
             _placeQuery = v;
@@ -938,11 +984,16 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
                       ListTile(
                         dense: true,
                         leading: const Icon(LucideIcons.mapPin, size: 18),
-                        title: Text(place.title,
-                            style: KolabingTextStyles.bodyMedium),
-                        subtitle: Text(place.displaySubtitle,
-                            style: KolabingTextStyles.bodySmall.copyWith(
-                                color: KolabingColors.onSurfaceVariant)),
+                        title: Text(
+                          place.title,
+                          style: KolabingTextStyles.bodyMedium,
+                        ),
+                        subtitle: Text(
+                          place.displaySubtitle,
+                          style: KolabingTextStyles.bodySmall.copyWith(
+                            color: KolabingColors.onSurfaceVariant,
+                          ),
+                        ),
                         onTap: () => _handlePlaceSelected(place),
                       ),
                   ],
@@ -961,29 +1012,35 @@ class _CreateEventScreenState extends ConsumerState<CreateEventScreen> {
   }
 
   Widget _placeHint(String message) => Padding(
-        padding: const EdgeInsets.symmetric(vertical: KolabingSpacing.sm),
-        child: Text(message,
-            style: KolabingTextStyles.bodySmall
-                .copyWith(color: KolabingColors.onSurfaceVariant)),
-      );
+    padding: const EdgeInsets.symmetric(vertical: KolabingSpacing.sm),
+    child: Text(
+      message,
+      style: KolabingTextStyles.bodySmall.copyWith(
+        color: KolabingColors.onSurfaceVariant,
+      ),
+    ),
+  );
 
   Widget _label(String t) => Padding(
-        padding: const EdgeInsets.only(bottom: KolabingSpacing.xs),
-        child: Text(t,
-            style: KolabingTextStyles.bodySmall.copyWith(
-                fontWeight: FontWeight.w700,
-                color: context.colors.onSurfaceVariant)),
-      );
+    padding: const EdgeInsets.only(bottom: KolabingSpacing.xs),
+    child: Text(
+      t,
+      style: KolabingTextStyles.bodySmall.copyWith(
+        fontWeight: FontWeight.w700,
+        color: context.colors.onSurfaceVariant,
+      ),
+    ),
+  );
 
   InputDecoration _dec(String hint) => InputDecoration(
-        hintText: hint,
-        filled: true,
-        fillColor: context.colors.surfaceContainerLow,
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
-          borderSide: BorderSide.none,
-        ),
-      );
+    hintText: hint,
+    filled: true,
+    fillColor: context.colors.surfaceContainerLow,
+    border: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: BorderSide.none,
+    ),
+  );
 }
 
 class _DateField extends StatelessWidget {
@@ -1014,7 +1071,9 @@ class _DateField extends StatelessWidget {
           ),
           suffixIcon: onClear != null
               ? IconButton(
-                  icon: const Icon(LucideIcons.x, size: 16), onPressed: onClear)
+                  icon: const Icon(LucideIcons.x, size: 16),
+                  onPressed: onClear,
+                )
               : const Icon(LucideIcons.calendar, size: 18),
         ),
         child: Text(
@@ -1031,8 +1090,18 @@ class _DateField extends StatelessWidget {
 
   static String _fmt(DateTime d) {
     const months = [
-      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
     ];
     final h = d.hour.toString().padLeft(2, '0');
     final m = d.minute.toString().padLeft(2, '0');
@@ -1112,10 +1181,10 @@ class _CommunityGalleryPickerState extends State<_CommunityGalleryPicker> {
                       ),
                       gridDelegate:
                           const SliverGridDelegateWithFixedCrossAxisCount(
-                        crossAxisCount: 3,
-                        crossAxisSpacing: KolabingSpacing.xs,
-                        mainAxisSpacing: KolabingSpacing.xs,
-                      ),
+                            crossAxisCount: 3,
+                            crossAxisSpacing: KolabingSpacing.xs,
+                            mainAxisSpacing: KolabingSpacing.xs,
+                          ),
                       itemCount: available.length,
                       itemBuilder: (_, i) {
                         final photo = available[i];
@@ -1132,8 +1201,10 @@ class _CommunityGalleryPickerState extends State<_CommunityGalleryPicker> {
                                   fit: BoxFit.cover,
                                   errorBuilder: (_, __, ___) => Container(
                                     color: KolabingColors.surfaceVariant,
-                                    child: const Icon(LucideIcons.image,
-                                        color: KolabingColors.textTertiary),
+                                    child: const Icon(
+                                      LucideIcons.image,
+                                      color: KolabingColors.textTertiary,
+                                    ),
                                   ),
                                 ),
                               ),
@@ -1141,8 +1212,9 @@ class _CommunityGalleryPickerState extends State<_CommunityGalleryPicker> {
                                 DecoratedBox(
                                   decoration: BoxDecoration(
                                     borderRadius: BorderRadius.circular(8),
-                                    color: KolabingColors.primary
-                                        .withValues(alpha: 0.35),
+                                    color: KolabingColors.primary.withValues(
+                                      alpha: 0.35,
+                                    ),
                                     border: Border.all(
                                       color: KolabingColors.primary,
                                       width: 2,
@@ -1152,9 +1224,11 @@ class _CommunityGalleryPickerState extends State<_CommunityGalleryPicker> {
                                     alignment: Alignment.topRight,
                                     child: Padding(
                                       padding: EdgeInsets.all(4),
-                                      child: Icon(LucideIcons.checkCircle2,
-                                          size: 20,
-                                          color: KolabingColors.primaryDark),
+                                      child: Icon(
+                                        LucideIcons.checkCircle2,
+                                        size: 20,
+                                        color: KolabingColors.primaryDark,
+                                      ),
                                     ),
                                   ),
                                 ),
@@ -1188,8 +1262,9 @@ class _CommunityGalleryPickerState extends State<_CommunityGalleryPicker> {
                   ),
                   child: Text(
                     l10n.eventFormCommunityGalleryAdd(_selected.length),
-                    style: KolabingTextStyles.bodyMedium
-                        .copyWith(fontWeight: FontWeight.w700),
+                    style: KolabingTextStyles.bodyMedium.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
                   ),
                 ),
               ),
@@ -1209,8 +1284,12 @@ class _CommunityGalleryPickerState extends State<_CommunityGalleryPicker> {
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(l10n.eventPhotosTotalCapPartial(
-                widget.maxSelectable, kEventGalleryMaxTotal)),
+            content: Text(
+              l10n.eventPhotosTotalCapPartial(
+                widget.maxSelectable,
+                kEventGalleryMaxTotal,
+              ),
+            ),
           ),
         );
       }

--- a/lib/features/event/widgets/event_card.dart
+++ b/lib/features/event/widgets/event_card.dart
@@ -47,7 +47,8 @@ class EventCard extends StatelessWidget {
                     ? Image.network(
                         event.coverPhotoUrl!,
                         fit: BoxFit.cover,
-                        errorBuilder: (_, __, ___) => _buildPlaceholder(context),
+                        errorBuilder: (_, __, ___) =>
+                            _buildPlaceholder(context),
                       )
                     : _buildPlaceholder(context),
               ),

--- a/lib/features/event/widgets/past_events_section.dart
+++ b/lib/features/event/widgets/past_events_section.dart
@@ -114,10 +114,11 @@ class PastEventsSection extends ConsumerWidget {
   // Shared container
   // ---------------------------------------------------------------------------
 
-  Widget _buildContainer(
-      {required BuildContext context,
-      required bool isDark,
-      required Widget child}) {
+  Widget _buildContainer({
+    required BuildContext context,
+    required bool isDark,
+    required Widget child,
+  }) {
     return Container(
       padding: const EdgeInsets.all(KolabingSpacing.md),
       decoration: BoxDecoration(
@@ -142,20 +143,21 @@ class PastEventsSection extends ConsumerWidget {
   // ---------------------------------------------------------------------------
 
   Widget _buildHeader(
-      BuildContext context, WidgetRef ref, List<Event> events, bool isDark) {
+    BuildContext context,
+    WidgetRef ref,
+    List<Event> events,
+    bool isDark,
+  ) {
     return Row(
       children: [
-        Icon(
-          LucideIcons.calendar,
-          size: 20,
-          color: context.colors.primary,
-        ),
+        Icon(LucideIcons.calendar, size: 20, color: context.colors.primary),
         const SizedBox(width: KolabingSpacing.xs),
         Text(
           AppLocalizations.of(context).pastEventsTitle,
           style: KolabingTextStyles.titleMedium.copyWith(
-            color:
-                isDark ? context.colors.textOnDark : context.colors.onSurface,
+            color: isDark
+                ? context.colors.textOnDark
+                : context.colors.onSurface,
           ),
         ),
         if (events.isNotEmpty) ...[
@@ -204,7 +206,11 @@ class PastEventsSection extends ConsumerWidget {
   // ---------------------------------------------------------------------------
 
   Widget _buildOwnContent(
-      BuildContext context, WidgetRef ref, EventsState state, bool isDark) {
+    BuildContext context,
+    WidgetRef ref,
+    EventsState state,
+    bool isDark,
+  ) {
     if (state.isLoading) {
       return _buildLoadingState(context, isDark);
     }
@@ -235,8 +241,9 @@ class PastEventsSection extends ConsumerWidget {
           baseColor: isDark
               ? context.colors.darkSurface
               : context.colors.surfaceVariant,
-          highlightColor:
-              isDark ? context.colors.darkBorder : context.colors.surface,
+          highlightColor: isDark
+              ? context.colors.darkBorder
+              : context.colors.surface,
           child: Container(
             width: 180,
             decoration: BoxDecoration(
@@ -250,17 +257,17 @@ class PastEventsSection extends ConsumerWidget {
   }
 
   Widget _buildErrorState(
-      BuildContext context, WidgetRef ref, String error, bool isDark) {
+    BuildContext context,
+    WidgetRef ref,
+    String error,
+    bool isDark,
+  ) {
     return Container(
       padding: const EdgeInsets.all(KolabingSpacing.lg),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(
-            LucideIcons.alertCircle,
-            size: 32,
-            color: context.colors.error,
-          ),
+          Icon(LucideIcons.alertCircle, size: 32, color: context.colors.error),
           const SizedBox(height: KolabingSpacing.sm),
           Text(
             AppLocalizations.of(context).pastEventsLoadError,
@@ -330,7 +337,9 @@ class PastEventsSection extends ConsumerWidget {
             icon: const Icon(LucideIcons.plus, size: 16),
             label: Text(
               AppLocalizations.of(context).pastEventsEmptyAddButton,
-              style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w600),
+              style: KolabingTextStyles.bodySmall.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
             ),
             style: TextButton.styleFrom(
               foregroundColor: context.colors.onSurfaceVariant,

--- a/lib/features/friends/models/friendship.dart
+++ b/lib/features/friends/models/friendship.dart
@@ -54,24 +54,24 @@ class FriendSummary {
   });
 
   factory FriendSummary.fromJson(Map<String, dynamic> json) => FriendSummary(
-        // Tolerate both `profile_id` (contract) and a bare `id` fallback.
-        profileId:
-            (json['profile_id'] ?? json['id'])?.toString() ?? '',
-        name: json['name'] as String? ?? '',
-        avatarUrl: _firstNonEmpty([
-          json['avatar_url'] as String?,
-          json['logo_url'] as String?,
-          json['profile_photo'] as String?,
-        ]),
-        userType: json['user_type'] as String? ?? '',
-      );
+    // Tolerate both `profile_id` (contract) and a bare `id` fallback.
+    profileId: (json['profile_id'] ?? json['id'])?.toString() ?? '',
+    name: json['name'] as String? ?? '',
+    avatarUrl: _firstNonEmpty([
+      json['avatar_url'] as String?,
+      json['logo_url'] as String?,
+      json['profile_photo'] as String?,
+    ]),
+    userType: json['user_type'] as String? ?? '',
+  );
 
   final String profileId;
   final String name;
   final String? avatarUrl;
   final String userType;
 
-  String get initial => name.trim().isNotEmpty ? name.trim()[0].toUpperCase() : '?';
+  String get initial =>
+      name.trim().isNotEmpty ? name.trim()[0].toUpperCase() : '?';
 }
 
 /// Result of `GET /me/friend-requests`: the incoming list plus its count badge.
@@ -79,9 +79,7 @@ class FriendSummary {
 class FriendRequests {
   const FriendRequests({required this.requests, required this.count});
 
-  const FriendRequests.empty()
-      : requests = const [],
-        count = 0;
+  const FriendRequests.empty() : requests = const [], count = 0;
 
   final List<FriendSummary> requests;
   final int count;

--- a/lib/features/friends/providers/friends_provider.dart
+++ b/lib/features/friends/providers/friends_provider.dart
@@ -11,31 +11,31 @@ final friendshipServiceProvider = Provider<FriendshipService>(
 /// Accepted friends (`GET /me/friends`). Self-gates: a 404 (feature not
 /// deployed) resolves to an empty list instead of an error so the screen
 /// shows its empty state rather than crashing.
-final friendsProvider = FutureProvider.autoDispose<List<FriendSummary>>(
-  (ref) async {
-    final service = ref.watch(friendshipServiceProvider);
-    try {
-      return await service.getFriends();
-    } on FriendshipException catch (e) {
-      if (e.isFeatureOff) return const <FriendSummary>[];
-      rethrow;
-    }
-  },
-);
+final friendsProvider = FutureProvider.autoDispose<List<FriendSummary>>((
+  ref,
+) async {
+  final service = ref.watch(friendshipServiceProvider);
+  try {
+    return await service.getFriends();
+  } on FriendshipException catch (e) {
+    if (e.isFeatureOff) return const <FriendSummary>[];
+    rethrow;
+  }
+});
 
 /// Incoming friend requests + count (`GET /me/friend-requests`). Self-gates the
 /// same way: a 404 resolves to [FriendRequests.empty].
-final friendRequestsProvider = FutureProvider.autoDispose<FriendRequests>(
-  (ref) async {
-    final service = ref.watch(friendshipServiceProvider);
-    try {
-      return await service.getFriendRequests();
-    } on FriendshipException catch (e) {
-      if (e.isFeatureOff) return const FriendRequests.empty();
-      rethrow;
-    }
-  },
-);
+final friendRequestsProvider = FutureProvider.autoDispose<FriendRequests>((
+  ref,
+) async {
+  final service = ref.watch(friendshipServiceProvider);
+  try {
+    return await service.getFriendRequests();
+  } on FriendshipException catch (e) {
+    if (e.isFeatureOff) return const FriendRequests.empty();
+    rethrow;
+  }
+});
 
 /// Just the incoming-request count, for the badge. Returns 0 while loading,
 /// on error, or when the feature is off (never throws to the badge widget).

--- a/lib/features/friends/screens/add_friend_screen.dart
+++ b/lib/features/friends/screens/add_friend_screen.dart
@@ -144,10 +144,7 @@ class _AddFriendScreenState extends ConsumerState<AddFriendScreen> {
       );
     }
     if (_result != null) {
-      return _ResultCard(
-        result: _result!,
-        onChanged: () => setState(() {}),
-      );
+      return _ResultCard(result: _result!, onChanged: () => setState(() {}));
     }
     if (!_searched) {
       return const SizedBox.shrink();
@@ -192,8 +189,7 @@ class _ResultCard extends ConsumerStatefulWidget {
 
 class _ResultCardState extends ConsumerState<_ResultCard> {
   bool _busy = false;
-  late FriendStatus _status =
-      widget.result.friendStatus ?? FriendStatus.none;
+  late FriendStatus _status = widget.result.friendStatus ?? FriendStatus.none;
 
   Future<void> _add() async {
     final l10n = AppLocalizations.of(context);
@@ -212,11 +208,15 @@ class _ResultCardState extends ConsumerState<_ResultCard> {
       } else if (e.requestExists) {
         if (mounted) setState(() => _status = FriendStatus.pendingOutgoing);
       } else if (!e.isFeatureOff && mounted) {
-        messenger.showSnackBar(SnackBar(content: Text(l10n.friendActionFailed)));
+        messenger.showSnackBar(
+          SnackBar(content: Text(l10n.friendActionFailed)),
+        );
       }
     } catch (_) {
       if (mounted) {
-        messenger.showSnackBar(SnackBar(content: Text(l10n.friendActionFailed)));
+        messenger.showSnackBar(
+          SnackBar(content: Text(l10n.friendActionFailed)),
+        );
       }
     } finally {
       if (mounted) setState(() => _busy = false);
@@ -275,10 +275,7 @@ class _ResultCardState extends ConsumerState<_ResultCard> {
   Widget _buildCta(AppLocalizations l10n) {
     switch (_status) {
       case FriendStatus.self:
-        return OutlinedButton(
-          onPressed: null,
-          child: Text(l10n.addFriendSelf),
-        );
+        return OutlinedButton(onPressed: null, child: Text(l10n.addFriendSelf));
       case FriendStatus.friends:
         return OutlinedButton.icon(
           onPressed: null,

--- a/lib/features/friends/screens/friends_screen.dart
+++ b/lib/features/friends/screens/friends_screen.dart
@@ -90,9 +90,8 @@ class FriendsScreen extends ConsumerWidget {
                 padding: EdgeInsets.symmetric(vertical: KolabingSpacing.xl),
                 child: Center(child: CircularProgressIndicator()),
               ),
-              error: (error, _) => _FriendsError(
-                onRetry: () => ref.invalidate(friendsProvider),
-              ),
+              error: (error, _) =>
+                  _FriendsError(onRetry: () => ref.invalidate(friendsProvider)),
               data: (friends) {
                 if (friends.isEmpty) return const _FriendsEmpty();
                 return Column(
@@ -274,11 +273,7 @@ class _FriendTile extends StatelessWidget {
 }
 
 class _SectionTitle extends StatelessWidget {
-  const _SectionTitle({
-    required this.icon,
-    required this.title,
-    this.count,
-  });
+  const _SectionTitle({required this.icon, required this.title, this.count});
 
   final IconData icon;
   final String title;
@@ -286,35 +281,35 @@ class _SectionTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Row(
-        children: [
-          Icon(icon, size: 20, color: KolabingColors.primary),
-          const SizedBox(width: KolabingSpacing.xs),
-          Text(
-            title,
-            style: KolabingTextStyles.titleMedium.copyWith(
+    children: [
+      Icon(icon, size: 20, color: KolabingColors.primary),
+      const SizedBox(width: KolabingSpacing.xs),
+      Text(
+        title,
+        style: KolabingTextStyles.titleMedium.copyWith(
+          color: KolabingColors.onSurface,
+        ),
+      ),
+      if (count != null && count! > 0) ...[
+        const SizedBox(width: KolabingSpacing.xs),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+          decoration: BoxDecoration(
+            color: KolabingColors.primary.withValues(alpha: 0.15),
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Text(
+            '$count',
+            style: KolabingTextStyles.labelSmall.copyWith(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
               color: KolabingColors.onSurface,
             ),
           ),
-          if (count != null && count! > 0) ...[
-            const SizedBox(width: KolabingSpacing.xs),
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-              decoration: BoxDecoration(
-                color: KolabingColors.primary.withValues(alpha: 0.15),
-                borderRadius: BorderRadius.circular(10),
-              ),
-              child: Text(
-                '$count',
-                style: KolabingTextStyles.labelSmall.copyWith(
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
-                  color: KolabingColors.onSurface,
-                ),
-              ),
-            ),
-          ],
-        ],
-      );
+        ),
+      ],
+    ],
+  );
 }
 
 class _FriendsEmpty extends StatelessWidget {
@@ -387,11 +382,7 @@ class _FriendsError extends StatelessWidget {
 }
 
 class _Avatar extends StatelessWidget {
-  const _Avatar({
-    required this.initial,
-    required this.size,
-    this.avatarUrl,
-  });
+  const _Avatar({required this.initial, required this.size, this.avatarUrl});
 
   final String? avatarUrl;
   final String initial;
@@ -414,20 +405,20 @@ class _Avatar extends StatelessWidget {
   }
 
   Widget _initialCircle() => Container(
-        width: size,
-        height: size,
-        decoration: BoxDecoration(
-          color: KolabingColors.primary.withValues(alpha: 0.2),
-          shape: BoxShape.circle,
+    width: size,
+    height: size,
+    decoration: BoxDecoration(
+      color: KolabingColors.primary.withValues(alpha: 0.2),
+      shape: BoxShape.circle,
+    ),
+    child: Center(
+      child: Text(
+        initial,
+        style: KolabingTextStyles.bodyMedium.copyWith(
+          fontWeight: FontWeight.w700,
+          color: KolabingColors.onSurface,
         ),
-        child: Center(
-          child: Text(
-            initial,
-            style: KolabingTextStyles.bodyMedium.copyWith(
-              fontWeight: FontWeight.w700,
-              color: KolabingColors.onSurface,
-            ),
-          ),
-        ),
-      );
+      ),
+    ),
+  );
 }

--- a/lib/features/friends/services/friendship_service.dart
+++ b/lib/features/friends/services/friendship_service.dart
@@ -38,11 +38,9 @@ class FriendshipException implements Exception {
 /// [FriendshipException] with [FriendshipException.isFeatureOff] so callers can
 /// silently degrade rather than crash.
 class FriendshipService {
-  FriendshipService({
-    AuthService? authService,
-    http.Client? httpClient,
-  })  : _authService = authService ?? AuthService(),
-        _httpClient = httpClient ?? http.Client();
+  FriendshipService({AuthService? authService, http.Client? httpClient})
+    : _authService = authService ?? AuthService(),
+      _httpClient = httpClient ?? http.Client();
 
   final AuthService _authService;
   final http.Client _httpClient;
@@ -102,40 +100,40 @@ class FriendshipService {
   /// `POST /friends/{profile}` — send a friend request (requester = me). If a
   /// reverse pending exists the backend auto-accepts (mutual).
   Future<void> sendRequest(String profileId) => _guard(() async {
-        final res = await _httpClient.post(
-          Uri.parse('$_baseUrl/friends/$profileId'),
-          headers: await _headers(),
-        );
-        _unwrap(res);
-      }, 'sendRequest');
+    final res = await _httpClient.post(
+      Uri.parse('$_baseUrl/friends/$profileId'),
+      headers: await _headers(),
+    );
+    _unwrap(res);
+  }, 'sendRequest');
 
   /// `POST /friends/{profile}/accept` — accept an incoming pending request.
   Future<void> accept(String profileId) => _guard(() async {
-        final res = await _httpClient.post(
-          Uri.parse('$_baseUrl/friends/$profileId/accept'),
-          headers: await _headers(),
-        );
-        _unwrap(res);
-      }, 'accept');
+    final res = await _httpClient.post(
+      Uri.parse('$_baseUrl/friends/$profileId/accept'),
+      headers: await _headers(),
+    );
+    _unwrap(res);
+  }, 'accept');
 
   /// `POST /friends/{profile}/decline` — decline an incoming pending request.
   Future<void> decline(String profileId) => _guard(() async {
-        final res = await _httpClient.post(
-          Uri.parse('$_baseUrl/friends/$profileId/decline'),
-          headers: await _headers(),
-        );
-        _unwrap(res);
-      }, 'decline');
+    final res = await _httpClient.post(
+      Uri.parse('$_baseUrl/friends/$profileId/decline'),
+      headers: await _headers(),
+    );
+    _unwrap(res);
+  }, 'decline');
 
   /// `DELETE /friends/{profile}` — remove a friend OR cancel my outgoing
   /// request (deletes the row either way).
   Future<void> remove(String profileId) => _guard(() async {
-        final res = await _httpClient.delete(
-          Uri.parse('$_baseUrl/friends/$profileId'),
-          headers: await _headers(),
-        );
-        _unwrap(res);
-      }, 'remove');
+    final res = await _httpClient.delete(
+      Uri.parse('$_baseUrl/friends/$profileId'),
+      headers: await _headers(),
+    );
+    _unwrap(res);
+  }, 'remove');
 
   // ---------------------------------------------------------------------------
   // Reads
@@ -143,29 +141,27 @@ class FriendshipService {
 
   /// `GET /me/friends` — accepted friends (first page).
   Future<List<FriendSummary>> getFriends({int page = 1}) => _guard(() async {
-        final res = await _httpClient.get(
-          Uri.parse('$_baseUrl/me/friends?page=$page'),
-          headers: await _headers(),
-        );
-        return _list(_unwrap(res), 'friends')
-            .map(FriendSummary.fromJson)
-            .toList();
-      }, 'getFriends');
+    final res = await _httpClient.get(
+      Uri.parse('$_baseUrl/me/friends?page=$page'),
+      headers: await _headers(),
+    );
+    return _list(_unwrap(res), 'friends').map(FriendSummary.fromJson).toList();
+  }, 'getFriends');
 
   /// `GET /me/friend-requests` — incoming pending requests + count badge.
   Future<FriendRequests> getFriendRequests() => _guard(() async {
-        final res = await _httpClient.get(
-          Uri.parse('$_baseUrl/me/friend-requests'),
-          headers: await _headers(),
-        );
-        final data = _unwrap(res);
-        final list = _list(data, 'requests').isNotEmpty
-            ? _list(data, 'requests')
-            : _list(data, 'data');
-        final requests = list.map(FriendSummary.fromJson).toList();
-        final count = data is Map
-            ? ((data['count'] as num?)?.toInt() ?? requests.length)
-            : requests.length;
-        return FriendRequests(requests: requests, count: count);
-      }, 'getFriendRequests');
+    final res = await _httpClient.get(
+      Uri.parse('$_baseUrl/me/friend-requests'),
+      headers: await _headers(),
+    );
+    final data = _unwrap(res);
+    final list = _list(data, 'requests').isNotEmpty
+        ? _list(data, 'requests')
+        : _list(data, 'data');
+    final requests = list.map(FriendSummary.fromJson).toList();
+    final count = data is Map
+        ? ((data['count'] as num?)?.toInt() ?? requests.length)
+        : requests.length;
+    return FriendRequests(requests: requests, count: count);
+  }, 'getFriendRequests');
 }

--- a/lib/features/friends/widgets/friend_cta_button.dart
+++ b/lib/features/friends/widgets/friend_cta_button.dart
@@ -195,14 +195,14 @@ class _PrimaryPill extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => _Pill(
-        icon: icon,
-        label: label,
-        busy: busy,
-        onTap: onTap,
-        background: KolabingColors.onSurface,
-        foreground: KolabingColors.primary,
-        border: null,
-      );
+    icon: icon,
+    label: label,
+    busy: busy,
+    onTap: onTap,
+    background: KolabingColors.onSurface,
+    foreground: KolabingColors.primary,
+    border: null,
+  );
 }
 
 class _SecondaryPill extends StatelessWidget {
@@ -220,14 +220,14 @@ class _SecondaryPill extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => _Pill(
-        icon: icon,
-        label: label,
-        busy: busy,
-        onTap: onTap,
-        background: Colors.white.withValues(alpha: 0.9),
-        foreground: KolabingColors.onSurface,
-        border: KolabingColors.onSurface.withValues(alpha: 0.2),
-      );
+    icon: icon,
+    label: label,
+    busy: busy,
+    onTap: onTap,
+    background: Colors.white.withValues(alpha: 0.9),
+    foreground: KolabingColors.onSurface,
+    border: KolabingColors.onSurface.withValues(alpha: 0.2),
+  );
 }
 
 class _Pill extends StatelessWidget {
@@ -251,45 +251,45 @@ class _Pill extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Material(
-        color: Colors.transparent,
-        child: InkWell(
-          borderRadius: KolabingRadius.borderRadiusRound,
-          onTap: busy ? null : onTap,
-          child: Container(
-            padding: const EdgeInsets.symmetric(
-              horizontal: KolabingSpacing.md,
-              vertical: KolabingSpacing.xs,
-            ),
-            decoration: BoxDecoration(
-              color: background,
-              borderRadius: KolabingRadius.borderRadiusRound,
-              border: border != null ? Border.all(color: border!) : null,
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                if (busy)
-                  SizedBox(
-                    width: 14,
-                    height: 14,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      color: foreground,
-                    ),
-                  )
-                else
-                  Icon(icon, size: 16, color: foreground),
-                const SizedBox(width: 6),
-                Text(
-                  label,
-                  style: KolabingTextStyles.bodySmall.copyWith(
-                    fontWeight: FontWeight.w700,
-                    color: foreground,
-                  ),
-                ),
-              ],
-            ),
-          ),
+    color: Colors.transparent,
+    child: InkWell(
+      borderRadius: KolabingRadius.borderRadiusRound,
+      onTap: busy ? null : onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: KolabingSpacing.md,
+          vertical: KolabingSpacing.xs,
         ),
-      );
+        decoration: BoxDecoration(
+          color: background,
+          borderRadius: KolabingRadius.borderRadiusRound,
+          border: border != null ? Border.all(color: border!) : null,
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (busy)
+              SizedBox(
+                width: 14,
+                height: 14,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: foreground,
+                ),
+              )
+            else
+              Icon(icon, size: 16, color: foreground),
+            const SizedBox(width: 6),
+            Text(
+              label,
+              style: KolabingTextStyles.bodySmall.copyWith(
+                fontWeight: FontWeight.w700,
+                color: foreground,
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
 }

--- a/lib/features/gamification/providers/challenge_provider.dart
+++ b/lib/features/gamification/providers/challenge_provider.dart
@@ -271,6 +271,7 @@ Future<Challenge> createChallenge(
   String? description,
   required ChallengeDifficulty difficulty,
   int? points,
+  ChallengeProofType proofType = ChallengeProofType.text,
 }) async {
   final service = ref.read(challengeServiceProvider);
   final challenge = await service.createChallenge(
@@ -279,6 +280,7 @@ Future<Challenge> createChallenge(
     description: description,
     difficulty: difficulty,
     points: points,
+    proofType: proofType,
   );
   // Invalidate the challenges provider to refresh the list
   ref.invalidate(eventChallengesProvider(eventId));
@@ -294,10 +296,12 @@ Future<Challenge> updateChallenge(
   String? description,
   ChallengeDifficulty? difficulty,
   int? points,
+  ChallengeProofType? proofType,
 }) async {
   final service = ref.read(challengeServiceProvider);
   final challenge = await service.updateChallenge(
     challengeId,
+    proofType: proofType,
     name: name,
     description: description,
     difficulty: difficulty,

--- a/lib/features/gamification/screens/create_challenge_screen.dart
+++ b/lib/features/gamification/screens/create_challenge_screen.dart
@@ -15,9 +15,20 @@ import '../providers/challenge_provider.dart';
 
 /// Screen for organizers to create a custom challenge
 class CreateChallengeScreen extends ConsumerStatefulWidget {
-  const CreateChallengeScreen({super.key, required this.eventId});
+  const CreateChallengeScreen({
+    super.key,
+    required this.eventId,
+    this.challenge,
+  });
 
   final String eventId;
+
+  /// When present the screen edits that challenge instead of creating one.
+  /// `EventChallengesScreen` has pushed
+  /// `/events/{id}/challenges/{challengeId}/edit` since it shipped, and that
+  /// route was never registered — tapping a custom challenge as the organizer
+  /// landed on the not-found page (#188).
+  final Challenge? challenge;
 
   @override
   ConsumerState<CreateChallengeScreen> createState() =>
@@ -31,11 +42,26 @@ class _CreateChallengeScreenState extends ConsumerState<CreateChallengeScreen> {
   final _pointsController = TextEditingController();
 
   ChallengeDifficulty _selectedDifficulty = ChallengeDifficulty.medium;
+
+  /// Whether the app opens the camera when the pair agrees.
+  ChallengeProofType _proofType = ChallengeProofType.text;
+
   bool _isLoading = false;
+
+  bool get _isEditing => widget.challenge != null;
 
   @override
   void initState() {
     super.initState();
+    final existing = widget.challenge;
+    if (existing != null) {
+      _nameController.text = existing.name;
+      _descriptionController.text = existing.description ?? '';
+      _selectedDifficulty = existing.difficulty;
+      _proofType = existing.proofType;
+      _pointsController.text = existing.points.toString();
+      return;
+    }
     // Set default points based on difficulty
     _pointsController.text = _selectedDifficulty.defaultPoints.toString();
   }
@@ -57,28 +83,49 @@ class _CreateChallengeScreenState extends ConsumerState<CreateChallengeScreen> {
     });
   }
 
-  Future<void> _handleCreate() async {
+  Future<void> _handleSubmit() async {
     if (!_formKey.currentState!.validate()) return;
 
     setState(() => _isLoading = true);
 
     try {
-      await createChallenge(
-        ref,
-        widget.eventId,
-        name: _nameController.text.trim(),
-        description: _descriptionController.text.trim().isEmpty
-            ? null
-            : _descriptionController.text.trim(),
-        difficulty: _selectedDifficulty,
-        points: int.tryParse(_pointsController.text),
-      );
+      final existing = widget.challenge;
+      final description = _descriptionController.text.trim().isEmpty
+          ? null
+          : _descriptionController.text.trim();
+
+      if (existing == null) {
+        await createChallenge(
+          ref,
+          widget.eventId,
+          name: _nameController.text.trim(),
+          description: description,
+          difficulty: _selectedDifficulty,
+          points: int.tryParse(_pointsController.text),
+          proofType: _proofType,
+        );
+      } else {
+        await updateChallenge(
+          ref,
+          widget.eventId,
+          existing.id,
+          name: _nameController.text.trim(),
+          description: description,
+          difficulty: _selectedDifficulty,
+          points: int.tryParse(_pointsController.text),
+          proofType: _proofType,
+        );
+      }
 
       if (!mounted) return;
 
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text(AppLocalizations.of(context).createChallengeSuccess),
+          content: Text(
+            _isEditing
+                ? AppLocalizations.of(context).createChallengeUpdated
+                : AppLocalizations.of(context).createChallengeSuccess,
+          ),
           backgroundColor: context.colors.success,
           behavior: SnackBarBehavior.floating,
           shape: RoundedRectangleBorder(
@@ -129,7 +176,9 @@ class _CreateChallengeScreenState extends ConsumerState<CreateChallengeScreen> {
           onPressed: () => context.pop(),
         ),
         title: Text(
-          l10n.createChallengeTitle,
+          _isEditing
+              ? l10n.createChallengeEditTitle
+              : l10n.createChallengeTitle,
           style: KolabingTextStyles.bodyMedium.copyWith(
             fontSize: 18,
             fontWeight: FontWeight.w600,
@@ -208,6 +257,28 @@ class _CreateChallengeScreenState extends ConsumerState<CreateChallengeScreen> {
 
                 const SizedBox(height: KolabingSpacing.lg),
 
+                // Camera or not — the backend's proof_type (#188).
+                _FieldLabel(
+                  label: l10n.createChallengeProofTypeLabel,
+                  required: false,
+                ),
+                const SizedBox(height: KolabingSpacing.xs),
+                _ProofTypeSelector(
+                  selected: _proofType,
+                  onChanged: (value) => setState(() => _proofType = value),
+                  enabled: !_isLoading,
+                ),
+                const SizedBox(height: KolabingSpacing.xs),
+                Text(
+                  l10n.createChallengeProofTypeHint,
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    fontSize: 12,
+                    color: context.colors.textTertiary,
+                  ),
+                ),
+
+                const SizedBox(height: KolabingSpacing.lg),
+
                 // Points field
                 _FieldLabel(
                   label: l10n.createChallengePointsLabel,
@@ -268,8 +339,10 @@ class _CreateChallengeScreenState extends ConsumerState<CreateChallengeScreen> {
 
                 // Create button
                 KolabingButton(
-                  label: l10n.createChallengeSubmit,
-                  onPressed: _isLoading ? null : _handleCreate,
+                  label: _isEditing
+                      ? l10n.createChallengeSaveChanges
+                      : l10n.createChallengeSubmit,
+                  onPressed: _isLoading ? null : _handleSubmit,
                   variant: KolabingButtonVariant.primary,
                   isLoading: _isLoading,
                 ),
@@ -352,6 +425,111 @@ class _FieldLabel extends StatelessWidget {
             ),
           ),
       ],
+    );
+  }
+}
+
+/// Camera, or no camera — the backend's `proof_type` (#188, kolabing-v2#216).
+///
+/// Two options rather than a switch, because "off" is a real choice with its own
+/// meaning ("the instruction is the game") and a switch labelled *Camera* leaves
+/// the reader guessing what happens when it is off.
+class _ProofTypeSelector extends StatelessWidget {
+  const _ProofTypeSelector({
+    required this.selected,
+    required this.onChanged,
+    required this.enabled,
+  });
+
+  final ChallengeProofType selected;
+  final ValueChanged<ChallengeProofType> onChanged;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return Row(
+      children: [
+        Expanded(
+          child: _ProofTypeOption(
+            icon: LucideIcons.fileText,
+            label: l10n.createChallengeProofTypeText,
+            isSelected: selected == ChallengeProofType.text,
+            onTap: enabled ? () => onChanged(ChallengeProofType.text) : null,
+          ),
+        ),
+        const SizedBox(width: KolabingSpacing.xs),
+        Expanded(
+          child: _ProofTypeOption(
+            icon: LucideIcons.camera,
+            label: l10n.createChallengeProofTypePhoto,
+            isSelected: selected == ChallengeProofType.photo,
+            onTap: enabled ? () => onChanged(ChallengeProofType.photo) : null,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ProofTypeOption extends StatelessWidget {
+  const _ProofTypeOption({
+    required this.icon,
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final bool isSelected;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedFg = context.colors.onSurface;
+
+    return Material(
+      color: isSelected ? context.colors.primaryTint : Colors.transparent,
+      borderRadius: BorderRadius.circular(KolabingRadius.md),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(KolabingRadius.md),
+        child: Container(
+          padding: const EdgeInsets.symmetric(
+            horizontal: KolabingSpacing.sm,
+            vertical: KolabingSpacing.sm,
+          ),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(KolabingRadius.md),
+            border: Border.all(
+              color: isSelected
+                  ? context.colors.primaryDark
+                  : context.colors.outlineVariant,
+              width: isSelected ? 2 : 1,
+            ),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, size: 16, color: selectedFg),
+              const SizedBox(width: KolabingSpacing.xs),
+              Flexible(
+                child: Text(
+                  label,
+                  maxLines: 2,
+                  textAlign: TextAlign.center,
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    fontWeight: isSelected ? FontWeight.w700 : FontWeight.w500,
+                    color: selectedFg,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/gamification/screens/event_challenges_screen.dart
+++ b/lib/features/gamification/screens/event_challenges_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:lucide_icons/lucide_icons.dart';
 
 import '../../../config/constants/spacing.dart';
+import '../../../config/routes/routes.dart';
 import '../../../config/theme/colors.dart';
 import '../../../config/theme/typography.dart';
 import '../../../l10n/app_localizations.dart';
@@ -174,9 +175,11 @@ class _EventChallengesScreenState extends ConsumerState<EventChallengesScreen>
 
   void _handleChallengeTap(Challenge challenge) {
     if (widget.isOrganizer && challenge.isCustom) {
-      // Organizer can edit custom challenges
+      // Organizer can edit custom challenges. The object rides along in
+      // `extra`: there is no single-challenge endpoint to re-read it from.
       context.push(
-        '/attendee/events/${widget.eventId}/challenges/${challenge.id}/edit',
+        KolabingRoutes.buildEditChallengePath(widget.eventId, challenge.id),
+        extra: challenge,
       );
     } else {
       // Show challenge details / initiate challenge

--- a/lib/features/gamification/services/challenge_service.dart
+++ b/lib/features/gamification/services/challenge_service.dart
@@ -268,6 +268,7 @@ class ChallengeService {
     String? description,
     required ChallengeDifficulty difficulty,
     int? points,
+    ChallengeProofType proofType = ChallengeProofType.text,
   }) async {
     final token = await _authService.getToken();
     if (token == null) {
@@ -284,6 +285,10 @@ class ChallengeService {
           'description': description,
         'difficulty': difficulty.toApiValue(),
         if (points != null) 'points': points,
+        // Whether the app opens the camera when the pair agrees (#188). Always
+        // sent: the API defaults it to `text`, and being explicit means an edit
+        // that turns the camera OFF actually says so.
+        'proof_type': proofType.toApiValue(),
       };
 
       final response = await _httpClient.post(
@@ -332,6 +337,7 @@ class ChallengeService {
     String? description,
     ChallengeDifficulty? difficulty,
     int? points,
+    ChallengeProofType? proofType,
   }) async {
     final token = await _authService.getToken();
     if (token == null) {
@@ -347,6 +353,9 @@ class ChallengeService {
       if (description != null) body['description'] = description;
       if (difficulty != null) body['difficulty'] = difficulty.toApiValue();
       if (points != null) body['points'] = points;
+      // Null means "leave it as it is"; a value means the author chose, which
+      // includes choosing to turn the camera off again (#188).
+      if (proofType != null) body['proof_type'] = proofType.toApiValue();
 
       final response = await _httpClient.put(
         Uri.parse(url),

--- a/lib/features/identity/models/handle_availability.dart
+++ b/lib/features/identity/models/handle_availability.dart
@@ -4,7 +4,10 @@ import 'package:flutter/foundation.dart';
 /// `{ available: bool, suggestions: [..] }`.
 @immutable
 class HandleAvailability {
-  const HandleAvailability({required this.available, this.suggestions = const []});
+  const HandleAvailability({
+    required this.available,
+    this.suggestions = const [],
+  });
 
   factory HandleAvailability.fromJson(Map<String, dynamic> json) =>
       HandleAvailability(

--- a/lib/features/identity/models/profile_lookup_result.dart
+++ b/lib/features/identity/models/profile_lookup_result.dart
@@ -40,7 +40,8 @@ class ProfileLookupResult {
   final String userType;
   final FriendStatus? friendStatus;
 
-  String get initial => name.trim().isNotEmpty ? name.trim()[0].toUpperCase() : '?';
+  String get initial =>
+      name.trim().isNotEmpty ? name.trim()[0].toUpperCase() : '?';
 
   bool get isAttendee => userType == 'attendee';
 }

--- a/lib/features/identity/widgets/handle_field.dart
+++ b/lib/features/identity/widgets/handle_field.dart
@@ -189,7 +189,10 @@ class _HandleFieldState extends ConsumerState<HandleField> {
                     padding: const EdgeInsets.only(right: KolabingSpacing.sm),
                     child: suffix,
                   ),
-            suffixIconConstraints: const BoxConstraints(minWidth: 0, minHeight: 0),
+            suffixIconConstraints: const BoxConstraints(
+              minWidth: 0,
+              minHeight: 0,
+            ),
             filled: true,
             fillColor: KolabingColors.surfaceVariant,
             border: OutlineInputBorder(

--- a/lib/features/kolab/models/kolab.dart
+++ b/lib/features/kolab/models/kolab.dart
@@ -528,8 +528,7 @@ class Kolab {
     if (communityTypes.isNotEmpty) 'community_types': communityTypes,
     if (communitySize != null) 'community_size': communitySize,
     if (typicalAttendance != null) 'typical_attendance': typicalAttendance,
-    if (offersInReturn.isNotEmpty)
-      'offers_in_return': offersInReturn,
+    if (offersInReturn.isNotEmpty) 'offers_in_return': offersInReturn,
     if (venuePreference != null)
       'venue_preference': venuePreference!.toApiValue(),
     if (venueName != null && venueName!.isNotEmpty) 'venue_name': venueName,
@@ -544,8 +543,7 @@ class Kolab {
     if (seekingCommunities.isNotEmpty)
       'seeking_communities': seekingCommunities,
     if (minCommunitySize != null) 'min_community_size': minCommunitySize,
-    if (expects.isNotEmpty)
-      'expects': expects,
+    if (expects.isNotEmpty) 'expects': expects,
     if (pastEvents.isNotEmpty)
       'past_events': pastEvents.map((e) => e.toJson()).toList(),
     if (publishedAt != null) 'published_at': publishedAt!.toIso8601String(),

--- a/lib/features/kolab/providers/offer_option_provider.dart
+++ b/lib/features/kolab/providers/offer_option_provider.dart
@@ -48,9 +48,10 @@ final goalsProvider = FutureProvider.autoDispose<List<OfferOption>>(
 
 /// "Product interaction" options — how communities can engage with a product
 /// promotion. From `GET /lookup/product-interactions`.
-final productInteractionsProvider = FutureProvider.autoDispose<List<OfferOption>>(
-  (ref) => ref.watch(offerOptionServiceProvider).getProductInteractions(),
-);
+final productInteractionsProvider =
+    FutureProvider.autoDispose<List<OfferOption>>(
+      (ref) => ref.watch(offerOptionServiceProvider).getProductInteractions(),
+    );
 
 /// "Venue fit" options — the venue-promotion "Best for:" chips. From
 /// `GET /lookup/venue-fits`.

--- a/lib/features/kolab/screens/business/availability_screen.dart
+++ b/lib/features/kolab/screens/business/availability_screen.dart
@@ -44,8 +44,9 @@ class _AvailabilityScreenState extends ConsumerState<AvailabilityScreen> {
     // mode shows no date picker and defaults to today via
     // KolabFormNotifier.updateAvailabilityMode. Non-immediate modes require
     // tomorrow or later.
-    final firstAllowedDate =
-        DateUtils.dateOnly(DateTime.now()).add(const Duration(days: 1));
+    final firstAllowedDate = DateUtils.dateOnly(
+      DateTime.now(),
+    ).add(const Duration(days: 1));
     final initialStart =
         kolab.availabilityStart != null &&
             !DateUtils.dateOnly(
@@ -106,7 +107,11 @@ class _AvailabilityScreenState extends ConsumerState<AvailabilityScreen> {
         // -- Section header
         Text(
           'AVAILABILITY',
-          style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontWeight: FontWeight.w700,
+            color: context.colors.onSurfaceVariant,
+            letterSpacing: 1.0,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.md),
 
@@ -116,7 +121,10 @@ class _AvailabilityScreenState extends ConsumerState<AvailabilityScreen> {
             padding: const EdgeInsets.only(bottom: KolabingSpacing.xs),
             child: Text(
               errors['availability_mode']!,
-              style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.error),
+              style: KolabingTextStyles.bodySmall.copyWith(
+                fontSize: 12,
+                color: context.colors.error,
+              ),
             ),
           ),
 
@@ -160,7 +168,10 @@ class _AvailabilityScreenState extends ConsumerState<AvailabilityScreen> {
             ),
             child: Text(
               'This Kolab is ready to start today — no dates needed.',
-              style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurface, height: 1.4),
+              style: KolabingTextStyles.captionSecondary.copyWith(
+                color: context.colors.onSurface,
+                height: 1.4,
+              ),
             ),
           ),
 
@@ -190,7 +201,11 @@ class _AvailabilityScreenState extends ConsumerState<AvailabilityScreen> {
       children: [
         Text(
           'DATE RANGE',
-          style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontWeight: FontWeight.w700,
+            color: context.colors.onSurfaceVariant,
+            letterSpacing: 1.0,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.xs),
         KolabingInput(
@@ -209,7 +224,10 @@ class _AvailabilityScreenState extends ConsumerState<AvailabilityScreen> {
             padding: const EdgeInsets.only(top: KolabingSpacing.xs),
             child: Text(
               errors['availability_start']!,
-              style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.error),
+              style: KolabingTextStyles.bodySmall.copyWith(
+                fontSize: 12,
+                color: context.colors.error,
+              ),
             ),
           ),
       ],
@@ -227,7 +245,11 @@ class _AvailabilityScreenState extends ConsumerState<AvailabilityScreen> {
       children: [
         Text(
           'PREFERRED TIME',
-          style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontWeight: FontWeight.w700,
+            color: context.colors.onSurfaceVariant,
+            letterSpacing: 1.0,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.xs),
         KolabingInput(
@@ -250,7 +272,11 @@ class _AvailabilityScreenState extends ConsumerState<AvailabilityScreen> {
     children: [
       Text(
         'RECURRING DAYS',
-        style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
+        style: KolabingTextStyles.bodySmall.copyWith(
+          fontWeight: FontWeight.w700,
+          color: context.colors.onSurfaceVariant,
+          letterSpacing: 1.0,
+        ),
       ),
       const SizedBox(height: KolabingSpacing.xs),
       Row(
@@ -278,9 +304,13 @@ class _AvailabilityScreenState extends ConsumerState<AvailabilityScreen> {
               child: Center(
                 child: Text(
                   _dayLabels[index],
-                  style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400, color: isSelected
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    fontSize: 12,
+                    fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
+                    color: isSelected
                         ? context.colors.onPrimary
-                        : context.colors.onSurface),
+                        : context.colors.onSurface,
+                  ),
                 ),
               ),
             ),
@@ -331,7 +361,9 @@ class _ModeCard extends StatelessWidget {
         color: isSelected ? context.colors.softYellow : context.colors.surface,
         borderRadius: KolabingRadius.borderRadiusMd,
         border: Border.all(
-          color: isSelected ? context.colors.primary : context.colors.darkBorder,
+          color: isSelected
+              ? context.colors.primary
+              : context.colors.darkBorder,
         ),
       ),
       child: Row(
@@ -378,12 +410,18 @@ class _ModeCard extends StatelessWidget {
               children: [
                 Text(
                   title,
-                  style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: context.colors.onSurface,
+                  ),
                 ),
                 const SizedBox(height: 2),
                 Text(
                   subtitle,
-                  style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.textTertiary),
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    fontSize: 12,
+                    color: context.colors.textTertiary,
+                  ),
                 ),
               ],
             ),

--- a/lib/features/kolab/screens/business/goal_screen.dart
+++ b/lib/features/kolab/screens/business/goal_screen.dart
@@ -37,17 +37,27 @@ class GoalScreen extends ConsumerWidget {
       children: [
         Text(
           'GOAL',
-          style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontWeight: FontWeight.w700,
+            color: context.colors.onSurfaceVariant,
+            letterSpacing: 1.0,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.xs),
         Text(
           'What would make this Kolab a success?',
-          style: KolabingTextStyles.bodyMedium.copyWith(fontSize: 18, fontWeight: FontWeight.w700, color: context.colors.onSurface),
+          style: KolabingTextStyles.bodyMedium.copyWith(
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
+            color: context.colors.onSurface,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.xxs),
         Text(
           'Pick the main goal so communities understand what you’re looking for.',
-          style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            color: context.colors.onSurfaceVariant,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.md),
 
@@ -56,7 +66,10 @@ class GoalScreen extends ConsumerWidget {
             padding: const EdgeInsets.only(bottom: KolabingSpacing.xs),
             child: Text(
               errors['goal']!,
-              style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.error),
+              style: KolabingTextStyles.bodySmall.copyWith(
+                fontSize: 12,
+                color: context.colors.error,
+              ),
             ),
           ),
 
@@ -67,69 +80,90 @@ class GoalScreen extends ConsumerWidget {
               error: (_, _) => const <OfferOption>[],
             )
             .map((option) {
-          final isSelected = selectedGoal == option.slug;
-          return Padding(
-            padding: const EdgeInsets.only(bottom: KolabingSpacing.sm),
-            child: GestureDetector(
-              onTap: () => notifier.updateGoal(option.slug),
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 200),
-                padding: const EdgeInsets.all(KolabingSpacing.md),
-                decoration: BoxDecoration(
-                  color: isSelected ? context.colors.softYellow : context.colors.surface,
-                  borderRadius: KolabingRadius.borderRadiusMd,
-                  border: Border.all(
-                    color: isSelected ? context.colors.primary : context.colors.darkBorder,
-                  ),
-                ),
-                child: Row(
-                  children: [
-                    AnimatedContainer(
-                      duration: const Duration(milliseconds: 200),
-                      width: 24,
-                      height: 24,
-                      decoration: BoxDecoration(
-                        color: isSelected ? context.colors.primary : Colors.transparent,
-                        shape: BoxShape.circle,
-                        border: Border.all(
-                          color: isSelected ? context.colors.primary : context.colors.darkBorder,
-                          width: 1.5,
-                        ),
+              final isSelected = selectedGoal == option.slug;
+              return Padding(
+                padding: const EdgeInsets.only(bottom: KolabingSpacing.sm),
+                child: GestureDetector(
+                  onTap: () => notifier.updateGoal(option.slug),
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 200),
+                    padding: const EdgeInsets.all(KolabingSpacing.md),
+                    decoration: BoxDecoration(
+                      color: isSelected
+                          ? context.colors.softYellow
+                          : context.colors.surface,
+                      borderRadius: KolabingRadius.borderRadiusMd,
+                      border: Border.all(
+                        color: isSelected
+                            ? context.colors.primary
+                            : context.colors.darkBorder,
                       ),
-                      child: isSelected
-                          ? Icon(LucideIcons.check, size: 14, color: context.colors.onPrimary)
-                          : null,
                     ),
-                    const SizedBox(width: KolabingSpacing.sm),
-                    CategoryIcon(name: option.name, iconUrl: option.iconUrl, size: 24),
-                    const SizedBox(width: KolabingSpacing.sm),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            option.name,
-                            style: KolabingTextStyles.bodySmall.copyWith(
-                              fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
-                              color: context.colors.onSurface,
+                    child: Row(
+                      children: [
+                        AnimatedContainer(
+                          duration: const Duration(milliseconds: 200),
+                          width: 24,
+                          height: 24,
+                          decoration: BoxDecoration(
+                            color: isSelected
+                                ? context.colors.primary
+                                : Colors.transparent,
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color: isSelected
+                                  ? context.colors.primary
+                                  : context.colors.darkBorder,
+                              width: 1.5,
                             ),
                           ),
-                          if (option.description?.isNotEmpty ?? false) ...[
-                            const SizedBox(height: 2),
-                            Text(
-                              option.description!,
-                              style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.textTertiary),
-                            ),
-                          ],
-                        ],
-                      ),
+                          child: isSelected
+                              ? Icon(
+                                  LucideIcons.check,
+                                  size: 14,
+                                  color: context.colors.onPrimary,
+                                )
+                              : null,
+                        ),
+                        const SizedBox(width: KolabingSpacing.sm),
+                        CategoryIcon(
+                          name: option.name,
+                          iconUrl: option.iconUrl,
+                          size: 24,
+                        ),
+                        const SizedBox(width: KolabingSpacing.sm),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                option.name,
+                                style: KolabingTextStyles.bodySmall.copyWith(
+                                  fontWeight: isSelected
+                                      ? FontWeight.w600
+                                      : FontWeight.w400,
+                                  color: context.colors.onSurface,
+                                ),
+                              ),
+                              if (option.description?.isNotEmpty ?? false) ...[
+                                const SizedBox(height: 2),
+                                Text(
+                                  option.description!,
+                                  style: KolabingTextStyles.bodySmall.copyWith(
+                                    fontSize: 12,
+                                    color: context.colors.textTertiary,
+                                  ),
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+                      ],
                     ),
-                  ],
+                  ),
                 ),
-              ),
-            ),
-          );
-        }),
+              );
+            }),
 
         if (goalOptionsAsync.isLoading)
           const Padding(

--- a/lib/features/kolab/screens/business/ideal_community_screen.dart
+++ b/lib/features/kolab/screens/business/ideal_community_screen.dart
@@ -75,54 +75,72 @@ class _IdealCommunityScreenState extends ConsumerState<IdealCommunityScreen> {
           // -- Section header
           Text(
             'BEST-FIT COMMUNITIES',
-            style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontWeight: FontWeight.w700,
+              color: context.colors.onSurfaceVariant,
+              letterSpacing: 1.0,
+            ),
           ),
           const SizedBox(height: KolabingSpacing.xs),
 
           Text(
             'Who would this Kolab be perfect for?',
-            style: KolabingTextStyles.bodyMedium.copyWith(fontSize: 18, fontWeight: FontWeight.w700, color: context.colors.onSurface),
+            style: KolabingTextStyles.bodyMedium.copyWith(
+              fontSize: 18,
+              fontWeight: FontWeight.w700,
+              color: context.colors.onSurface,
+            ),
           ),
           const SizedBox(height: KolabingSpacing.xxs),
           Text(
             'Choose a few. This helps the right communities understand the opportunity faster.',
-            style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              color: context.colors.onSurfaceVariant,
+            ),
           ),
           const SizedBox(height: KolabingSpacing.md),
 
           // -- Community type chips (dynamic, via the existing shared
           // /lookup/community-types endpoint)
-          Builder(builder: (context) {
-            final communityTypesAsync = ref.watch(communityTypesProvider);
-            final types = communityTypesAsync.when(
-              data: (options) => options.map((o) => o.name).toList(),
-              loading: () => const <String>[],
-              error: (_, _) => const <String>[],
-            );
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                MultiSelectChips<String>(
-                  items: types,
-                  selected: kolab.seekingCommunities,
-                  labelBuilder: (t) => t,
-                  onToggle: notifier.toggleSeekingCommunity,
-                  maxSelect: 5,
-                ),
-                if (communityTypesAsync.isLoading)
-                  const Padding(
-                    padding: EdgeInsets.symmetric(vertical: KolabingSpacing.sm),
-                    child: Center(child: CircularProgressIndicator()),
+          Builder(
+            builder: (context) {
+              final communityTypesAsync = ref.watch(communityTypesProvider);
+              final types = communityTypesAsync.when(
+                data: (options) => options.map((o) => o.name).toList(),
+                loading: () => const <String>[],
+                error: (_, _) => const <String>[],
+              );
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  MultiSelectChips<String>(
+                    items: types,
+                    selected: kolab.seekingCommunities,
+                    labelBuilder: (t) => t,
+                    onToggle: notifier.toggleSeekingCommunity,
+                    maxSelect: 5,
                   ),
-              ],
-            );
-          }),
+                  if (communityTypesAsync.isLoading)
+                    const Padding(
+                      padding: EdgeInsets.symmetric(
+                        vertical: KolabingSpacing.sm,
+                      ),
+                      child: Center(child: CircularProgressIndicator()),
+                    ),
+                ],
+              );
+            },
+          ),
           const SizedBox(height: KolabingSpacing.lg),
 
           // -- Minimum Community Size
           Text(
             'MINIMUM COMMUNITY SIZE (OPTIONAL)',
-            style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontWeight: FontWeight.w700,
+              color: context.colors.onSurfaceVariant,
+              letterSpacing: 1.0,
+            ),
           ),
           const SizedBox(height: KolabingSpacing.xs),
 

--- a/lib/features/kolab/screens/business/media_screen.dart
+++ b/lib/features/kolab/screens/business/media_screen.dart
@@ -76,21 +76,28 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
         notifier.removeMedia(0);
       }
 
-      final existingPhotos = (isOnlyDefaultCover ? const <KolabMedia>[] : kolab.media)
-          .where((m) => m.type == 'image');
+      final existingPhotos =
+          (isOnlyDefaultCover ? const <KolabMedia>[] : kolab.media).where(
+            (m) => m.type == 'image',
+          );
       final nextSort = existingPhotos.isEmpty
           ? 0
           : existingPhotos
-                  .map((m) => m.sortOrder)
-                  .reduce((a, b) => a > b ? a : b) +
-              1;
+                    .map((m) => m.sortOrder)
+                    .reduce((a, b) => a > b ? a : b) +
+                1;
       notifier.addMedia(
         KolabMedia(url: url, type: 'image', sortOrder: nextSort),
       );
     } on Exception catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(AppLocalizations.of(context).mediaUploadFailed(e.toString())), backgroundColor: context.colors.error),
+          SnackBar(
+            content: Text(
+              AppLocalizations.of(context).mediaUploadFailed(e.toString()),
+            ),
+            backgroundColor: context.colors.error,
+          ),
         );
       }
     } finally {
@@ -129,7 +136,9 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
         ? 0
         : existing.map((m) => m.sortOrder).reduce((a, b) => a > b ? a : b) + 1;
     final toAdd = selectedPhotos
-        .where((photo) => photo.url.isNotEmpty && !existingUrls.contains(photo.url))
+        .where(
+          (photo) => photo.url.isNotEmpty && !existingUrls.contains(photo.url),
+        )
         .take(maxToAdd)
         .toList(growable: false);
 
@@ -139,7 +148,9 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
           SnackBar(
             content: Text(
               AppLocalizations.of(context).mediaPhotosAlreadyAdded,
-              style: KolabingTextStyles.bodyMedium.copyWith(color: Colors.white),
+              style: KolabingTextStyles.bodyMedium.copyWith(
+                color: Colors.white,
+              ),
             ),
             backgroundColor: context.colors.onSurfaceVariant,
             behavior: SnackBarBehavior.floating,
@@ -184,10 +195,13 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
     final intent = formState.intentType ?? IntentType.productPromotion;
 
     final venuePhotoUrls = ref.watch(
-      profileProvider.select((s) => s.profile?.businessProfile?.primaryVenue?.photos),
+      profileProvider.select(
+        (s) => s.profile?.businessProfile?.primaryVenue?.photos,
+      ),
     );
     final galleryState = ref.watch(galleryProvider);
-    final hasUsableDefault = galleryState.photos.isNotEmpty ||
+    final hasUsableDefault =
+        galleryState.photos.isNotEmpty ||
         (isVenue && (venuePhotoUrls?.isNotEmpty ?? false));
     final showReuseCta =
         kolab.media.length < 5 && (galleryState.isLoading || hasUsableDefault);
@@ -201,12 +215,18 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
       children: [
         Text(
           'ADD PHOTOS',
-          style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w800, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontWeight: FontWeight.w800,
+            color: context.colors.onSurfaceVariant,
+            letterSpacing: 1.0,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.xs),
         Text(
           'Kolabs need a cover image. You can upload your own or use a Kolabing default.',
-          style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            color: context.colors.onSurfaceVariant,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.md),
 
@@ -227,14 +247,16 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
           _ChoiceCard(
             icon: LucideIcons.upload,
             title: 'Upload my photo',
-            helper: 'Best if you have a real product, venue, food, or event image.',
+            helper:
+                'Best if you have a real product, venue, food, or event image.',
             onTap: _isUploading ? null : _pickAndUploadPhoto,
           ),
           const SizedBox(height: KolabingSpacing.sm),
           _ChoiceCard(
             icon: LucideIcons.imagePlus,
             title: 'Use default cover',
-            helper: "We'll use a designed Kolabing cover for this type of Kolab.",
+            helper:
+                "We'll use a designed Kolabing cover for this type of Kolab.",
             previewAssetPath:
                 'assets/images/defaults/${intent == IntentType.venuePromotion ? 'venue_1' : 'product_cover_1'}.png',
             onTap: _isUploading ? null : () => _useDefaultCover(intent),
@@ -253,7 +275,9 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
               child: TextButton(
                 onPressed: _isUploading ? null : _selectExistingPhotos,
                 child: Text(
-                  isVenue ? 'Or use business photo / choose existing' : 'Or choose an existing photo',
+                  isVenue
+                      ? 'Or use business photo / choose existing'
+                      : 'Or choose an existing photo',
                   style: KolabingTextStyles.bodySmall.copyWith(
                     fontWeight: FontWeight.w700,
                     color: context.colors.primary,
@@ -281,7 +305,10 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
                 Expanded(
                   child: Text(
                     'Kolabs with strong visuals usually get more interest.',
-                    style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurface, height: 1.4),
+                    style: KolabingTextStyles.captionSecondary.copyWith(
+                      color: context.colors.onSurface,
+                      height: 1.4,
+                    ),
                   ),
                 ),
               ],
@@ -293,8 +320,14 @@ class _MediaScreenState extends ConsumerState<MediaScreen> {
               onPressed: _isUploading ? null : _selectExistingPhotos,
               icon: const Icon(LucideIcons.imagePlus, size: 18),
               label: Text(
-                isVenue ? 'Use business photo or choose existing' : 'Choose existing photo',
-                style: KolabingTextStyles.button.copyWith(fontSize: 13, fontWeight: FontWeight.w700, letterSpacing: 0.5),
+                isVenue
+                    ? 'Use business photo or choose existing'
+                    : 'Choose existing photo',
+                style: KolabingTextStyles.button.copyWith(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0.5,
+                ),
               ),
               style: OutlinedButton.styleFrom(
                 foregroundColor: context.colors.primary,
@@ -358,39 +391,28 @@ class _ChoiceCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: onTap,
+    color: Colors.transparent,
+    child: InkWell(
+      onTap: onTap,
+      borderRadius: KolabingRadius.borderRadiusOptionCard,
+      child: Container(
+        padding: const EdgeInsets.all(KolabingSpacing.md),
+        decoration: BoxDecoration(
+          color: context.colors.softYellow,
           borderRadius: KolabingRadius.borderRadiusOptionCard,
-          child: Container(
-            padding: const EdgeInsets.all(KolabingSpacing.md),
-            decoration: BoxDecoration(
-              color: context.colors.softYellow,
-              borderRadius: KolabingRadius.borderRadiusOptionCard,
-              border: Border.all(color: context.colors.softYellowBorder),
-            ),
-            child: Row(
-              children: [
-                previewAssetPath != null
-                    ? ClipRRect(
-                        borderRadius: BorderRadius.circular(8),
-                        child: Image.asset(
-                          previewAssetPath!,
-                          width: 40,
-                          height: 40,
-                          fit: BoxFit.cover,
-                          errorBuilder: (context, error, stackTrace) => Container(
-                            width: 40,
-                            height: 40,
-                            decoration: BoxDecoration(
-                              color: context.colors.primary,
-                              shape: BoxShape.circle,
-                            ),
-                            child: Icon(icon, size: 20, color: context.colors.ink),
-                          ),
-                        ),
-                      )
-                    : Container(
+          border: Border.all(color: context.colors.softYellowBorder),
+        ),
+        child: Row(
+          children: [
+            previewAssetPath != null
+                ? ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: Image.asset(
+                      previewAssetPath!,
+                      width: 40,
+                      height: 40,
+                      fit: BoxFit.cover,
+                      errorBuilder: (context, error, stackTrace) => Container(
                         width: 40,
                         height: 40,
                         decoration: BoxDecoration(
@@ -399,28 +421,43 @@ class _ChoiceCard extends StatelessWidget {
                         ),
                         child: Icon(icon, size: 20, color: context.colors.ink),
                       ),
-                const SizedBox(width: KolabingSpacing.sm),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        title,
-                        style: KolabingTextStyles.bodyMedium.copyWith(fontWeight: FontWeight.w700),
-                      ),
-                      const SizedBox(height: 2),
-                      Text(
-                        helper,
-                        style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
-                      ),
-                    ],
+                    ),
+                  )
+                : Container(
+                    width: 40,
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: context.colors.primary,
+                      shape: BoxShape.circle,
+                    ),
+                    child: Icon(icon, size: 20, color: context.colors.ink),
                   ),
-                ),
-              ],
+            const SizedBox(width: KolabingSpacing.sm),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: KolabingTextStyles.bodyMedium.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    helper,
+                    style: KolabingTextStyles.bodySmall.copyWith(
+                      color: context.colors.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
             ),
-          ),
+          ],
         ),
-      );
+      ),
+    ),
+  );
 }
 
 // =============================================================================
@@ -520,88 +557,94 @@ class _PhotoSlot extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Stack(
-      children: [
-        Container(
-          width: 120,
-          height: 120,
-          decoration: BoxDecoration(
-            color: context.colors.softYellow,
-            borderRadius: KolabingRadius.borderRadiusThumbnail,
-            border: Border.all(color: context.colors.softYellowBorder),
-          ),
-          child: ClipRRect(
-            borderRadius: KolabingRadius.borderRadiusThumbnail,
-            child: _isLocalFile
-                ? Image.file(
-                    File(url),
-                    width: 120,
-                    height: 120,
-                    fit: BoxFit.cover,
-                    errorBuilder: (context, error, stackTrace) =>
-                        _buildPlaceholder(context),
-                  )
-                : Image.network(
-                    url,
-                    width: 120,
-                    height: 120,
-                    fit: BoxFit.cover,
-                    errorBuilder: (context, error, stackTrace) =>
-                        _buildPlaceholder(context),
-                  ),
-          ),
+    children: [
+      Container(
+        width: 120,
+        height: 120,
+        decoration: BoxDecoration(
+          color: context.colors.softYellow,
+          borderRadius: KolabingRadius.borderRadiusThumbnail,
+          border: Border.all(color: context.colors.softYellowBorder),
         ),
-        if (isDefaultCover)
-          Positioned(
-            bottom: 4,
-            left: 4,
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-              decoration: BoxDecoration(
-                color: Colors.black.withValues(alpha: 0.6),
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: const Text(
-                'Default',
-                style: TextStyle(fontSize: 10, fontWeight: FontWeight.w700, color: Colors.white),
-              ),
-            ),
-          ),
+        child: ClipRRect(
+          borderRadius: KolabingRadius.borderRadiusThumbnail,
+          child: _isLocalFile
+              ? Image.file(
+                  File(url),
+                  width: 120,
+                  height: 120,
+                  fit: BoxFit.cover,
+                  errorBuilder: (context, error, stackTrace) =>
+                      _buildPlaceholder(context),
+                )
+              : Image.network(
+                  url,
+                  width: 120,
+                  height: 120,
+                  fit: BoxFit.cover,
+                  errorBuilder: (context, error, stackTrace) =>
+                      _buildPlaceholder(context),
+                ),
+        ),
+      ),
+      if (isDefaultCover)
         Positioned(
-          top: 4,
-          right: 4,
-          child: GestureDetector(
-            onTap: onRemove,
-            child: Container(
-              width: 22,
-              height: 22,
-              decoration: BoxDecoration(
-                color: context.colors.error,
-                shape: BoxShape.circle,
-              ),
-              child: const Icon(
-                LucideIcons.x,
-                size: 12,
+          bottom: 4,
+          left: 4,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.6),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: const Text(
+              'Default',
+              style: TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.w700,
                 color: Colors.white,
               ),
             ),
           ),
         ),
-      ],
-    );
+      Positioned(
+        top: 4,
+        right: 4,
+        child: GestureDetector(
+          onTap: onRemove,
+          child: Container(
+            width: 22,
+            height: 22,
+            decoration: BoxDecoration(
+              color: context.colors.error,
+              shape: BoxShape.circle,
+            ),
+            child: const Icon(LucideIcons.x, size: 12, color: Colors.white),
+          ),
+        ),
+      ),
+    ],
+  );
 
   Widget _buildPlaceholder(BuildContext context) => Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(LucideIcons.image, size: 24, color: context.colors.onSurfaceVariant),
-            const SizedBox(height: KolabingSpacing.xxs),
-            Text(
-              AppLocalizations.of(context).mediaPhotoSlot(index + 1),
-              style: KolabingTextStyles.labelSmall.copyWith(color: context.colors.onSurfaceVariant),
-            ),
-          ],
+    child: Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(
+          LucideIcons.image,
+          size: 24,
+          color: context.colors.onSurfaceVariant,
         ),
-      );
+        const SizedBox(height: KolabingSpacing.xxs),
+        Text(
+          AppLocalizations.of(context).mediaPhotoSlot(index + 1),
+          style: KolabingTextStyles.labelSmall.copyWith(
+            color: context.colors.onSurfaceVariant,
+          ),
+        ),
+      ],
+    ),
+  );
 }
 
 /// Paints a dashed rounded-rectangle border for the "Add Photo" tile.

--- a/lib/features/kolab/screens/business/offering_screen.dart
+++ b/lib/features/kolab/screens/business/offering_screen.dart
@@ -71,7 +71,11 @@ class _OfferingScreenState extends ConsumerState<OfferingScreen> {
         // -- Intro: this is the core of the Kolab
         Text(
           'This is the main reason a community will say yes.',
-          style: KolabingTextStyles.bodyMedium.copyWith(fontSize: 16, fontWeight: FontWeight.w700, color: context.colors.onSurface),
+          style: KolabingTextStyles.bodyMedium.copyWith(
+            fontSize: 16,
+            fontWeight: FontWeight.w700,
+            color: context.colors.onSurface,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.md),
 
@@ -80,13 +84,19 @@ class _OfferingScreenState extends ConsumerState<OfferingScreen> {
         // endpoint isn't deployed)
         Text(
           l10n.offeringTitle,
-          style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontWeight: FontWeight.w700,
+            color: context.colors.onSurfaceVariant,
+            letterSpacing: 1.0,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.xs),
 
         Text(
           l10n.offeringSelectAllThatApply,
-          style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            color: context.colors.onSurfaceVariant,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.md),
 
@@ -96,7 +106,10 @@ class _OfferingScreenState extends ConsumerState<OfferingScreen> {
             padding: const EdgeInsets.only(bottom: KolabingSpacing.xs),
             child: Text(
               errors['offering']!,
-              style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.error),
+              style: KolabingTextStyles.bodySmall.copyWith(
+                fontSize: 12,
+                color: context.colors.error,
+              ),
             ),
           ),
 
@@ -110,28 +123,28 @@ class _OfferingScreenState extends ConsumerState<OfferingScreen> {
               error: (_, _) => const <OfferOption>[],
             )
             .map((option) {
-          final isSelected = offerings.contains(option.slug);
-          final isVenueLocked = isVenueFlow && option.slug == 'venue';
+              final isSelected = offerings.contains(option.slug);
+              final isVenueLocked = isVenueFlow && option.slug == 'venue';
 
-          return Padding(
-            padding: const EdgeInsets.only(bottom: KolabingSpacing.sm),
-            child: _ToggleCard(
-              title: _offeringTitle(l10n, option.slug, option.name),
-              subtitle: _offeringSubtitle(
-                l10n,
-                option.slug,
-                option.description ?? '',
-              ),
-              iconName: option.name,
-              iconUrl: option.iconUrl,
-              isSelected: isVenueLocked || isSelected,
-              isLocked: isVenueLocked,
-              onTap: isVenueLocked
-                  ? null
-                  : () => notifier.toggleOffering(option.slug),
-            ),
-          );
-        }),
+              return Padding(
+                padding: const EdgeInsets.only(bottom: KolabingSpacing.sm),
+                child: _ToggleCard(
+                  title: _offeringTitle(l10n, option.slug, option.name),
+                  subtitle: _offeringSubtitle(
+                    l10n,
+                    option.slug,
+                    option.description ?? '',
+                  ),
+                  iconName: option.name,
+                  iconUrl: option.iconUrl,
+                  isSelected: isVenueLocked || isSelected,
+                  isLocked: isVenueLocked,
+                  onTap: isVenueLocked
+                      ? null
+                      : () => notifier.toggleOffering(option.slug),
+                ),
+              );
+            }),
 
         if (offeringOptionsAsync.isLoading)
           const Padding(
@@ -146,7 +159,10 @@ class _OfferingScreenState extends ConsumerState<OfferingScreen> {
         const SizedBox(height: KolabingSpacing.xxs),
         Text(
           l10n.offeringBaseOfferHelper,
-          style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant, height: 1.4),
+          style: KolabingTextStyles.captionSecondary.copyWith(
+            color: context.colors.onSurfaceVariant,
+            height: 1.4,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.xs),
         if (errors.containsKey('base_offer'))
@@ -154,7 +170,10 @@ class _OfferingScreenState extends ConsumerState<OfferingScreen> {
             padding: const EdgeInsets.only(bottom: KolabingSpacing.xs),
             child: Text(
               errors['base_offer']!,
-              style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.error),
+              style: KolabingTextStyles.bodySmall.copyWith(
+                fontSize: 12,
+                color: context.colors.error,
+              ),
             ),
           ),
         KolabingInput(
@@ -166,11 +185,13 @@ class _OfferingScreenState extends ConsumerState<OfferingScreen> {
           onTapOutside: (_) => FocusScope.of(context).unfocus(),
         ),
         const SizedBox(height: KolabingSpacing.xs),
-        const KolabExamplesBox(examples: [
-          'Free coffee tasting for 20 runners in exchange for tagged stories.',
-          '50 product samples for a fitness community in exchange for feedback.',
-          '20% off brunch for community members every Sunday.',
-        ]),
+        const KolabExamplesBox(
+          examples: [
+            'Free coffee tasting for 20 runners in exchange for tagged stories.',
+            '50 product samples for a fitness community in exchange for feedback.',
+            '20% off brunch for community members every Sunday.',
+          ],
+        ),
         const SizedBox(height: KolabingSpacing.md),
         Container(
           padding: const EdgeInsets.all(KolabingSpacing.sm),
@@ -181,7 +202,10 @@ class _OfferingScreenState extends ConsumerState<OfferingScreen> {
           child: Text(
             'Good Kolabs usually include a clear perk: free samples, a discount, '
             'a space, an experience, content, or something members will enjoy.',
-            style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurface, height: 1.4),
+            style: KolabingTextStyles.captionSecondary.copyWith(
+              color: context.colors.onSurface,
+              height: 1.4,
+            ),
           ),
         ),
         const SizedBox(height: KolabingSpacing.lg),
@@ -192,30 +216,39 @@ class _OfferingScreenState extends ConsumerState<OfferingScreen> {
         Text(
           'You can choose more than one. This is not a strict contract yet — '
           'it helps communities understand your expectations.',
-          style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant, height: 1.4),
+          style: KolabingTextStyles.captionSecondary.copyWith(
+            color: context.colors.onSurfaceVariant,
+            height: 1.4,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.sm),
-        Builder(builder: (context) {
-          final deliverableOptions = ref.watch(deliverablesProvider).when(
-                data: (options) => options,
-                loading: () => const <OfferOption>[],
-                error: (_, _) => const <OfferOption>[],
-              );
-          return MultiSelectChips<OfferOption>(
-            items: deliverableOptions,
-            selected: deliverableOptions
-                .where((o) => kolab.expects.contains(o.slug))
-                .toList(),
-            labelBuilder: (o) => o.name,
-            onToggle: (option) => notifier.toggleExpect(option.slug),
-          );
-        }),
+        Builder(
+          builder: (context) {
+            final deliverableOptions = ref
+                .watch(deliverablesProvider)
+                .when(
+                  data: (options) => options,
+                  loading: () => const <OfferOption>[],
+                  error: (_, _) => const <OfferOption>[],
+                );
+            return MultiSelectChips<OfferOption>(
+              items: deliverableOptions,
+              selected: deliverableOptions
+                  .where((o) => kolab.expects.contains(o.slug))
+                  .toList(),
+              labelBuilder: (o) => o.name,
+              onToggle: (option) => notifier.toggleExpect(option.slug),
+            );
+          },
+        ),
         const SizedBox(height: KolabingSpacing.xs),
-        const KolabExamplesBox(examples: [
-          'Tagged stories + honest feedback from members.',
-          'Minimum 15 attendees and community photos.',
-          'Open to ideas — we mainly want to connect with the right community.',
-        ]),
+        const KolabExamplesBox(
+          examples: [
+            'Tagged stories + honest feedback from members.',
+            'Minimum 15 attendees and community photos.',
+            'Open to ideas — we mainly want to connect with the right community.',
+          ],
+        ),
         const SizedBox(height: KolabingSpacing.lg),
 
         // H3: Negotiation triggers — surfaces only after a community applies.
@@ -223,7 +256,10 @@ class _OfferingScreenState extends ConsumerState<OfferingScreen> {
         const SizedBox(height: KolabingSpacing.xxs),
         Text(
           l10n.offeringExtraTermsHelper,
-          style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant, height: 1.4),
+          style: KolabingTextStyles.captionSecondary.copyWith(
+            color: context.colors.onSurfaceVariant,
+            height: 1.4,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.sm),
 
@@ -279,10 +315,7 @@ class _OfferingScreenState extends ConsumerState<OfferingScreen> {
       builder: (_) => const _TriggerEditorSheet(),
     );
     if (result == null) return;
-    notifier.updateNegotiationTriggers([
-      ...kolab.negotiationTriggers,
-      result,
-    ]);
+    notifier.updateNegotiationTriggers([...kolab.negotiationTriggers, result]);
   }
 }
 
@@ -337,9 +370,14 @@ class _SectionLabel extends StatelessWidget {
   final String label;
   @override
   Widget build(BuildContext context) => Text(
-        label,
-        style: KolabingTextStyles.bodySmall.copyWith(fontSize: 13, fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
-      );
+    label,
+    style: KolabingTextStyles.bodySmall.copyWith(
+      fontSize: 13,
+      fontWeight: FontWeight.w700,
+      color: context.colors.onSurfaceVariant,
+      letterSpacing: 1.0,
+    ),
+  );
 }
 
 class _TriggerCard extends StatelessWidget {
@@ -357,44 +395,51 @@ class _TriggerCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Container(
-        padding: const EdgeInsets.all(KolabingSpacing.md),
-        decoration: BoxDecoration(
-          color: context.colors.surface,
-          borderRadius: BorderRadius.circular(10),
-          border: Border.all(color: context.colors.darkBorder),
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    AppLocalizations.of(context).offeringTriggerIfPrefix(condition),
-                    style: KolabingTextStyles.labelSmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.textTertiary, letterSpacing: 0.5),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    additionalOffer,
-                    style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurface, height: 1.4),
-                  ),
-                ],
+    padding: const EdgeInsets.all(KolabingSpacing.md),
+    decoration: BoxDecoration(
+      color: context.colors.surface,
+      borderRadius: BorderRadius.circular(10),
+      border: Border.all(color: context.colors.darkBorder),
+    ),
+    child: Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                AppLocalizations.of(context).offeringTriggerIfPrefix(condition),
+                style: KolabingTextStyles.labelSmall.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: context.colors.textTertiary,
+                  letterSpacing: 0.5,
+                ),
               ),
-            ),
-            IconButton(
-              padding: EdgeInsets.zero,
-              constraints: const BoxConstraints(),
-              onPressed: onRemove,
-              icon: Icon(
-                LucideIcons.x,
-                size: 18,
-                color: context.colors.textTertiary,
+              const SizedBox(height: 4),
+              Text(
+                additionalOffer,
+                style: KolabingTextStyles.bodySmall.copyWith(
+                  color: context.colors.onSurface,
+                  height: 1.4,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
-      );
+        IconButton(
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(),
+          onPressed: onRemove,
+          icon: Icon(
+            LucideIcons.x,
+            size: 18,
+            color: context.colors.textTertiary,
+          ),
+        ),
+      ],
+    ),
+  );
 }
 
 class _TriggerEditorSheet extends StatefulWidget {
@@ -447,12 +492,18 @@ class _TriggerEditorSheetState extends State<_TriggerEditorSheet> {
           const SizedBox(height: KolabingSpacing.md),
           Text(
             l10n.offeringTriggerSheetTitle,
-            style: KolabingTextStyles.bodyMedium.copyWith(fontSize: 18, fontWeight: FontWeight.w700, color: context.colors.onSurface),
+            style: KolabingTextStyles.bodyMedium.copyWith(
+              fontSize: 18,
+              fontWeight: FontWeight.w700,
+              color: context.colors.onSurface,
+            ),
           ),
           const SizedBox(height: KolabingSpacing.xs),
           Text(
             l10n.offeringTriggerSheetSubtitle,
-            style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant),
+            style: KolabingTextStyles.captionSecondary.copyWith(
+              color: context.colors.onSurfaceVariant,
+            ),
           ),
           const SizedBox(height: KolabingSpacing.md),
           KolabingInput(
@@ -496,7 +547,6 @@ class _TriggerEditorSheetState extends State<_TriggerEditorSheet> {
   }
 }
 
-
 // =============================================================================
 // Toggle Card
 // =============================================================================
@@ -526,73 +576,75 @@ class _ToggleCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => GestureDetector(
-      onTap: onTap,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 200),
-        padding: const EdgeInsets.all(KolabingSpacing.md),
-        decoration: BoxDecoration(
+    onTap: onTap,
+    child: AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      padding: const EdgeInsets.all(KolabingSpacing.md),
+      decoration: BoxDecoration(
+        color: isSelected ? context.colors.softYellow : context.colors.surface,
+        borderRadius: KolabingRadius.borderRadiusMd,
+        border: Border.all(
           color: isSelected
-              ? context.colors.softYellow
-              : context.colors.surface,
-          borderRadius: KolabingRadius.borderRadiusMd,
-          border: Border.all(
-            color: isSelected
-                ? context.colors.primary
-                : context.colors.darkBorder,
-          ),
-        ),
-        child: Row(
-          children: [
-            // Checkbox / Locked indicator
-            AnimatedContainer(
-              duration: const Duration(milliseconds: 200),
-              width: 24,
-              height: 24,
-              decoration: BoxDecoration(
-                color: isSelected
-                    ? context.colors.primary
-                    : Colors.transparent,
-                borderRadius: KolabingRadius.borderRadiusXs,
-                border: Border.all(
-                  color: isSelected
-                      ? context.colors.primary
-                      : context.colors.darkBorder,
-                  width: 1.5,
-                ),
-              ),
-              child: isSelected
-                  ? Icon(
-                      isLocked ? LucideIcons.lock : LucideIcons.check,
-                      size: 14,
-                      color: context.colors.onPrimary,
-                    )
-                  : null,
-            ),
-            const SizedBox(width: KolabingSpacing.sm),
-
-            // Icon (personalised category SVG; admin icon_url overrides)
-            CategoryIcon(name: iconName, iconUrl: iconUrl, size: 24),
-            const SizedBox(width: KolabingSpacing.sm),
-
-            // Title + subtitle
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurface),
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    subtitle,
-                    style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.textTertiary),
-                  ),
-                ],
-              ),
-            ),
-          ],
+              ? context.colors.primary
+              : context.colors.darkBorder,
         ),
       ),
-    );
+      child: Row(
+        children: [
+          // Checkbox / Locked indicator
+          AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            width: 24,
+            height: 24,
+            decoration: BoxDecoration(
+              color: isSelected ? context.colors.primary : Colors.transparent,
+              borderRadius: KolabingRadius.borderRadiusXs,
+              border: Border.all(
+                color: isSelected
+                    ? context.colors.primary
+                    : context.colors.darkBorder,
+                width: 1.5,
+              ),
+            ),
+            child: isSelected
+                ? Icon(
+                    isLocked ? LucideIcons.lock : LucideIcons.check,
+                    size: 14,
+                    color: context.colors.onPrimary,
+                  )
+                : null,
+          ),
+          const SizedBox(width: KolabingSpacing.sm),
+
+          // Icon (personalised category SVG; admin icon_url overrides)
+          CategoryIcon(name: iconName, iconUrl: iconUrl, size: 24),
+          const SizedBox(width: KolabingSpacing.sm),
+
+          // Title + subtitle
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: context.colors.onSurface,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  subtitle,
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    fontSize: 12,
+                    color: context.colors.textTertiary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
 }

--- a/lib/features/kolab/screens/business/past_events_screen.dart
+++ b/lib/features/kolab/screens/business/past_events_screen.dart
@@ -53,8 +53,10 @@ class _PastEventsScreenState extends ConsumerState<PastEventsScreen> {
   void _syncNotesController(Kolab kolab) {
     if (_didInitNotes) return;
     _didInitNotes = true;
-    final match = RegExp(r'\n\nNote: (.*)$', dotAll: true)
-        .firstMatch(kolab.description);
+    final match = RegExp(
+      r'\n\nNote: (.*)$',
+      dotAll: true,
+    ).firstMatch(kolab.description);
     _extraNotesController.text = match?.group(1) ?? '';
   }
 
@@ -101,31 +103,38 @@ class _PastEventsScreenState extends ConsumerState<PastEventsScreen> {
         const SizedBox(height: KolabingSpacing.md),
 
         // -- Highlight chips
-        Builder(builder: (context) {
-          final highlightsAsync = ref.watch(kolabHighlightsProvider);
-          final options = highlightsAsync.when(
-            data: (options) => options,
-            loading: () => const <OfferOption>[],
-            error: (_, _) => const <OfferOption>[],
-          );
-          return MultiSelectChips<OfferOption>(
-            items: options,
-            selected: kolab.highlights
-                .map((slug) => options.firstWhere(
+        Builder(
+          builder: (context) {
+            final highlightsAsync = ref.watch(kolabHighlightsProvider);
+            final options = highlightsAsync.when(
+              data: (options) => options,
+              loading: () => const <OfferOption>[],
+              error: (_, _) => const <OfferOption>[],
+            );
+            return MultiSelectChips<OfferOption>(
+              items: options,
+              selected: kolab.highlights
+                  .map(
+                    (slug) => options.firstWhere(
                       (o) => o.slug == slug,
-                      orElse: () => OfferOption(id: slug, slug: slug, name: slug),
-                    ))
-                .toList(),
-            labelBuilder: (o) => o.name,
-            onToggle: (option) => notifier.toggleHighlight(option.slug),
-          );
-        }),
+                      orElse: () =>
+                          OfferOption(id: slug, slug: slug, name: slug),
+                    ),
+                  )
+                  .toList(),
+              labelBuilder: (o) => o.name,
+              onToggle: (option) => notifier.toggleHighlight(option.slug),
+            );
+          },
+        ),
         const SizedBox(height: KolabingSpacing.xs),
-        const KolabExamplesBox(examples: [
-          'Central location and space for groups.',
-          'Free samples members can actually use.',
-          'A unique experience that creates good content.',
-        ]),
+        const KolabExamplesBox(
+          examples: [
+            'Central location and space for groups.',
+            'Free samples members can actually use.',
+            'A unique experience that creates good content.',
+          ],
+        ),
         const SizedBox(height: KolabingSpacing.lg),
 
         // -- Anything else communities should know (optional free text)

--- a/lib/features/kolab/screens/business/product_details_screen.dart
+++ b/lib/features/kolab/screens/business/product_details_screen.dart
@@ -139,7 +139,10 @@ class _ProductDetailsScreenState extends ConsumerState<ProductDetailsScreen> {
             padding: const EdgeInsets.only(bottom: KolabingSpacing.xxs),
             child: Text(
               errors['product_type']!,
-              style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.error),
+              style: KolabingTextStyles.bodySmall.copyWith(
+                fontSize: 12,
+                color: context.colors.error,
+              ),
             ),
           ),
         Wrap(
@@ -186,9 +189,14 @@ class _ProductDetailsScreenState extends ConsumerState<ProductDetailsScreen> {
                     const SizedBox(width: KolabingSpacing.xxs),
                     Text(
                       label,
-                      style: KolabingTextStyles.bodySmall.copyWith(fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400, color: isSelected
+                      style: KolabingTextStyles.bodySmall.copyWith(
+                        fontWeight: isSelected
+                            ? FontWeight.w600
+                            : FontWeight.w400,
+                        color: isSelected
                             ? context.colors.onPrimary
-                            : context.colors.onSurface),
+                            : context.colors.onSurface,
+                      ),
                     ),
                   ],
                 ),
@@ -216,11 +224,13 @@ class _ProductDetailsScreenState extends ConsumerState<ProductDetailsScreen> {
           onTapOutside: (_) => FocusScope.of(context).unfocus(),
         ),
         const SizedBox(height: KolabingSpacing.xs),
-        const KolabExamplesBox(examples: [
-          'Protein bars for runners to try after training.',
-          'Skincare samples for a wellness or self-care community.',
-          'A local clothing brand looking for try-ons, feedback, and content.',
-        ]),
+        const KolabExamplesBox(
+          examples: [
+            'Protein bars for runners to try after training.',
+            'Skincare samples for a wellness or self-care community.',
+            'A local clothing brand looking for try-ons, feedback, and content.',
+          ],
+        ),
         const SizedBox(height: KolabingSpacing.md),
 
         // -- Product interaction chips
@@ -230,46 +240,59 @@ class _ProductDetailsScreenState extends ConsumerState<ProductDetailsScreen> {
         const SizedBox(height: KolabingSpacing.xxs),
         Text(
           'Choose how communities could experience your product.',
-          style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.onSurfaceVariant),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontSize: 12,
+            color: context.colors.onSurfaceVariant,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.xs),
-        Builder(builder: (context) {
-          final productInteractionsAsync = ref.watch(productInteractionsProvider);
-          final options = productInteractionsAsync.when(
-            data: (options) => options,
-            loading: () => const <OfferOption>[],
-            error: (_, _) => const <OfferOption>[],
-          );
-          return MultiSelectChips<OfferOption>(
-            items: options,
-            selected: _selectedProductInteractions,
-            labelBuilder: (o) => o.name,
-            onToggle: (option) {
-              setState(() {
-                if (_selectedProductInteractions.contains(option)) {
-                  _selectedProductInteractions.remove(option);
-                } else {
-                  _selectedProductInteractions.add(option);
-                }
-              });
-              _appendInteractionsToDescription(notifier, kolab);
-            },
-          );
-        }),
+        Builder(
+          builder: (context) {
+            final productInteractionsAsync = ref.watch(
+              productInteractionsProvider,
+            );
+            final options = productInteractionsAsync.when(
+              data: (options) => options,
+              loading: () => const <OfferOption>[],
+              error: (_, _) => const <OfferOption>[],
+            );
+            return MultiSelectChips<OfferOption>(
+              items: options,
+              selected: _selectedProductInteractions,
+              labelBuilder: (o) => o.name,
+              onToggle: (option) {
+                setState(() {
+                  if (_selectedProductInteractions.contains(option)) {
+                    _selectedProductInteractions.remove(option);
+                  } else {
+                    _selectedProductInteractions.add(option);
+                  }
+                });
+                _appendInteractionsToDescription(notifier, kolab);
+              },
+            );
+          },
+        ),
         const SizedBox(height: KolabingSpacing.xs),
-        const KolabExamplesBox(label: 'EXAMPLES', examples: [
-          'Samples after a run',
-          'Giveaway for members',
-          'Content day with the product',
-          'Feedback from real users',
-        ]),
+        const KolabExamplesBox(
+          label: 'EXAMPLES',
+          examples: [
+            'Samples after a run',
+            'Giveaway for members',
+            'Content day with the product',
+            'Feedback from real users',
+          ],
+        ),
         const SizedBox(height: KolabingSpacing.md),
         // H2: short, one-line offer headline shown on the discovery card.
         _FieldLabel(label: l10n.productDetailsOfferHeadlineLabel),
         const SizedBox(height: KolabingSpacing.xxs),
         Text(
           l10n.productDetailsOfferHeadlineHelper,
-          style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.onSurfaceVariant),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontSize: 12,
+            color: context.colors.onSurfaceVariant,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.xs),
         KolabingInput(
@@ -287,32 +310,32 @@ class _ProductDetailsScreenState extends ConsumerState<ProductDetailsScreen> {
         const SizedBox(height: KolabingSpacing.xs),
         citiesAsync.when(
           data: (cities) => DropdownButtonFormField<String>(
-              initialValue: kolab.preferredCity.isNotEmpty
-                  ? kolab.preferredCity
-                  : null,
-              decoration: _inputDecoration(
-                context,
-                hint: l10n.productDetailsSelectCityHint,
-                error: errors['preferred_city'],
-              ),
-              style: _inputTextStyle(context),
-              icon: Icon(
-                LucideIcons.chevronDown,
-                size: 20,
-                color: context.colors.onSurfaceVariant,
-              ),
-              items: cities
-                  .map(
-                    (c) => DropdownMenuItem(
-                      value: c.name,
-                      child: Text(c.name, style: _inputTextStyle(context)),
-                    ),
-                  )
-                  .toList(),
-              onChanged: (v) {
-                if (v != null) notifier.updatePreferredCity(v);
-              },
+            initialValue: kolab.preferredCity.isNotEmpty
+                ? kolab.preferredCity
+                : null,
+            decoration: _inputDecoration(
+              context,
+              hint: l10n.productDetailsSelectCityHint,
+              error: errors['preferred_city'],
             ),
+            style: _inputTextStyle(context),
+            icon: Icon(
+              LucideIcons.chevronDown,
+              size: 20,
+              color: context.colors.onSurfaceVariant,
+            ),
+            items: cities
+                .map(
+                  (c) => DropdownMenuItem(
+                    value: c.name,
+                    child: Text(c.name, style: _inputTextStyle(context)),
+                  ),
+                )
+                .toList(),
+            onChanged: (v) {
+              if (v != null) notifier.updatePreferredCity(v);
+            },
+          ),
           loading: () => LinearProgressIndicator(
             color: context.colors.primary,
             backgroundColor: context.colors.darkBorder,
@@ -349,39 +372,40 @@ InputDecoration _inputDecoration(
   BuildContext context, {
   required String hint,
   String? error,
-}) =>
-    InputDecoration(
-      hintText: hint,
-      hintStyle: KolabingTextStyles.bodySmall.copyWith(color: context.colors.textTertiary),
-      errorText: error,
-      errorStyle: KolabingTextStyles.bodySmall.copyWith(fontSize: 12),
-      filled: true,
-      fillColor: context.colors.surface,
-      contentPadding: const EdgeInsets.symmetric(
-        horizontal: KolabingSpacing.md,
-        vertical: 14,
-      ),
-      border: OutlineInputBorder(
-        borderRadius: KolabingRadius.borderRadiusSm,
-        borderSide: BorderSide(color: context.colors.darkBorder),
-      ),
-      enabledBorder: OutlineInputBorder(
-        borderRadius: KolabingRadius.borderRadiusSm,
-        borderSide: BorderSide(color: context.colors.darkBorder),
-      ),
-      focusedBorder: OutlineInputBorder(
-        borderRadius: KolabingRadius.borderRadiusSm,
-        borderSide: BorderSide(color: context.colors.borderFocus, width: 1.5),
-      ),
-      errorBorder: OutlineInputBorder(
-        borderRadius: KolabingRadius.borderRadiusSm,
-        borderSide: BorderSide(color: context.colors.borderError),
-      ),
-      focusedErrorBorder: OutlineInputBorder(
-        borderRadius: KolabingRadius.borderRadiusSm,
-        borderSide: BorderSide(color: context.colors.borderError, width: 1.5),
-      ),
-    );
+}) => InputDecoration(
+  hintText: hint,
+  hintStyle: KolabingTextStyles.bodySmall.copyWith(
+    color: context.colors.textTertiary,
+  ),
+  errorText: error,
+  errorStyle: KolabingTextStyles.bodySmall.copyWith(fontSize: 12),
+  filled: true,
+  fillColor: context.colors.surface,
+  contentPadding: const EdgeInsets.symmetric(
+    horizontal: KolabingSpacing.md,
+    vertical: 14,
+  ),
+  border: OutlineInputBorder(
+    borderRadius: KolabingRadius.borderRadiusSm,
+    borderSide: BorderSide(color: context.colors.darkBorder),
+  ),
+  enabledBorder: OutlineInputBorder(
+    borderRadius: KolabingRadius.borderRadiusSm,
+    borderSide: BorderSide(color: context.colors.darkBorder),
+  ),
+  focusedBorder: OutlineInputBorder(
+    borderRadius: KolabingRadius.borderRadiusSm,
+    borderSide: BorderSide(color: context.colors.borderFocus, width: 1.5),
+  ),
+  errorBorder: OutlineInputBorder(
+    borderRadius: KolabingRadius.borderRadiusSm,
+    borderSide: BorderSide(color: context.colors.borderError),
+  ),
+  focusedErrorBorder: OutlineInputBorder(
+    borderRadius: KolabingRadius.borderRadiusSm,
+    borderSide: BorderSide(color: context.colors.borderError, width: 1.5),
+  ),
+);
 
 TextStyle _inputTextStyle(BuildContext context) =>
     KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurface);
@@ -396,9 +420,13 @@ class _SectionHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Text(
-      label,
-      style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
-    );
+    label,
+    style: KolabingTextStyles.bodySmall.copyWith(
+      fontWeight: FontWeight.w700,
+      color: context.colors.onSurfaceVariant,
+      letterSpacing: 1.0,
+    ),
+  );
 }
 
 class _FieldLabel extends StatelessWidget {
@@ -407,7 +435,10 @@ class _FieldLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Text(
-      label,
-      style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w500, color: context.colors.onSurface),
-    );
+    label,
+    style: KolabingTextStyles.bodySmall.copyWith(
+      fontWeight: FontWeight.w500,
+      color: context.colors.onSurface,
+    ),
+  );
 }

--- a/lib/features/kolab/screens/business/review_screen.dart
+++ b/lib/features/kolab/screens/business/review_screen.dart
@@ -34,39 +34,55 @@ class ReviewScreen extends ConsumerWidget {
     final isVenue = formState.intentType == IntentType.venuePromotion;
 
     final sections = _sectionsFor(kolab, isVenue, notifier);
-    final missingCount = sections.where((s) => s.status == _Status.missing).length;
+    final missingCount = sections
+        .where((s) => s.status == _Status.missing)
+        .length;
     final readyToPublish = missingCount == 0;
 
     final goalLabel = kolab.goal == null
         ? null
-        : ref.watch(goalsProvider).maybeWhen(
-            data: (options) => options
-                .firstWhere(
-                  (o) => o.slug == kolab.goal,
-                  orElse: () => OfferOption(id: kolab.goal!, slug: kolab.goal!, name: kolab.goal!),
-                )
-                .name,
-            orElse: () => kolab.goal!,
-          );
+        : ref
+              .watch(goalsProvider)
+              .maybeWhen(
+                data: (options) => options
+                    .firstWhere(
+                      (o) => o.slug == kolab.goal,
+                      orElse: () => OfferOption(
+                        id: kolab.goal!,
+                        slug: kolab.goal!,
+                        name: kolab.goal!,
+                      ),
+                    )
+                    .name,
+                orElse: () => kolab.goal!,
+              );
     final highlightLabels = kolab.highlights.isEmpty
         ? const <String>[]
-        : ref.watch(kolabHighlightsProvider).maybeWhen(
-            data: (options) => kolab.highlights
-                .map((slug) => options
-                    .firstWhere(
-                      (o) => o.slug == slug,
-                      orElse: () => OfferOption(id: slug, slug: slug, name: slug),
+        : ref
+              .watch(kolabHighlightsProvider)
+              .maybeWhen(
+                data: (options) => kolab.highlights
+                    .map(
+                      (slug) => options
+                          .firstWhere(
+                            (o) => o.slug == slug,
+                            orElse: () =>
+                                OfferOption(id: slug, slug: slug, name: slug),
+                          )
+                          .name,
                     )
-                    .name)
-                .toList(),
-            orElse: () => kolab.highlights,
-          );
-    final deliverableOptions = ref.watch(deliverablesProvider).maybeWhen(
+                    .toList(),
+                orElse: () => kolab.highlights,
+              );
+    final deliverableOptions = ref
+        .watch(deliverablesProvider)
+        .maybeWhen(
           data: (options) => options,
           orElse: () => const <OfferOption>[],
         );
-    final expectLabels =
-        kolab.expects.map((slug) => deliverableLabel(slug, deliverableOptions)).toList();
+    final expectLabels = kolab.expects
+        .map((slug) => deliverableLabel(slug, deliverableOptions))
+        .toList();
 
     return ListView(
       padding: const EdgeInsets.fromLTRB(
@@ -87,23 +103,27 @@ class ReviewScreen extends ConsumerWidget {
         const SizedBox(height: KolabingSpacing.md),
 
         // Readiness status banner
-        _StatusBanner(
-          ready: readyToPublish,
-          missingCount: missingCount,
-        ),
+        _StatusBanner(ready: readyToPublish, missingCount: missingCount),
         const SizedBox(height: KolabingSpacing.lg),
 
         Text(
           'CHECKLIST',
-          style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: FontWeight.w700, color: context.colors.textTertiary, letterSpacing: 1.2),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontSize: 12,
+            fontWeight: FontWeight.w700,
+            color: context.colors.textTertiary,
+            letterSpacing: 1.2,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.sm),
 
         // Section checklist cards
-        ...sections.map((section) => Padding(
-              padding: const EdgeInsets.only(bottom: KolabingSpacing.sm),
-              child: _SectionCard(section: section),
-            )),
+        ...sections.map(
+          (section) => Padding(
+            padding: const EdgeInsets.only(bottom: KolabingSpacing.sm),
+            child: _SectionCard(section: section),
+          ),
+        ),
       ],
     );
   }
@@ -124,16 +144,16 @@ class ReviewScreen extends ConsumerWidget {
       // Step 0 only collects campaign copy; venue meta is inherited from the
       // business onboarding profile and is not editable here. Status is based
       // on the user-editable fields only — venue meta is shown for context.
-      final copyFilled =
-          kolab.title.isNotEmpty && kolab.description.isNotEmpty;
-      final hasVenueMeta = (kolab.venueName?.isNotEmpty ?? false) &&
+      final copyFilled = kolab.title.isNotEmpty && kolab.description.isNotEmpty;
+      final hasVenueMeta =
+          (kolab.venueName?.isNotEmpty ?? false) &&
           kolab.venueType != null &&
           (kolab.capacity ?? 0) > 0;
 
       final summary = copyFilled
           ? hasVenueMeta
-              ? '${kolab.venueName} • ${kolab.venueType?.displayName} • ${kolab.capacity} guests'
-              : kolab.title
+                ? '${kolab.venueName} • ${kolab.venueType?.displayName} • ${kolab.capacity} guests'
+                : kolab.title
           : 'Add a campaign title and description';
       final secondary = copyFilled && hasVenueMeta
           ? [
@@ -142,100 +162,123 @@ class ReviewScreen extends ConsumerWidget {
             ].join(', ')
           : null;
 
-      sections.add(_Section(
-        icon: LucideIcons.building2,
-        title: 'Campaign & Venue',
-        status: copyFilled ? _Status.complete : _Status.missing,
-        summary: summary,
-        secondary: secondary?.isNotEmpty == true ? secondary : null,
-        onTap: () => notifier.goToStep(0),
-      ));
+      sections.add(
+        _Section(
+          icon: LucideIcons.building2,
+          title: 'Campaign & Venue',
+          status: copyFilled ? _Status.complete : _Status.missing,
+          summary: summary,
+          secondary: secondary?.isNotEmpty == true ? secondary : null,
+          onTap: () => notifier.goToStep(0),
+        ),
+      );
     } else {
-      final fieldsFilled = kolab.title.isNotEmpty &&
+      final fieldsFilled =
+          kolab.title.isNotEmpty &&
           kolab.description.isNotEmpty &&
           (kolab.productName?.isNotEmpty ?? false) &&
           kolab.productType != null &&
           kolab.preferredCity.isNotEmpty;
 
-      sections.add(_Section(
-        icon: LucideIcons.package,
-        title: 'Product Details',
-        status: fieldsFilled ? _Status.complete : _Status.missing,
-        summary: fieldsFilled
-            ? '${kolab.productName} • ${kolab.productType?.displayName}'
-            : 'Tap to fill product details',
-        secondary: fieldsFilled ? kolab.preferredCity : null,
-        onTap: () => notifier.goToStep(0),
-      ));
+      sections.add(
+        _Section(
+          icon: LucideIcons.package,
+          title: 'Product Details',
+          status: fieldsFilled ? _Status.complete : _Status.missing,
+          summary: fieldsFilled
+              ? '${kolab.productName} • ${kolab.productType?.displayName}'
+              : 'Tap to fill product details',
+          secondary: fieldsFilled ? kolab.preferredCity : null,
+          onTap: () => notifier.goToStep(0),
+        ),
+      );
     }
 
     // Step 1 — Goal (optional)
-    sections.add(_Section(
-      icon: LucideIcons.target,
-      title: 'Goal',
-      status: kolab.goal != null ? _Status.complete : _Status.optional,
-      summary: kolab.goal ?? 'Optional — helps communities understand this Kolab',
-      onTap: () => notifier.goToStep(1),
-    ));
+    sections.add(
+      _Section(
+        icon: LucideIcons.target,
+        title: 'Goal',
+        status: kolab.goal != null ? _Status.complete : _Status.optional,
+        summary:
+            kolab.goal ?? 'Optional — helps communities understand this Kolab',
+        onTap: () => notifier.goToStep(1),
+      ),
+    );
 
     // Step 2 — Media
     final photoCount = kolab.media.where((m) => m.type == 'image').length;
-    sections.add(_Section(
-      icon: LucideIcons.image,
-      title: 'Media',
-      status: photoCount > 0 ? _Status.complete : _Status.missing,
-      summary: photoCount > 0
-          ? '$photoCount photo${photoCount == 1 ? '' : 's'} added'
-          : 'Add at least 1 photo',
-      onTap: () => notifier.goToStep(2),
-    ));
+    sections.add(
+      _Section(
+        icon: LucideIcons.image,
+        title: 'Media',
+        status: photoCount > 0 ? _Status.complete : _Status.missing,
+        summary: photoCount > 0
+            ? '$photoCount photo${photoCount == 1 ? '' : 's'} added'
+            : 'Add at least 1 photo',
+        onTap: () => notifier.goToStep(2),
+      ),
+    );
 
     // Step 3 — Offering
-    sections.add(_Section(
-      icon: LucideIcons.gift,
-      title: 'Offering',
-      status: kolab.offering.isNotEmpty ? _Status.complete : _Status.missing,
-      summary: kolab.offering.isNotEmpty
-          ? _formatOffering(kolab.offering)
-          : 'Pick what you offer',
-      onTap: () => notifier.goToStep(3),
-    ));
+    sections.add(
+      _Section(
+        icon: LucideIcons.gift,
+        title: 'Offering',
+        status: kolab.offering.isNotEmpty ? _Status.complete : _Status.missing,
+        summary: kolab.offering.isNotEmpty
+            ? _formatOffering(kolab.offering)
+            : 'Pick what you offer',
+        onTap: () => notifier.goToStep(3),
+      ),
+    );
 
     // Step 4 — Ideal community (optional)
-    final hasIdealCommunity = kolab.seekingCommunities.isNotEmpty ||
+    final hasIdealCommunity =
+        kolab.seekingCommunities.isNotEmpty ||
         kolab.minCommunitySize != null ||
         kolab.expects.isNotEmpty;
-    sections.add(_Section(
-      icon: LucideIcons.users,
-      title: 'Ideal Community',
-      status: hasIdealCommunity ? _Status.complete : _Status.optional,
-      summary: hasIdealCommunity
-          ? _summarizeIdealCommunity(kolab)
-          : 'Optional — leave open to all',
-      onTap: () => notifier.goToStep(4),
-    ));
+    sections.add(
+      _Section(
+        icon: LucideIcons.users,
+        title: 'Ideal Community',
+        status: hasIdealCommunity ? _Status.complete : _Status.optional,
+        summary: hasIdealCommunity
+            ? _summarizeIdealCommunity(kolab)
+            : 'Optional — leave open to all',
+        onTap: () => notifier.goToStep(4),
+      ),
+    );
 
     // Step 5 — Past events (optional)
-    sections.add(_Section(
-      icon: LucideIcons.history,
-      title: 'Past Kolabs',
-      status: kolab.pastEvents.isNotEmpty ? _Status.complete : _Status.optional,
-      summary: kolab.pastEvents.isNotEmpty
-          ? '${kolab.pastEvents.length} event${kolab.pastEvents.length == 1 ? '' : 's'} added'
-          : 'Optional — adds credibility',
-      onTap: () => notifier.goToStep(5),
-    ));
+    sections.add(
+      _Section(
+        icon: LucideIcons.history,
+        title: 'Past Kolabs',
+        status: kolab.pastEvents.isNotEmpty
+            ? _Status.complete
+            : _Status.optional,
+        summary: kolab.pastEvents.isNotEmpty
+            ? '${kolab.pastEvents.length} event${kolab.pastEvents.length == 1 ? '' : 's'} added'
+            : 'Optional — adds credibility',
+        onTap: () => notifier.goToStep(5),
+      ),
+    );
 
     // Step 6 — Availability
-    sections.add(_Section(
-      icon: LucideIcons.calendar,
-      title: 'Availability',
-      status: kolab.availabilityMode != null ? _Status.complete : _Status.missing,
-      summary: kolab.availabilityMode != null
-          ? _summarizeAvailability(kolab)
-          : 'Set when you are available',
-      onTap: () => notifier.goToStep(6),
-    ));
+    sections.add(
+      _Section(
+        icon: LucideIcons.calendar,
+        title: 'Availability',
+        status: kolab.availabilityMode != null
+            ? _Status.complete
+            : _Status.missing,
+        summary: kolab.availabilityMode != null
+            ? _summarizeAvailability(kolab)
+            : 'Set when you are available',
+        onTap: () => notifier.goToStep(6),
+      ),
+    );
 
     return sections;
   }
@@ -260,7 +303,11 @@ class ReviewScreen extends ConsumerWidget {
     final parts = <String>[];
     if (kolab.seekingCommunities.isNotEmpty) {
       final s = kolab.seekingCommunities;
-      parts.add(s.length <= 2 ? s.join(' • ') : '${s.take(2).join(' • ')} +${s.length - 2}');
+      parts.add(
+        s.length <= 2
+            ? s.join(' • ')
+            : '${s.take(2).join(' • ')} +${s.length - 2}',
+      );
     }
     if (kolab.minCommunitySize != null) {
       parts.add('Min ${kolab.minCommunitySize}+');
@@ -277,7 +324,9 @@ class ReviewScreen extends ConsumerWidget {
         '${fmt.format(kolab.availabilityStart!)} – ${DateFormat('MMM d, yyyy').format(kolab.availabilityEnd!)}',
       );
     } else if (kolab.availabilityStart != null) {
-      parts.add('From ${DateFormat('MMM d, yyyy').format(kolab.availabilityStart!)}');
+      parts.add(
+        'From ${DateFormat('MMM d, yyyy').format(kolab.availabilityStart!)}',
+      );
     }
     if (kolab.selectedTime != null) {
       parts.add(
@@ -314,11 +363,11 @@ class _PreviewCard extends StatelessWidget {
 
     final venueOrProductLabel = isVenue
         ? (kolab.venueName?.isNotEmpty ?? false)
-            ? kolab.venueName!
-            : kolab.title
+              ? kolab.venueName!
+              : kolab.title
         : (kolab.productName?.isNotEmpty ?? false)
-            ? kolab.productName!
-            : kolab.title;
+        ? kolab.productName!
+        : kolab.title;
     // Offer headline (H2) is the primary listing hook; fall back to the
     // venue/product name when not yet filled in.
     final headline = (kolab.offerHeadline?.isNotEmpty ?? false)
@@ -373,11 +422,18 @@ class _PreviewCard extends StatelessWidget {
                       decoration: BoxDecoration(
                         color: context.colors.softYellow,
                         borderRadius: BorderRadius.circular(999),
-                        border: Border.all(color: context.colors.softYellowBorder),
+                        border: Border.all(
+                          color: context.colors.softYellowBorder,
+                        ),
                       ),
                       child: Text(
                         isVenue ? 'VENUE PROMOTION' : 'PRODUCT PROMOTION',
-                        style: KolabingTextStyles.bodySmall.copyWith(fontSize: 10, fontWeight: FontWeight.w700, color: context.colors.accentOrangeText, letterSpacing: 1.0),
+                        style: KolabingTextStyles.bodySmall.copyWith(
+                          fontSize: 10,
+                          fontWeight: FontWeight.w700,
+                          color: context.colors.accentOrangeText,
+                          letterSpacing: 1.0,
+                        ),
                       ),
                     ),
                     if (goalLabel != null)
@@ -393,7 +449,12 @@ class _PreviewCard extends StatelessWidget {
                         ),
                         child: Text(
                           goalLabel!,
-                          style: KolabingTextStyles.bodySmall.copyWith(fontSize: 10, fontWeight: FontWeight.w700, color: context.colors.onSurface, letterSpacing: 0.5),
+                          style: KolabingTextStyles.bodySmall.copyWith(
+                            fontSize: 10,
+                            fontWeight: FontWeight.w700,
+                            color: context.colors.onSurface,
+                            letterSpacing: 0.5,
+                          ),
                         ),
                       ),
                   ],
@@ -405,14 +466,21 @@ class _PreviewCard extends StatelessWidget {
                   headline.isNotEmpty ? headline : 'Untitled kolab',
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
-                  style: KolabingTextStyles.bodyLarge.copyWith(fontSize: 20, fontWeight: FontWeight.w700, color: context.colors.onSurface, height: 1.2),
+                  style: KolabingTextStyles.bodyLarge.copyWith(
+                    fontSize: 20,
+                    fontWeight: FontWeight.w700,
+                    color: context.colors.onSurface,
+                    height: 1.2,
+                  ),
                 ),
 
                 if (subhead.isNotEmpty) ...[
                   const SizedBox(height: 4),
                   Text(
                     subhead,
-                    style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant),
+                    style: KolabingTextStyles.captionSecondary.copyWith(
+                      color: context.colors.onSurfaceVariant,
+                    ),
                   ),
                 ],
 
@@ -422,7 +490,10 @@ class _PreviewCard extends StatelessWidget {
                     kolab.description,
                     maxLines: 3,
                     overflow: TextOverflow.ellipsis,
-                    style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant, height: 1.5),
+                    style: KolabingTextStyles.bodySmall.copyWith(
+                      color: context.colors.onSurfaceVariant,
+                      height: 1.5,
+                    ),
                   ),
                 ],
 
@@ -438,7 +509,10 @@ class _PreviewCard extends StatelessWidget {
                       const SizedBox(width: 4),
                       Text(
                         kolab.preferredCity,
-                        style: KolabingTextStyles.captionSecondary.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurfaceVariant),
+                        style: KolabingTextStyles.captionSecondary.copyWith(
+                          fontWeight: FontWeight.w600,
+                          color: context.colors.onSurfaceVariant,
+                        ),
                       ),
                     ],
                   ),
@@ -452,7 +526,10 @@ class _PreviewCard extends StatelessWidget {
                     kolab.baseOffer!,
                     maxLines: 3,
                     overflow: TextOverflow.ellipsis,
-                    style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurface, height: 1.4),
+                    style: KolabingTextStyles.bodySmall.copyWith(
+                      color: context.colors.onSurface,
+                      height: 1.4,
+                    ),
                   ),
                 ],
 
@@ -465,7 +542,9 @@ class _PreviewCard extends StatelessWidget {
 
                 if (expectLabels.isNotEmpty) ...[
                   const SizedBox(height: KolabingSpacing.md),
-                  const _PreviewLabel(label: "WHAT WE'D LIKE FROM THE COMMUNITY"),
+                  const _PreviewLabel(
+                    label: "WHAT WE'D LIKE FROM THE COMMUNITY",
+                  ),
                   const SizedBox(height: 4),
                   _PreviewChipRow(labels: expectLabels),
                 ],
@@ -483,7 +562,9 @@ class _PreviewCard extends StatelessWidget {
                   const SizedBox(height: 4),
                   Text(
                     ReviewScreen._summarizeAvailability(kolab),
-                    style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurface),
+                    style: KolabingTextStyles.bodySmall.copyWith(
+                      color: context.colors.onSurface,
+                    ),
                   ),
                 ],
               ],
@@ -501,9 +582,14 @@ class _PreviewLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Text(
-        label,
-        style: KolabingTextStyles.bodySmall.copyWith(fontSize: 11, fontWeight: FontWeight.w700, color: context.colors.textTertiary, letterSpacing: 0.8),
-      );
+    label,
+    style: KolabingTextStyles.bodySmall.copyWith(
+      fontSize: 11,
+      fontWeight: FontWeight.w700,
+      color: context.colors.textTertiary,
+      letterSpacing: 0.8,
+    ),
+  );
 }
 
 class _PreviewChipRow extends StatelessWidget {
@@ -512,27 +598,30 @@ class _PreviewChipRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Wrap(
-        spacing: KolabingSpacing.xs,
-        runSpacing: KolabingSpacing.xs,
-        children: labels
-            .map(
-              (label) => Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: KolabingSpacing.sm,
-                  vertical: 4,
-                ),
-                decoration: BoxDecoration(
-                  color: context.colors.surfaceVariant,
-                  borderRadius: KolabingRadius.borderRadiusSm,
-                ),
-                child: Text(
-                  label,
-                  style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.onSurface),
-                ),
+    spacing: KolabingSpacing.xs,
+    runSpacing: KolabingSpacing.xs,
+    children: labels
+        .map(
+          (label) => Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: KolabingSpacing.sm,
+              vertical: 4,
+            ),
+            decoration: BoxDecoration(
+              color: context.colors.surfaceVariant,
+              borderRadius: KolabingRadius.borderRadiusSm,
+            ),
+            child: Text(
+              label,
+              style: KolabingTextStyles.bodySmall.copyWith(
+                fontSize: 12,
+                color: context.colors.onSurface,
               ),
-            )
-            .toList(),
-      );
+            ),
+          ),
+        )
+        .toList(),
+  );
 }
 
 class _CoverImage extends StatelessWidget {
@@ -569,15 +658,15 @@ class _CoverImage extends StatelessWidget {
   }
 
   Widget _placeholder(BuildContext context) => Container(
-        color: context.colors.surfaceVariant,
-        child: Center(
-          child: Icon(
-            LucideIcons.imageOff,
-            size: 28,
-            color: context.colors.textTertiary,
-          ),
-        ),
-      );
+    color: context.colors.surfaceVariant,
+    child: Center(
+      child: Icon(
+        LucideIcons.imageOff,
+        size: 28,
+        color: context.colors.textTertiary,
+      ),
+    ),
+  );
 }
 
 // =============================================================================
@@ -598,8 +687,9 @@ class _StatusBanner extends StatelessWidget {
     final border = ready
         ? context.colors.success.withValues(alpha: 0.4)
         : context.colors.warning.withValues(alpha: 0.4);
-    final iconColor =
-        ready ? context.colors.success : context.colors.accentOrangeText;
+    final iconColor = ready
+        ? context.colors.success
+        : context.colors.accentOrangeText;
     final icon = ready ? LucideIcons.checkCircle : LucideIcons.alertCircle;
     final title = ready
         ? 'Ready to publish'
@@ -626,12 +716,19 @@ class _StatusBanner extends StatelessWidget {
               children: [
                 Text(
                   title,
-                  style: KolabingTextStyles.bodyMedium.copyWith(fontSize: 15, fontWeight: FontWeight.w700, color: context.colors.onSurface),
+                  style: KolabingTextStyles.bodyMedium.copyWith(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                    color: context.colors.onSurface,
+                  ),
                 ),
                 const SizedBox(height: 2),
                 Text(
                   subtitle,
-                  style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant, height: 1.4),
+                  style: KolabingTextStyles.captionSecondary.copyWith(
+                    color: context.colors.onSurfaceVariant,
+                    height: 1.4,
+                  ),
                 ),
               ],
             ),
@@ -673,23 +770,24 @@ class _SectionCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ({Color bg, Color fg, IconData icon}) badge = switch (section.status) {
-      _Status.complete => (
-          bg: context.colors.success.withValues(alpha: 0.18),
-          fg: context.colors.success,
-          icon: LucideIcons.check,
-        ),
-      _Status.missing => (
-          bg: context.colors.error.withValues(alpha: 0.14),
-          fg: context.colors.error,
-          icon: LucideIcons.alertCircle,
-        ),
-      _Status.optional => (
-          bg: context.colors.surfaceVariant,
-          fg: context.colors.textTertiary,
-          icon: LucideIcons.minus,
-        ),
-    };
+    final ({Color bg, Color fg, IconData icon}) badge =
+        switch (section.status) {
+          _Status.complete => (
+            bg: context.colors.success.withValues(alpha: 0.18),
+            fg: context.colors.success,
+            icon: LucideIcons.check,
+          ),
+          _Status.missing => (
+            bg: context.colors.error.withValues(alpha: 0.14),
+            fg: context.colors.error,
+            icon: LucideIcons.alertCircle,
+          ),
+          _Status.optional => (
+            bg: context.colors.surfaceVariant,
+            fg: context.colors.textTertiary,
+            icon: LucideIcons.minus,
+          ),
+        };
 
     return Material(
       color: Colors.transparent,
@@ -736,7 +834,10 @@ class _SectionCard extends StatelessWidget {
                         const SizedBox(width: 6),
                         Text(
                           section.title,
-                          style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                          style: KolabingTextStyles.bodySmall.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: context.colors.onSurface,
+                          ),
                         ),
                       ],
                     ),
@@ -745,9 +846,12 @@ class _SectionCard extends StatelessWidget {
                       section.summary,
                       maxLines: 2,
                       overflow: TextOverflow.ellipsis,
-                      style: KolabingTextStyles.captionSecondary.copyWith(color: section.status == _Status.missing
+                      style: KolabingTextStyles.captionSecondary.copyWith(
+                        color: section.status == _Status.missing
                             ? context.colors.error
-                            : context.colors.onSurfaceVariant, height: 1.4),
+                            : context.colors.onSurfaceVariant,
+                        height: 1.4,
+                      ),
                     ),
                     if (section.secondary != null) ...[
                       const SizedBox(height: 2),
@@ -755,7 +859,10 @@ class _SectionCard extends StatelessWidget {
                         section.secondary!,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.textTertiary),
+                        style: KolabingTextStyles.bodySmall.copyWith(
+                          fontSize: 12,
+                          color: context.colors.textTertiary,
+                        ),
                       ),
                     ],
                   ],

--- a/lib/features/kolab/screens/business/venue_details_screen.dart
+++ b/lib/features/kolab/screens/business/venue_details_screen.dart
@@ -73,7 +73,8 @@ class _VenueDetailsScreenState extends ConsumerState<VenueDetailsScreen> {
     _syncControllers();
 
     final l10n = AppLocalizations.of(context);
-    final hasVenueProfile = kolab.venueName != null &&
+    final hasVenueProfile =
+        kolab.venueName != null &&
         kolab.venueName!.isNotEmpty &&
         kolab.venueType != null &&
         kolab.capacity != null &&
@@ -118,18 +119,23 @@ class _VenueDetailsScreenState extends ConsumerState<VenueDetailsScreen> {
           onTapOutside: (_) => FocusScope.of(context).unfocus(),
         ),
         const SizedBox(height: KolabingSpacing.xs),
-        const KolabExamplesBox(examples: [
-          'A cozy café for post-run coffee and brunch.',
-          'A wellness studio for yoga, pilates, or community workshops.',
-          'A concept store for creative meetups, try-ons, or content days.',
-        ]),
+        const KolabExamplesBox(
+          examples: [
+            'A cozy café for post-run coffee and brunch.',
+            'A wellness studio for yoga, pilates, or community workshops.',
+            'A concept store for creative meetups, try-ons, or content days.',
+          ],
+        ),
         const SizedBox(height: KolabingSpacing.md),
         // H2: short, one-line offer headline shown on the discovery card.
         _FieldLabel(label: l10n.venueDetailsOfferHeadlineLabel),
         const SizedBox(height: KolabingSpacing.xxs),
         Text(
           l10n.venueDetailsOfferHeadlineHelper,
-          style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.onSurfaceVariant),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontSize: 12,
+            color: context.colors.onSurfaceVariant,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.xs),
         KolabingInput(
@@ -143,29 +149,31 @@ class _VenueDetailsScreenState extends ConsumerState<VenueDetailsScreen> {
         const SizedBox(height: KolabingSpacing.lg),
         const _FieldLabel(label: 'BEST FOR:'),
         const SizedBox(height: KolabingSpacing.xs),
-        Builder(builder: (context) {
-          final venueFitsAsync = ref.watch(venueFitsProvider);
-          final options = venueFitsAsync.when(
-            data: (options) => options,
-            loading: () => const <OfferOption>[],
-            error: (_, _) => const <OfferOption>[],
-          );
-          return MultiSelectChips<OfferOption>(
-            items: options,
-            selected: _selectedVenueFits,
-            labelBuilder: (o) => o.name,
-            onToggle: (option) {
-              setState(() {
-                if (_selectedVenueFits.contains(option)) {
-                  _selectedVenueFits.remove(option);
-                } else {
-                  _selectedVenueFits.add(option);
-                }
-              });
-              _appendVenueFitsToDescription(notifier, kolab);
-            },
-          );
-        }),
+        Builder(
+          builder: (context) {
+            final venueFitsAsync = ref.watch(venueFitsProvider);
+            final options = venueFitsAsync.when(
+              data: (options) => options,
+              loading: () => const <OfferOption>[],
+              error: (_, _) => const <OfferOption>[],
+            );
+            return MultiSelectChips<OfferOption>(
+              items: options,
+              selected: _selectedVenueFits,
+              labelBuilder: (o) => o.name,
+              onToggle: (option) {
+                setState(() {
+                  if (_selectedVenueFits.contains(option)) {
+                    _selectedVenueFits.remove(option);
+                  } else {
+                    _selectedVenueFits.add(option);
+                  }
+                });
+                _appendVenueFitsToDescription(notifier, kolab);
+              },
+            );
+          },
+        ),
       ],
     );
   }
@@ -180,37 +188,42 @@ class _VenueSummaryCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     return Container(
-        padding: const EdgeInsets.all(KolabingSpacing.md),
-        decoration: BoxDecoration(
-          color: context.colors.softYellow,
-          borderRadius: KolabingRadius.borderRadiusMd,
-          border: Border.all(color: context.colors.softYellowBorder),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              l10n.venueDetailsPrimaryVenue,
-              style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: FontWeight.w700, color: context.colors.primaryDark, letterSpacing: 0.8),
+      padding: const EdgeInsets.all(KolabingSpacing.md),
+      decoration: BoxDecoration(
+        color: context.colors.softYellow,
+        borderRadius: KolabingRadius.borderRadiusMd,
+        border: Border.all(color: context.colors.softYellowBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            l10n.venueDetailsPrimaryVenue,
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              color: context.colors.primaryDark,
+              letterSpacing: 0.8,
             ),
-            const SizedBox(height: KolabingSpacing.sm),
-            _SummaryRow(
-              icon: LucideIcons.building2,
-              title: kolab.venueName ?? '--',
-              subtitle: l10n.venueDetailsTypeCapacity(
-                kolab.venueType?.displayName ?? l10n.venueDetailsVenueFallback,
-                (kolab.capacity ?? '--').toString(),
-              ),
+          ),
+          const SizedBox(height: KolabingSpacing.sm),
+          _SummaryRow(
+            icon: LucideIcons.building2,
+            title: kolab.venueName ?? '--',
+            subtitle: l10n.venueDetailsTypeCapacity(
+              kolab.venueType?.displayName ?? l10n.venueDetailsVenueFallback,
+              (kolab.capacity ?? '--').toString(),
             ),
-            const SizedBox(height: KolabingSpacing.xs),
-            _SummaryRow(
-              icon: LucideIcons.mapPin,
-              title: kolab.venueAddress ?? '--',
-              subtitle: kolab.preferredCity,
-            ),
-          ],
-        ),
-      );
+          ),
+          const SizedBox(height: KolabingSpacing.xs),
+          _SummaryRow(
+            icon: LucideIcons.mapPin,
+            title: kolab.venueAddress ?? '--',
+            subtitle: kolab.preferredCity,
+          ),
+        ],
+      ),
+    );
   }
 }
 
@@ -227,28 +240,33 @@ class _SummaryRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Icon(icon, size: 18, color: context.colors.primaryDark),
-          const SizedBox(width: KolabingSpacing.sm),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  title,
-                  style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurface),
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  subtitle,
-                  style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant),
-                ),
-              ],
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Icon(icon, size: 18, color: context.colors.primaryDark),
+      const SizedBox(width: KolabingSpacing.sm),
+      Expanded(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: KolabingTextStyles.bodySmall.copyWith(
+                fontWeight: FontWeight.w700,
+                color: context.colors.onSurface,
+              ),
             ),
-          ),
-        ],
-      );
+            const SizedBox(height: 2),
+            Text(
+              subtitle,
+              style: KolabingTextStyles.captionSecondary.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    ],
+  );
 }
 
 class _SectionHeader extends StatelessWidget {
@@ -258,9 +276,13 @@ class _SectionHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Text(
-        label,
-        style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1),
-      );
+    label,
+    style: KolabingTextStyles.bodySmall.copyWith(
+      fontWeight: FontWeight.w700,
+      color: context.colors.onSurfaceVariant,
+      letterSpacing: 1,
+    ),
+  );
 }
 
 class _FieldLabel extends StatelessWidget {
@@ -270,7 +292,10 @@ class _FieldLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Text(
-        label,
-        style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurface),
-      );
+    label,
+    style: KolabingTextStyles.bodySmall.copyWith(
+      fontWeight: FontWeight.w700,
+      color: context.colors.onSurface,
+    ),
+  );
 }

--- a/lib/features/kolab/screens/community/community_info_screen.dart
+++ b/lib/features/kolab/screens/community/community_info_screen.dart
@@ -85,11 +85,11 @@ class _CommunityInfoScreenState extends ConsumerState<CommunityInfoScreen> {
   }
 
   Widget _buildLabel(String label) => Text(
-        label,
-        style: KolabingTextStyles.bodySmall.copyWith(
-          fontWeight: FontWeight.w700,
-          color: context.colors.onSurfaceVariant,
-          letterSpacing: 1.0,
-        ),
-      );
+    label,
+    style: KolabingTextStyles.bodySmall.copyWith(
+      fontWeight: FontWeight.w700,
+      color: context.colors.onSurfaceVariant,
+      letterSpacing: 1.0,
+    ),
+  );
 }

--- a/lib/features/kolab/screens/community/event_details_screen.dart
+++ b/lib/features/kolab/screens/community/event_details_screen.dart
@@ -27,8 +27,7 @@ class EventDetailsScreen extends ConsumerStatefulWidget {
   const EventDetailsScreen({super.key});
 
   @override
-  ConsumerState<EventDetailsScreen> createState() =>
-      _EventDetailsScreenState();
+  ConsumerState<EventDetailsScreen> createState() => _EventDetailsScreenState();
 }
 
 class _EventDetailsScreenState extends ConsumerState<EventDetailsScreen> {
@@ -84,12 +83,18 @@ class _EventDetailsScreenState extends ConsumerState<EventDetailsScreen> {
           // Section header
           Text(
             l10n.eventDetailsHeader,
-            style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontWeight: FontWeight.w700,
+              color: context.colors.onSurfaceVariant,
+              letterSpacing: 1.0,
+            ),
           ),
           const SizedBox(height: KolabingSpacing.xxs),
           Text(
             l10n.eventDetailsSubtitle,
-            style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              color: context.colors.onSurfaceVariant,
+            ),
           ),
           const SizedBox(height: KolabingSpacing.lg),
 
@@ -128,7 +133,11 @@ class _EventDetailsScreenState extends ConsumerState<EventDetailsScreen> {
           // "What you offer in return" section header
           Text(
             l10n.eventDetailsOffersHeader,
-            style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontWeight: FontWeight.w700,
+              color: context.colors.onSurfaceVariant,
+              letterSpacing: 1.0,
+            ),
           ),
           if (state.fieldErrors['offers_in_return'] != null) ...[
             const SizedBox(height: KolabingSpacing.sm),
@@ -204,12 +213,19 @@ class _EventDetailsScreenState extends ConsumerState<EventDetailsScreen> {
                           children: [
                             Text(
                               label,
-                              style: KolabingTextStyles.bodySmall.copyWith(fontSize: 15, fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                              style: KolabingTextStyles.bodySmall.copyWith(
+                                fontSize: 15,
+                                fontWeight: FontWeight.w600,
+                                color: context.colors.onSurface,
+                              ),
                             ),
                             const SizedBox(height: 2),
                             Text(
                               subtitle,
-                              style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.onSurfaceVariant),
+                              style: KolabingTextStyles.bodySmall.copyWith(
+                                fontSize: 12,
+                                color: context.colors.onSurfaceVariant,
+                              ),
                             ),
                           ],
                         ),
@@ -232,34 +248,36 @@ class _EventDetailsScreenState extends ConsumerState<EventDetailsScreen> {
   }
 
   Widget _buildLabel(String label) => Text(
-        label,
-        style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurface),
-      );
+    label,
+    style: KolabingTextStyles.bodySmall.copyWith(
+      fontWeight: FontWeight.w600,
+      color: context.colors.onSurface,
+    ),
+  );
 
   Widget _buildFieldError(String error) => Container(
-        padding: const EdgeInsets.symmetric(
-          horizontal: KolabingSpacing.sm,
-          vertical: KolabingSpacing.xs,
-        ),
-        decoration: BoxDecoration(
-          color: context.colors.errorBg,
-          borderRadius: KolabingRadius.borderRadiusSm,
-        ),
-        child: Row(
-          children: [
-            Icon(
-              Icons.error_outline,
-              size: 14,
+    padding: const EdgeInsets.symmetric(
+      horizontal: KolabingSpacing.sm,
+      vertical: KolabingSpacing.xs,
+    ),
+    decoration: BoxDecoration(
+      color: context.colors.errorBg,
+      borderRadius: KolabingRadius.borderRadiusSm,
+    ),
+    child: Row(
+      children: [
+        Icon(Icons.error_outline, size: 14, color: context.colors.error),
+        const SizedBox(width: KolabingSpacing.xs),
+        Expanded(
+          child: Text(
+            error,
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontSize: 12,
               color: context.colors.error,
             ),
-            const SizedBox(width: KolabingSpacing.xs),
-            Expanded(
-              child: Text(
-                error,
-                style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.error),
-              ),
-            ),
-          ],
+          ),
         ),
-      );
+      ],
+    ),
+  );
 }

--- a/lib/features/kolab/screens/community/logistics_screen.dart
+++ b/lib/features/kolab/screens/community/logistics_screen.dart
@@ -116,7 +116,9 @@ class _LogisticsScreenState extends ConsumerState<LogisticsScreen> {
           const SizedBox(height: KolabingSpacing.xxs),
           Text(
             l10n.logisticsAvailabilitySubtitle,
-            style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              color: context.colors.onSurfaceVariant,
+            ),
           ),
 
           if (state.fieldErrors['availability_mode'] != null) ...[
@@ -132,26 +134,27 @@ class _LogisticsScreenState extends ConsumerState<LogisticsScreen> {
             children: AvailabilityMode.values
                 .where((mode) => mode != AvailabilityMode.immediate)
                 .map((mode) {
-              final isSelected = kolab.availabilityMode == mode;
-              return Expanded(
-                child: Padding(
-                  padding: EdgeInsets.only(
-                    right: mode != AvailabilityMode.recurring
-                        ? KolabingSpacing.xs
-                        : 0,
-                  ),
-                  child: _buildSelectionCard(
-                    icon: _availabilityModeIcon(mode),
-                    title: mode.displayName,
-                    description: mode.description,
-                    isSelected: isSelected,
-                    onTap: () => ref
-                        .read(kolabFormProvider.notifier)
-                        .updateAvailabilityMode(mode),
-                  ),
-                ),
-              );
-            }).toList(),
+                  final isSelected = kolab.availabilityMode == mode;
+                  return Expanded(
+                    child: Padding(
+                      padding: EdgeInsets.only(
+                        right: mode != AvailabilityMode.recurring
+                            ? KolabingSpacing.xs
+                            : 0,
+                      ),
+                      child: _buildSelectionCard(
+                        icon: _availabilityModeIcon(mode),
+                        title: mode.displayName,
+                        description: mode.description,
+                        isSelected: isSelected,
+                        onTap: () => ref
+                            .read(kolabFormProvider.notifier)
+                            .updateAvailabilityMode(mode),
+                      ),
+                    ),
+                  );
+                })
+                .toList(),
           ),
 
           const SizedBox(height: KolabingSpacing.lg),
@@ -288,13 +291,19 @@ class _LogisticsScreenState extends ConsumerState<LogisticsScreen> {
                   ),
                   title: Text(
                     items[i].title,
-                    style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                    style: KolabingTextStyles.bodySmall.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: context.colors.onSurface,
+                    ),
                   ),
                   subtitle: Text(
                     items[i].formattedAddress,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.onSurfaceVariant),
+                    style: KolabingTextStyles.bodySmall.copyWith(
+                      fontSize: 12,
+                      color: context.colors.onSurfaceVariant,
+                    ),
                   ),
                   onTap: () => _selectAreaSuggestion(items[i]),
                 ),
@@ -404,9 +413,13 @@ class _LogisticsScreenState extends ConsumerState<LogisticsScreen> {
                 ),
                 child: Text(
                   _dayNames[i].substring(0, 3),
-                  style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: isSelected ? FontWeight.w700 : FontWeight.w400, color: isSelected
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    fontSize: 12,
+                    fontWeight: isSelected ? FontWeight.w700 : FontWeight.w400,
+                    color: isSelected
                         ? context.colors.onSurface
-                        : context.colors.onSurfaceVariant),
+                        : context.colors.onSurfaceVariant,
+                  ),
                 ),
               ),
             ),
@@ -443,7 +456,9 @@ class _LogisticsScreenState extends ConsumerState<LogisticsScreen> {
         color: isSelected ? context.colors.softYellow : context.colors.surface,
         borderRadius: KolabingRadius.borderRadiusMd,
         border: Border.all(
-          color: isSelected ? context.colors.primary : context.colors.darkBorder,
+          color: isSelected
+              ? context.colors.primary
+              : context.colors.darkBorder,
           width: isSelected ? 2 : 1,
         ),
       ),
@@ -459,13 +474,20 @@ class _LogisticsScreenState extends ConsumerState<LogisticsScreen> {
           const SizedBox(height: KolabingSpacing.xxs),
           Text(
             title,
-            style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: FontWeight.w600, color: context.colors.onSurface),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: context.colors.onSurface,
+            ),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 2),
           Text(
             description,
-            style: KolabingTextStyles.labelSmall.copyWith(fontSize: 10, color: context.colors.textTertiary),
+            style: KolabingTextStyles.labelSmall.copyWith(
+              fontSize: 10,
+              color: context.colors.textTertiary,
+            ),
             textAlign: TextAlign.center,
             maxLines: 2,
             overflow: TextOverflow.ellipsis,
@@ -549,9 +571,11 @@ class _LogisticsScreenState extends ConsumerState<LogisticsScreen> {
                     value != null
                         ? dateFormat.format(value)
                         : AppLocalizations.of(context).logisticsSelectDate,
-                    style: KolabingTextStyles.bodySmall.copyWith(color: value != null
+                    style: KolabingTextStyles.bodySmall.copyWith(
+                      color: value != null
                           ? context.colors.onSurface
-                          : context.colors.textTertiary),
+                          : context.colors.textTertiary,
+                    ),
                   ),
                 ),
               ],
@@ -562,7 +586,10 @@ class _LogisticsScreenState extends ConsumerState<LogisticsScreen> {
           const SizedBox(height: 4),
           Text(
             error,
-            style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.error),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontSize: 12,
+              color: context.colors.error,
+            ),
           ),
         ],
       ],
@@ -615,9 +642,11 @@ class _LogisticsScreenState extends ConsumerState<LogisticsScreen> {
                 value != null
                     ? value.format(context)
                     : AppLocalizations.of(context).logisticsSelectTime,
-                style: KolabingTextStyles.bodySmall.copyWith(color: value != null
+                style: KolabingTextStyles.bodySmall.copyWith(
+                  color: value != null
                       ? context.colors.onSurface
-                      : context.colors.textTertiary),
+                      : context.colors.textTertiary,
+                ),
               ),
             ],
           ),
@@ -627,7 +656,10 @@ class _LogisticsScreenState extends ConsumerState<LogisticsScreen> {
         const SizedBox(height: 4),
         Text(
           error,
-          style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.error),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontSize: 12,
+            color: context.colors.error,
+          ),
         ),
       ],
     ],
@@ -635,7 +667,9 @@ class _LogisticsScreenState extends ConsumerState<LogisticsScreen> {
 
   InputDecoration _inputDecoration({required String hint}) => InputDecoration(
     hintText: hint,
-    hintStyle: KolabingTextStyles.bodyMedium.copyWith(color: context.colors.textTertiary),
+    hintStyle: KolabingTextStyles.bodyMedium.copyWith(
+      color: context.colors.textTertiary,
+    ),
     filled: true,
     fillColor: context.colors.surface,
     border: OutlineInputBorder(
@@ -654,12 +688,19 @@ class _LogisticsScreenState extends ConsumerState<LogisticsScreen> {
 
   Widget _buildSectionHeader(String title) => Text(
     title,
-    style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
+    style: KolabingTextStyles.bodySmall.copyWith(
+      fontWeight: FontWeight.w700,
+      color: context.colors.onSurfaceVariant,
+      letterSpacing: 1.0,
+    ),
   );
 
   Widget _buildLabel(String label) => Text(
     label,
-    style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurface),
+    style: KolabingTextStyles.bodySmall.copyWith(
+      fontWeight: FontWeight.w600,
+      color: context.colors.onSurface,
+    ),
   );
 
   Widget _buildFieldError(String error) => Container(
@@ -678,7 +719,10 @@ class _LogisticsScreenState extends ConsumerState<LogisticsScreen> {
         Expanded(
           child: Text(
             error,
-            style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.error),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontSize: 12,
+              color: context.colors.error,
+            ),
           ),
         ),
       ],

--- a/lib/features/kolab/screens/community/photo_screen.dart
+++ b/lib/features/kolab/screens/community/photo_screen.dart
@@ -167,12 +167,18 @@ class _PhotoScreenState extends ConsumerState<PhotoScreen> {
           // Section header
           Text(
             l10n.photoAddHeader,
-            style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontWeight: FontWeight.w700,
+              color: context.colors.onSurfaceVariant,
+              letterSpacing: 1.0,
+            ),
           ),
           const SizedBox(height: KolabingSpacing.xxs),
           Text(
             l10n.photoAddSubtitle,
-            style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              color: context.colors.onSurfaceVariant,
+            ),
           ),
 
           const SizedBox(height: KolabingSpacing.lg),
@@ -228,7 +234,11 @@ class _PhotoScreenState extends ConsumerState<PhotoScreen> {
                   Expanded(
                     child: Text(
                       l10n.photoUseProfilePhoto,
-                      style: KolabingTextStyles.bodySmall.copyWith(fontSize: 15, fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                      style: KolabingTextStyles.bodySmall.copyWith(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
+                        color: context.colors.onSurface,
+                      ),
                     ),
                   ),
                 ],
@@ -248,7 +258,11 @@ class _PhotoScreenState extends ConsumerState<PhotoScreen> {
                 ),
                 child: Text(
                   l10n.photoDividerOr,
-                  style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: FontWeight.w600, color: context.colors.textTertiary),
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: context.colors.textTertiary,
+                  ),
                 ),
               ),
               Expanded(child: Divider(color: context.colors.darkBorder)),
@@ -281,7 +295,10 @@ class _PhotoScreenState extends ConsumerState<PhotoScreen> {
                 decoration: BoxDecoration(
                   color: context.colors.surface,
                   borderRadius: KolabingRadius.borderRadiusMd,
-                  border: Border.all(color: context.colors.darkBorder, width: 1),
+                  border: Border.all(
+                    color: context.colors.darkBorder,
+                    width: 1,
+                  ),
                 ),
                 child: CustomPaint(
                   painter: _DashedBorderPainter(
@@ -306,12 +323,19 @@ class _PhotoScreenState extends ConsumerState<PhotoScreen> {
                       const SizedBox(height: KolabingSpacing.sm),
                       Text(
                         l10n.photoUploadTitle,
-                        style: KolabingTextStyles.bodySmall.copyWith(fontSize: 15, fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                        style: KolabingTextStyles.bodySmall.copyWith(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                          color: context.colors.onSurface,
+                        ),
                       ),
                       const SizedBox(height: KolabingSpacing.xxs),
                       Text(
                         l10n.photoUploadMaxSize,
-                        style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.textTertiary),
+                        style: KolabingTextStyles.bodySmall.copyWith(
+                          fontSize: 12,
+                          color: context.colors.textTertiary,
+                        ),
                       ),
                     ],
                   ),
@@ -353,70 +377,76 @@ class _UploadedPhotoCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     return Container(
-    width: double.infinity,
-    padding: const EdgeInsets.all(KolabingSpacing.sm),
-    decoration: BoxDecoration(
-      color: context.colors.surface,
-      borderRadius: KolabingRadius.borderRadiusMd,
-      border: Border.all(color: context.colors.primary, width: 1.5),
-    ),
-    child: Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        ClipRRect(
-          borderRadius: KolabingRadius.borderRadiusMd,
-          child: AspectRatio(
-            aspectRatio: 16 / 10,
-            child: _isLocalFile
-                ? Image.file(File(photo.url), fit: BoxFit.cover)
-                : Image.network(
-                    photo.url,
-                    fit: BoxFit.cover,
-                    errorBuilder: (context, error, stackTrace) => Container(
-                      color: context.colors.surfaceVariant,
-                      alignment: Alignment.center,
-                      child: Icon(
-                        LucideIcons.imageOff,
-                        color: context.colors.textTertiary,
-                        size: 28,
+      width: double.infinity,
+      padding: const EdgeInsets.all(KolabingSpacing.sm),
+      decoration: BoxDecoration(
+        color: context.colors.surface,
+        borderRadius: KolabingRadius.borderRadiusMd,
+        border: Border.all(color: context.colors.primary, width: 1.5),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ClipRRect(
+            borderRadius: KolabingRadius.borderRadiusMd,
+            child: AspectRatio(
+              aspectRatio: 16 / 10,
+              child: _isLocalFile
+                  ? Image.file(File(photo.url), fit: BoxFit.cover)
+                  : Image.network(
+                      photo.url,
+                      fit: BoxFit.cover,
+                      errorBuilder: (context, error, stackTrace) => Container(
+                        color: context.colors.surfaceVariant,
+                        alignment: Alignment.center,
+                        child: Icon(
+                          LucideIcons.imageOff,
+                          color: context.colors.textTertiary,
+                          size: 28,
+                        ),
                       ),
                     ),
-                  ),
+            ),
           ),
-        ),
-        const SizedBox(height: KolabingSpacing.sm),
-        Text(
-          l10n.photoUploadedSelectedTitle,
-          style: KolabingTextStyles.bodySmall.copyWith(fontSize: 15, fontWeight: FontWeight.w700, color: context.colors.onSurface),
-        ),
-        const SizedBox(height: KolabingSpacing.xxs),
-        Text(
-          l10n.photoUploadedSelectedSubtitle,
-          style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant),
-        ),
-        const SizedBox(height: KolabingSpacing.sm),
-        Row(
-          children: [
-            Expanded(
-              child: OutlinedButton(
-                onPressed: isUploading ? null : onRemove,
-                child: Text(l10n.photoUseProfilePhotoButton),
-              ),
+          const SizedBox(height: KolabingSpacing.sm),
+          Text(
+            l10n.photoUploadedSelectedTitle,
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+              color: context.colors.onSurface,
             ),
-            const SizedBox(width: KolabingSpacing.sm),
-            Expanded(
-              child: KolabingButton(
-                label: l10n.photoReplacePhotoButton,
-                onPressed: isUploading ? null : onReplace,
-                variant: KolabingButtonVariant.primary,
-                size: KolabingButtonSize.compact,
-              ),
+          ),
+          const SizedBox(height: KolabingSpacing.xxs),
+          Text(
+            l10n.photoUploadedSelectedSubtitle,
+            style: KolabingTextStyles.captionSecondary.copyWith(
+              color: context.colors.onSurfaceVariant,
             ),
-          ],
-        ),
-      ],
-    ),
-  );
+          ),
+          const SizedBox(height: KolabingSpacing.sm),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: isUploading ? null : onRemove,
+                  child: Text(l10n.photoUseProfilePhotoButton),
+                ),
+              ),
+              const SizedBox(width: KolabingSpacing.sm),
+              Expanded(
+                child: KolabingButton(
+                  label: l10n.photoReplacePhotoButton,
+                  onPressed: isUploading ? null : onReplace,
+                  variant: KolabingButtonVariant.primary,
+                  size: KolabingButtonSize.compact,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/lib/features/kolab/screens/community/review_screen.dart
+++ b/lib/features/kolab/screens/community/review_screen.dart
@@ -35,7 +35,9 @@ class ReviewScreen extends ConsumerWidget {
     final state = ref.watch(kolabFormProvider);
     final kolab = state.kolab;
     final dateFormat = DateFormat('MMM d, yyyy');
-    final deliverableOptions = ref.watch(deliverablesProvider).maybeWhen(
+    final deliverableOptions = ref
+        .watch(deliverablesProvider)
+        .maybeWhen(
           data: (options) => options,
           orElse: () => const <OfferOption>[],
         );
@@ -48,12 +50,18 @@ class ReviewScreen extends ConsumerWidget {
           // Section header
           Text(
             'REVIEW & PUBLISH',
-            style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontWeight: FontWeight.w700,
+              color: context.colors.onSurfaceVariant,
+              letterSpacing: 1.0,
+            ),
           ),
           const SizedBox(height: KolabingSpacing.xxs),
           Text(
             'Make sure everything looks correct before publishing',
-            style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              color: context.colors.onSurfaceVariant,
+            ),
           ),
           const SizedBox(height: KolabingSpacing.lg),
 
@@ -81,14 +89,21 @@ class ReviewScreen extends ConsumerWidget {
                     children: [
                       Text(
                         kolab.title.isEmpty ? 'Untitled Kolab' : kolab.title,
-                        style: KolabingTextStyles.bodyMedium.copyWith(fontSize: 18, fontWeight: FontWeight.w700, color: context.colors.onSurface),
+                        style: KolabingTextStyles.bodyMedium.copyWith(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w700,
+                          color: context.colors.onSurface,
+                        ),
                       ),
                       const SizedBox(height: KolabingSpacing.xs),
                       Text(
                         kolab.description.isEmpty
                             ? 'No description provided'
                             : kolab.description,
-                        style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant, height: 1.5),
+                        style: KolabingTextStyles.bodySmall.copyWith(
+                          color: context.colors.onSurfaceVariant,
+                          height: 1.5,
+                        ),
                         maxLines: 4,
                         overflow: TextOverflow.ellipsis,
                       ),
@@ -112,14 +127,18 @@ class ReviewScreen extends ConsumerWidget {
                       if (kolab.needs.isEmpty)
                         Text(
                           'No needs selected',
-                          style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.textTertiary),
+                          style: KolabingTextStyles.captionSecondary.copyWith(
+                            color: context.colors.textTertiary,
+                          ),
                         )
                       else
                         Wrap(
                           spacing: KolabingSpacing.xs,
                           runSpacing: KolabingSpacing.xs,
                           children: kolab.needs
-                              .map((need) => _buildChip(context, need.displayName))
+                              .map(
+                                (need) => _buildChip(context, need.displayName),
+                              )
                               .toList(),
                         ),
                     ],
@@ -142,17 +161,21 @@ class ReviewScreen extends ConsumerWidget {
                       if (kolab.offersInReturn.isEmpty)
                         Text(
                           'No deliverables selected',
-                          style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.textTertiary),
+                          style: KolabingTextStyles.captionSecondary.copyWith(
+                            color: context.colors.textTertiary,
+                          ),
                         )
                       else
                         Wrap(
                           spacing: KolabingSpacing.xs,
                           runSpacing: KolabingSpacing.xs,
                           children: kolab.offersInReturn
-                              .map((slug) => _buildChip(
-                                    context,
-                                    deliverableLabel(slug, deliverableOptions),
-                                  ))
+                              .map(
+                                (slug) => _buildChip(
+                                  context,
+                                  deliverableLabel(slug, deliverableOptions),
+                                ),
+                              )
                               .toList(),
                         ),
                     ],
@@ -220,7 +243,7 @@ class ReviewScreen extends ConsumerWidget {
                       if (kolab.area != null && kolab.area!.isNotEmpty) ...[
                         const SizedBox(height: KolabingSpacing.xxs),
                         _buildReviewInfoRow(
-                        context,
+                          context,
                           LucideIcons.navigation,
                           kolab.area!,
                         ),
@@ -244,7 +267,7 @@ class ReviewScreen extends ConsumerWidget {
                       const SizedBox(height: KolabingSpacing.xs),
                       if (kolab.availabilityMode != null) ...[
                         _buildReviewInfoRow(
-                        context,
+                          context,
                           _availabilityModeIcon(kolab.availabilityMode!),
                           kolab.availabilityMode!.displayName,
                         ),
@@ -252,14 +275,14 @@ class ReviewScreen extends ConsumerWidget {
                         if (kolab.availabilityMode ==
                             AvailabilityMode.recurring) ...[
                           _buildReviewInfoRow(
-                        context,
+                            context,
                             LucideIcons.calendar,
                             'Every ${kolab.recurringDays.isNotEmpty ? kolab.recurringDays.map((d) => _dayNames[d - 1]).join(', ') : '--'}'
                             '${kolab.selectedTime != null ? ' at ${kolab.selectedTime!.format(context)}' : ''}',
                           ),
                         ] else ...[
                           _buildReviewInfoRow(
-                        context,
+                            context,
                             LucideIcons.calendar,
                             '${kolab.availabilityStart != null ? dateFormat.format(kolab.availabilityStart!) : '--'}'
                             ' -- '
@@ -270,7 +293,9 @@ class ReviewScreen extends ConsumerWidget {
                       ] else
                         Text(
                           'Not set',
-                          style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.textTertiary),
+                          style: KolabingTextStyles.captionSecondary.copyWith(
+                            color: context.colors.textTertiary,
+                          ),
                         ),
                     ],
                   ),
@@ -285,7 +310,10 @@ class ReviewScreen extends ConsumerWidget {
           Center(
             child: Text(
               'Tap any section above to edit',
-              style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.textTertiary, fontStyle: FontStyle.italic),
+              style: KolabingTextStyles.captionSecondary.copyWith(
+                color: context.colors.textTertiary,
+                fontStyle: FontStyle.italic,
+              ),
             ),
           ),
         ],
@@ -327,17 +355,28 @@ class ReviewScreen extends ConsumerWidget {
 
   Widget _buildReviewLabel(BuildContext context, String label) => Text(
     label.toUpperCase(),
-    style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: FontWeight.w700, color: context.colors.textTertiary, letterSpacing: 0.8),
+    style: KolabingTextStyles.bodySmall.copyWith(
+      fontSize: 12,
+      fontWeight: FontWeight.w700,
+      color: context.colors.textTertiary,
+      letterSpacing: 0.8,
+    ),
   );
 
-  Widget _buildReviewInfoRow(BuildContext context, IconData icon, String label) => Row(
+  Widget _buildReviewInfoRow(
+    BuildContext context,
+    IconData icon,
+    String label,
+  ) => Row(
     children: [
       Icon(icon, size: 16, color: context.colors.onSurfaceVariant),
       const SizedBox(width: KolabingSpacing.xs),
       Expanded(
         child: Text(
           label,
-          style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant),
+          style: KolabingTextStyles.captionSecondary.copyWith(
+            color: context.colors.onSurfaceVariant,
+          ),
         ),
       ),
     ],
@@ -355,7 +394,11 @@ class ReviewScreen extends ConsumerWidget {
     ),
     child: Text(
       label,
-      style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: FontWeight.w600, color: context.colors.onSurface),
+      style: KolabingTextStyles.bodySmall.copyWith(
+        fontSize: 12,
+        fontWeight: FontWeight.w600,
+        color: context.colors.onSurface,
+      ),
     ),
   );
 

--- a/lib/features/kolab/screens/intent_selection_screen.dart
+++ b/lib/features/kolab/screens/intent_selection_screen.dart
@@ -167,7 +167,8 @@ class _IntentSelectionScreenState extends ConsumerState<IntentSelectionScreen> {
                       ),
                       const SizedBox(height: KolabingSpacing.md),
                       Text(
-                        profileState.error ?? l10n.intentSelectionProfileLoadError,
+                        profileState.error ??
+                            l10n.intentSelectionProfileLoadError,
                         textAlign: TextAlign.center,
                         style: KolabingTextStyles.titleMedium.copyWith(
                           color: context.colors.onSurface,
@@ -218,11 +219,7 @@ class _LockedBusinessCreateState extends StatelessWidget {
               color: context.colors.primaryTint,
               shape: BoxShape.circle,
             ),
-            child: Icon(
-              LucideIcons.crown,
-              size: 34,
-              color: context.colors.ink,
-            ),
+            child: Icon(LucideIcons.crown, size: 34, color: context.colors.ink),
           ),
           const SizedBox(height: KolabingSpacing.lg),
           Text(
@@ -322,7 +319,9 @@ class _IntentOption extends StatelessWidget {
                       ),
                       decoration: BoxDecoration(
                         color: c.primaryTint,
-                        borderRadius: BorderRadius.circular(KolabingRadius.pill),
+                        borderRadius: BorderRadius.circular(
+                          KolabingRadius.pill,
+                        ),
                       ),
                       child: Text(
                         badge!,

--- a/lib/features/kolab/screens/kolab_flow_screen.dart
+++ b/lib/features/kolab/screens/kolab_flow_screen.dart
@@ -164,7 +164,9 @@ class _KolabFlowScreenState extends ConsumerState<KolabFlowScreen> {
                       Expanded(
                         child: Text(
                           formState.error!,
-                          style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.error),
+                          style: KolabingTextStyles.captionSecondary.copyWith(
+                            color: context.colors.error,
+                          ),
                         ),
                       ),
                     ],
@@ -305,14 +307,20 @@ class _KolabFlowScreenState extends ConsumerState<KolabFlowScreen> {
               wasPublished
                   ? l10n.kolabFlowPublishedTitle
                   : l10n.kolabFlowDraftSavedTitle,
-              style: KolabingTextStyles.bodyLarge.copyWith(fontSize: 20, fontWeight: FontWeight.w700, color: context.colors.onSurface),
+              style: KolabingTextStyles.bodyLarge.copyWith(
+                fontSize: 20,
+                fontWeight: FontWeight.w700,
+                color: context.colors.onSurface,
+              ),
             ),
             const SizedBox(height: KolabingSpacing.xs),
             Text(
               wasPublished
                   ? l10n.kolabFlowPublishedMessage
                   : l10n.kolabFlowDraftSavedMessage,
-              style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
+              style: KolabingTextStyles.bodySmall.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
               textAlign: TextAlign.center,
             ),
           ],

--- a/lib/features/kolab/services/kolab_service.dart
+++ b/lib/features/kolab/services/kolab_service.dart
@@ -195,7 +195,8 @@ class KolabService {
             AnalyticsEvents.kolabPublished,
             properties: {
               'kolab_id': published.id ?? '',
-              'is_direct': recipientCommunityId != null &&
+              'is_direct':
+                  recipientCommunityId != null &&
                   recipientCommunityId.isNotEmpty,
             },
           ),

--- a/lib/features/kolab/services/offer_option_service.dart
+++ b/lib/features/kolab/services/offer_option_service.dart
@@ -29,7 +29,8 @@ class OfferOptionService {
   Future<List<OfferOption>> getDeliverables() =>
       _fetch('lookup/deliverables', _fallbackDeliverables);
 
-  Future<List<OfferOption>> getNeeds() => _fetch('lookup/needs', _fallbackNeeds);
+  Future<List<OfferOption>> getNeeds() =>
+      _fetch('lookup/needs', _fallbackNeeds);
 
   Future<List<OfferOption>> getProductTypes() =>
       _fetch('lookup/product-types', _fallbackProductTypes);
@@ -244,13 +245,21 @@ class OfferOptionService {
   static const List<OfferOption> _fallbackProductInteractions = [
     OfferOption(id: 'try_samples', slug: 'try_samples', name: 'Try Samples'),
     OfferOption(id: 'review_it', slug: 'review_it', name: 'Review It'),
-    OfferOption(id: 'create_content', slug: 'create_content', name: 'Create Content'),
+    OfferOption(
+      id: 'create_content',
+      slug: 'create_content',
+      name: 'Create Content',
+    ),
     OfferOption(
       id: 'use_during_event',
       slug: 'use_during_event',
       name: 'Use During an Event',
     ),
-    OfferOption(id: 'give_feedback', slug: 'give_feedback', name: 'Give Feedback'),
+    OfferOption(
+      id: 'give_feedback',
+      slug: 'give_feedback',
+      name: 'Give Feedback',
+    ),
     OfferOption(id: 'giveaway', slug: 'giveaway', name: 'Offer as a Giveaway'),
     OfferOption(
       id: 'discount_code',
@@ -262,7 +271,11 @@ class OfferOptionService {
       slug: 'sell_during_event',
       name: 'Sell During an Event',
     ),
-    OfferOption(id: 'open_to_ideas', slug: 'open_to_ideas', name: 'Open to Ideas'),
+    OfferOption(
+      id: 'open_to_ideas',
+      slug: 'open_to_ideas',
+      name: 'Open to Ideas',
+    ),
   ];
 
   static const List<OfferOption> _fallbackVenueFits = [
@@ -278,11 +291,19 @@ class OfferOptionService {
     OfferOption(id: 'after_work', slug: 'after_work', name: 'After-Work'),
     OfferOption(id: 'networking', slug: 'networking', name: 'Networking'),
     OfferOption(id: 'pop_ups', slug: 'pop_ups', name: 'Pop-Ups'),
-    OfferOption(id: 'recurring_plans', slug: 'recurring_plans', name: 'Recurring Plans'),
+    OfferOption(
+      id: 'recurring_plans',
+      slug: 'recurring_plans',
+      name: 'Recurring Plans',
+    ),
   ];
 
   static const List<OfferOption> _fallbackKolabHighlights = [
-    OfferOption(id: 'good_location', slug: 'good_location', name: 'Good Location'),
+    OfferOption(
+      id: 'good_location',
+      slug: 'good_location',
+      name: 'Good Location',
+    ),
     OfferOption(
       id: 'nice_space_for_groups',
       slug: 'nice_space_for_groups',
@@ -349,6 +370,10 @@ class OfferOptionService {
       slug: 'cozy_indoor_space',
       name: 'Cozy Indoor Space',
     ),
-    OfferOption(id: 'good_for_content', slug: 'good_for_content', name: 'Good for Content'),
+    OfferOption(
+      id: 'good_for_content',
+      slug: 'good_for_content',
+      name: 'Good for Content',
+    ),
   ];
 }

--- a/lib/features/kolab/widgets/create_kolab_choice_sheet.dart
+++ b/lib/features/kolab/widgets/create_kolab_choice_sheet.dart
@@ -35,8 +35,10 @@ class CreateKolabChoiceSheet extends ConsumerWidget {
     // Creator gate (the organizer area's own gate), matching how the create
     // flow already shows-then-gates a non-subscribed business.
     final entitled =
-        ref.watch(multiKolabEntitlementProvider).value?.
-            hasEventCreatorEntitlement ??
+        ref
+            .watch(multiKolabEntitlementProvider)
+            .value
+            ?.hasEventCreatorEntitlement ??
         false;
 
     return SafeArea(

--- a/lib/features/kolab/widgets/existing_photo_picker_sheet.dart
+++ b/lib/features/kolab/widgets/existing_photo_picker_sheet.dart
@@ -107,12 +107,18 @@ class _ExistingPhotoPickerSheetState
                   const SizedBox(height: KolabingSpacing.md),
                   Text(
                     widget.title,
-                    style: KolabingTextStyles.bodyMedium.copyWith(fontSize: 18, fontWeight: FontWeight.w700, color: context.colors.onSurface),
+                    style: KolabingTextStyles.bodyMedium.copyWith(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w700,
+                      color: context.colors.onSurface,
+                    ),
                   ),
                   const SizedBox(height: KolabingSpacing.xxs),
                   Text(
                     l10n.existingPhotoPickerSubtitle(widget.maxSelection),
-                    style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant),
+                    style: KolabingTextStyles.captionSecondary.copyWith(
+                      color: context.colors.onSurfaceVariant,
+                    ),
                   ),
                   const SizedBox(height: KolabingSpacing.md),
                   Expanded(
@@ -168,7 +174,9 @@ class _ExistingPhotoPickerSheetState
       return Center(
         child: Text(
           AppLocalizations.of(context).existingPhotoPickerEmpty,
-          style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            color: context.colors.onSurfaceVariant,
+          ),
         ),
       );
     }

--- a/lib/features/kolab/widgets/intent_card.dart
+++ b/lib/features/kolab/widgets/intent_card.dart
@@ -42,83 +42,90 @@ class IntentCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => GestureDetector(
-        onTap: onTap,
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeInOut,
-          padding: const EdgeInsets.all(KolabingSpacing.lg - 4), // 20dp
-          decoration: BoxDecoration(
-            color: isSelected ? context.colors.softYellow : Colors.white,
-            borderRadius: KolabingRadius.borderRadiusMd,
-            border: Border.all(
-              color:
-                  isSelected ? context.colors.primary : context.colors.hairline,
-              width: isSelected ? 2 : 1,
+    onTap: onTap,
+    child: AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeInOut,
+      padding: const EdgeInsets.all(KolabingSpacing.lg - 4), // 20dp
+      decoration: BoxDecoration(
+        color: isSelected ? context.colors.softYellow : Colors.white,
+        borderRadius: KolabingRadius.borderRadiusMd,
+        border: Border.all(
+          color: isSelected ? context.colors.primary : context.colors.hairline,
+          width: isSelected ? 2 : 1,
+        ),
+        boxShadow: isSelected ? null : [KolabingShadows.card],
+      ),
+      child: Row(
+        children: [
+          // Icon in circle
+          Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: isSelected
+                  ? context.colors.primary.withValues(alpha: 0.2)
+                  : context.colors.background,
             ),
-            boxShadow: isSelected ? null : [KolabingShadows.card],
+            child: Center(
+              child: Icon(
+                icon,
+                size: 22,
+                color: isSelected
+                    ? context.colors.onPrimary
+                    : context.colors.onSurfaceVariant,
+              ),
+            ),
           ),
-          child: Row(
-            children: [
-              // Icon in circle
-              Container(
-                width: 48,
-                height: 48,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: isSelected
-                      ? context.colors.primary.withValues(alpha: 0.2)
-                      : context.colors.background,
-                ),
-                child: Center(
-                  child: Icon(
-                    icon,
-                    size: 22,
-                    color: isSelected
-                        ? context.colors.onPrimary
-                        : context.colors.onSurfaceVariant,
+          const SizedBox(width: KolabingSpacing.sm),
+          // Title + subtitle
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: KolabingTextStyles.bodyMedium.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: context.colors.onSurface,
                   ),
                 ),
-              ),
-              const SizedBox(width: KolabingSpacing.sm),
-              // Title + subtitle
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      title,
-                      style: KolabingTextStyles.bodyMedium.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurface),
-                    ),
-                    const SizedBox(height: KolabingSpacing.xxxs),
-                    Text(
-                      subtitle,
-                      style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
-                ),
-              ),
-              // Badge
-              if (badge != null) ...[
-                const SizedBox(width: KolabingSpacing.xs),
-                Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: KolabingSpacing.xs,
-                    vertical: KolabingSpacing.xxs,
+                const SizedBox(height: KolabingSpacing.xxxs),
+                Text(
+                  subtitle,
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    color: context.colors.onSurfaceVariant,
                   ),
-                  decoration: BoxDecoration(
-                    color: context.colors.softYellow,
-                    borderRadius: KolabingRadius.borderRadiusSm,
-                  ),
-                  child: Text(
-                    badge!,
-                    style: KolabingTextStyles.labelSmall.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurface),
-                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ],
-            ],
+            ),
           ),
-        ),
-      );
+          // Badge
+          if (badge != null) ...[
+            const SizedBox(width: KolabingSpacing.xs),
+            Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: KolabingSpacing.xs,
+                vertical: KolabingSpacing.xxs,
+              ),
+              decoration: BoxDecoration(
+                color: context.colors.softYellow,
+                borderRadius: KolabingRadius.borderRadiusSm,
+              ),
+              child: Text(
+                badge!,
+                style: KolabingTextStyles.labelSmall.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: context.colors.onSurface,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    ),
+  );
 }

--- a/lib/features/kolab/widgets/kolab_action_bar.dart
+++ b/lib/features/kolab/widgets/kolab_action_bar.dart
@@ -50,22 +50,20 @@ class KolabActionBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Container(
-        padding: EdgeInsets.only(
-          left: KolabingSpacing.md,
-          right: KolabingSpacing.md,
-          top: KolabingSpacing.sm,
-          bottom: MediaQuery.of(context).padding.bottom + KolabingSpacing.sm,
-        ),
-        decoration: BoxDecoration(
-          color: context.colors.surface,
-          border: Border(
-            top: BorderSide(color: context.colors.darkBorder),
-          ),
-        ),
-        child: isLastStep
-            ? _buildLastStepRow(context)
-            : _buildNavigationRow(context),
-      );
+    padding: EdgeInsets.only(
+      left: KolabingSpacing.md,
+      right: KolabingSpacing.md,
+      top: KolabingSpacing.sm,
+      bottom: MediaQuery.of(context).padding.bottom + KolabingSpacing.sm,
+    ),
+    decoration: BoxDecoration(
+      color: context.colors.surface,
+      border: Border(top: BorderSide(color: context.colors.darkBorder)),
+    ),
+    child: isLastStep
+        ? _buildLastStepRow(context)
+        : _buildNavigationRow(context),
+  );
 
   Widget _buildNavigationRow(BuildContext context) {
     final l10n = AppLocalizations.of(context);
@@ -131,13 +129,13 @@ class _PrimaryActionButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => KolabingButton(
-        label: label,
-        onPressed: onPressed,
-        variant: KolabingButtonVariant.primary,
-        size: KolabingButtonSize.compact,
-        isLoading: isLoading,
-        isDisabled: onPressed == null && !isLoading,
-      );
+    label: label,
+    onPressed: onPressed,
+    variant: KolabingButtonVariant.primary,
+    size: KolabingButtonSize.compact,
+    isLoading: isLoading,
+    isDisabled: onPressed == null && !isLoading,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -157,11 +155,11 @@ class _OutlinedActionButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => KolabingButton(
-        label: label,
-        onPressed: isLoading ? null : onPressed,
-        variant: KolabingButtonVariant.secondary,
-        size: KolabingButtonSize.compact,
-        isLoading: isLoading,
-        isDisabled: !isLoading && onPressed == null,
-      );
+    label: label,
+    onPressed: isLoading ? null : onPressed,
+    variant: KolabingButtonVariant.secondary,
+    size: KolabingButtonSize.compact,
+    isLoading: isLoading,
+    isDisabled: !isLoading && onPressed == null,
+  );
 }

--- a/lib/features/kolab/widgets/kolab_examples_box.dart
+++ b/lib/features/kolab/widgets/kolab_examples_box.dart
@@ -10,44 +10,64 @@ import '../../../config/theme/typography.dart';
 /// blank-page anxiety — short, concrete example phrasings a business could
 /// use, not just a tooltip.
 class KolabExamplesBox extends StatelessWidget {
-  const KolabExamplesBox({required this.examples, super.key, this.label = 'EXAMPLES'});
+  const KolabExamplesBox({
+    required this.examples,
+    super.key,
+    this.label = 'EXAMPLES',
+  });
 
   final String label;
   final List<String> examples;
 
   @override
   Widget build(BuildContext context) => Container(
-        padding: const EdgeInsets.all(KolabingSpacing.sm),
-        decoration: BoxDecoration(
-          color: context.colors.surfaceVariant,
-          borderRadius: KolabingRadius.borderRadiusSm,
-          border: Border.all(color: context.colors.darkBorder),
+    padding: const EdgeInsets.all(KolabingSpacing.sm),
+    decoration: BoxDecoration(
+      color: context.colors.surfaceVariant,
+      borderRadius: KolabingRadius.borderRadiusSm,
+      border: Border.all(color: context.colors.darkBorder),
+    ),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontSize: 11,
+            fontWeight: FontWeight.w700,
+            color: context.colors.textTertiary,
+            letterSpacing: 0.8,
+          ),
         ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              label,
-              style: KolabingTextStyles.bodySmall.copyWith(fontSize: 11, fontWeight: FontWeight.w700, color: context.colors.textTertiary, letterSpacing: 0.8),
-            ),
-            const SizedBox(height: KolabingSpacing.xs),
-            ...examples.map((example) => Padding(
-                  padding: const EdgeInsets.only(bottom: KolabingSpacing.xxs),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Icon(LucideIcons.sparkle, size: 12, color: context.colors.textTertiary),
-                      const SizedBox(width: KolabingSpacing.xs),
-                      Expanded(
-                        child: Text(
-                          example,
-                          style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12.5, color: context.colors.onSurfaceVariant, height: 1.35, fontStyle: FontStyle.italic),
-                        ),
-                      ),
-                    ],
+        const SizedBox(height: KolabingSpacing.xs),
+        ...examples.map(
+          (example) => Padding(
+            padding: const EdgeInsets.only(bottom: KolabingSpacing.xxs),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(
+                  LucideIcons.sparkle,
+                  size: 12,
+                  color: context.colors.textTertiary,
+                ),
+                const SizedBox(width: KolabingSpacing.xs),
+                Expanded(
+                  child: Text(
+                    example,
+                    style: KolabingTextStyles.bodySmall.copyWith(
+                      fontSize: 12.5,
+                      color: context.colors.onSurfaceVariant,
+                      height: 1.35,
+                      fontStyle: FontStyle.italic,
+                    ),
                   ),
-                )),
-          ],
+                ),
+              ],
+            ),
+          ),
         ),
-      );
+      ],
+    ),
+  );
 }

--- a/lib/features/kolab/widgets/kolab_review_card.dart
+++ b/lib/features/kolab/widgets/kolab_review_card.dart
@@ -36,7 +36,9 @@ class KolabReviewCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
-    final deliverableOptions = ref.watch(deliverablesProvider).maybeWhen(
+    final deliverableOptions = ref
+        .watch(deliverablesProvider)
+        .maybeWhen(
           data: (options) => options,
           orElse: () => const <OfferOption>[],
         );
@@ -55,7 +57,10 @@ class KolabReviewCard extends ConsumerWidget {
   // Section dispatcher based on intent type
   // ---------------------------------------------------------------------------
 
-  List<Widget> _buildSections(AppLocalizations l10n, List<OfferOption> deliverableOptions) {
+  List<Widget> _buildSections(
+    AppLocalizations l10n,
+    List<OfferOption> deliverableOptions,
+  ) {
     switch (kolab.intentType) {
       case IntentType.communitySeeking:
         return _buildCommunitySeekingSections(l10n, deliverableOptions);
@@ -70,7 +75,10 @@ class KolabReviewCard extends ConsumerWidget {
   // Community Seeking sections
   // ---------------------------------------------------------------------------
 
-  List<Widget> _buildCommunitySeekingSections(AppLocalizations l10n, List<OfferOption> deliverableOptions) => [
+  List<Widget> _buildCommunitySeekingSections(
+    AppLocalizations l10n,
+    List<OfferOption> deliverableOptions,
+  ) => [
     // Step 0 -- Title & Description
     _ReviewSection(
       icon: LucideIcons.fileText,
@@ -484,7 +492,10 @@ class _ReviewSection extends StatelessWidget {
               Expanded(
                 child: Text(
                   title,
-                  style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: context.colors.onSurface,
+                  ),
                 ),
               ),
               Icon(
@@ -524,12 +535,18 @@ class _ReviewField extends StatelessWidget {
     children: [
       Text(
         label,
-        style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: FontWeight.w600, color: context.colors.textTertiary),
+        style: KolabingTextStyles.bodySmall.copyWith(
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          color: context.colors.textTertiary,
+        ),
       ),
       const SizedBox(height: KolabingSpacing.xxxs),
       Text(
         value,
-        style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurface),
+        style: KolabingTextStyles.bodySmall.copyWith(
+          color: context.colors.onSurface,
+        ),
       ),
     ],
   );
@@ -558,7 +575,11 @@ class _ChipList extends StatelessWidget {
             ),
             child: Text(
               item,
-              style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: FontWeight.w500, color: context.colors.onSurface),
+              style: KolabingTextStyles.bodySmall.copyWith(
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color: context.colors.onSurface,
+              ),
             ),
           ),
         )
@@ -575,6 +596,9 @@ class _EmptyHint extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Text(
     text,
-    style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.textTertiary, fontStyle: FontStyle.italic),
+    style: KolabingTextStyles.captionSecondary.copyWith(
+      color: context.colors.textTertiary,
+      fontStyle: FontStyle.italic,
+    ),
   );
 }

--- a/lib/features/kolab/widgets/kolab_step_indicator.dart
+++ b/lib/features/kolab/widgets/kolab_step_indicator.dart
@@ -27,39 +27,37 @@ class KolabStepIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: List.generate(totalSteps, (index) {
-          final isActive = index == currentStep;
-          final isCompleted = index < currentStep;
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: List.generate(totalSteps, (index) {
+      final isActive = index == currentStep;
+      final isCompleted = index < currentStep;
 
-          return Padding(
-            padding: const EdgeInsets.symmetric(
-              horizontal: KolabingSpacing.xxs,
-            ),
-            child: GestureDetector(
-              onTap: isCompleted && onStepTap != null
-                  ? () => onStepTap!(index)
-                  : null,
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 200),
-                curve: Curves.easeInOut,
-                width: isActive ? 10 : 8,
-                height: isActive ? 10 : 8,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: isActive || isCompleted
-                      ? context.colors.ink
-                      : Colors.transparent,
-                  border: Border.all(
-                    color: isActive || isCompleted
-                        ? context.colors.ink
-                        : context.colors.hairline,
-                    width: 1.5,
-                  ),
-                ),
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: KolabingSpacing.xxs),
+        child: GestureDetector(
+          onTap: isCompleted && onStepTap != null
+              ? () => onStepTap!(index)
+              : null,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeInOut,
+            width: isActive ? 10 : 8,
+            height: isActive ? 10 : 8,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: isActive || isCompleted
+                  ? context.colors.ink
+                  : Colors.transparent,
+              border: Border.all(
+                color: isActive || isCompleted
+                    ? context.colors.ink
+                    : context.colors.hairline,
+                width: 1.5,
               ),
             ),
-          );
-        }),
+          ),
+        ),
       );
+    }),
+  );
 }

--- a/lib/features/kolab/widgets/media_picker_grid.dart
+++ b/lib/features/kolab/widgets/media_picker_grid.dart
@@ -35,7 +35,8 @@ class MediaPickerGrid extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final totalSlots = media.length < maxItems
-        ? media.length + 1 // existing + add button
+        ? media.length +
+              1 // existing + add button
         : media.length;
 
     return GridView.builder(
@@ -50,17 +51,11 @@ class MediaPickerGrid extends StatelessWidget {
       itemBuilder: (context, index) {
         // Add button slot
         if (index == media.length && media.length < maxItems) {
-          return _AddSlot(
-            onTap: onAdd,
-            remaining: maxItems - media.length,
-          );
+          return _AddSlot(onTap: onAdd, remaining: maxItems - media.length);
         }
 
         // Existing media slot
-        return _MediaSlot(
-          media: media[index],
-          onRemove: () => onRemove(index),
-        );
+        return _MediaSlot(media: media[index], onRemove: () => onRemove(index));
       },
     );
   }
@@ -71,81 +66,74 @@ class MediaPickerGrid extends StatelessWidget {
 // ---------------------------------------------------------------------------
 
 class _MediaSlot extends StatelessWidget {
-  const _MediaSlot({
-    required this.media,
-    required this.onRemove,
-  });
+  const _MediaSlot({required this.media, required this.onRemove});
 
   final KolabMedia media;
   final VoidCallback onRemove;
 
   @override
   Widget build(BuildContext context) => ClipRRect(
-        borderRadius: KolabingRadius.borderRadiusSm,
-        child: Stack(
-          fit: StackFit.expand,
-          children: [
-            // Placeholder or network image
-            if (media.url.isNotEmpty)
-              Image.network(
-                media.url,
-                fit: BoxFit.cover,
-                errorBuilder: (_, _, _) => _buildPlaceholder(context),
-              )
-            else
-              _buildPlaceholder(context),
-            // Video overlay icon
-            if (media.type == 'video')
-              Center(
-                child: Container(
-                  width: 28,
-                  height: 28,
-                  decoration: BoxDecoration(
-                    color: Colors.black.withValues(alpha: 0.5),
-                    shape: BoxShape.circle,
-                  ),
-                  child: const Icon(
-                    LucideIcons.play,
-                    size: 14,
-                    color: Colors.white,
-                  ),
-                ),
+    borderRadius: KolabingRadius.borderRadiusSm,
+    child: Stack(
+      fit: StackFit.expand,
+      children: [
+        // Placeholder or network image
+        if (media.url.isNotEmpty)
+          Image.network(
+            media.url,
+            fit: BoxFit.cover,
+            errorBuilder: (_, _, _) => _buildPlaceholder(context),
+          )
+        else
+          _buildPlaceholder(context),
+        // Video overlay icon
+        if (media.type == 'video')
+          Center(
+            child: Container(
+              width: 28,
+              height: 28,
+              decoration: BoxDecoration(
+                color: Colors.black.withValues(alpha: 0.5),
+                shape: BoxShape.circle,
               ),
-            // Remove button
-            Positioned(
-              top: 4,
-              right: 4,
-              child: GestureDetector(
-                onTap: onRemove,
-                child: Container(
-                  width: 22,
-                  height: 22,
-                  decoration: BoxDecoration(
-                    color: Colors.black.withValues(alpha: 0.6),
-                    shape: BoxShape.circle,
-                  ),
-                  child: const Icon(
-                    LucideIcons.x,
-                    size: 12,
-                    color: Colors.white,
-                  ),
-                ),
+              child: const Icon(
+                LucideIcons.play,
+                size: 14,
+                color: Colors.white,
               ),
             ),
-          ],
-        ),
-      );
-
-  Widget _buildPlaceholder(BuildContext context) => ColoredBox(
-        color: context.colors.surfaceVariant,
-        child: Center(
-          child: Icon(
-            LucideIcons.image,
-            size: 24,
-            color: context.colors.textTertiary,
+          ),
+        // Remove button
+        Positioned(
+          top: 4,
+          right: 4,
+          child: GestureDetector(
+            onTap: onRemove,
+            child: Container(
+              width: 22,
+              height: 22,
+              decoration: BoxDecoration(
+                color: Colors.black.withValues(alpha: 0.6),
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(LucideIcons.x, size: 12, color: Colors.white),
+            ),
           ),
         ),
-      );
+      ],
+    ),
+  );
+
+  Widget _buildPlaceholder(BuildContext context) => ColoredBox(
+    color: context.colors.surfaceVariant,
+    child: Center(
+      child: Icon(
+        LucideIcons.image,
+        size: 24,
+        color: context.colors.textTertiary,
+      ),
+    ),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -153,38 +141,38 @@ class _MediaSlot extends StatelessWidget {
 // ---------------------------------------------------------------------------
 
 class _AddSlot extends StatelessWidget {
-  const _AddSlot({
-    required this.onTap,
-    required this.remaining,
-  });
+  const _AddSlot({required this.onTap, required this.remaining});
 
   final VoidCallback onTap;
   final int remaining;
 
   @override
   Widget build(BuildContext context) => GestureDetector(
-        onTap: onTap,
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: context.colors.background,
-            borderRadius: KolabingRadius.borderRadiusSm,
-            border: Border.all(color: context.colors.darkBorder),
+    onTap: onTap,
+    child: DecoratedBox(
+      decoration: BoxDecoration(
+        color: context.colors.background,
+        borderRadius: KolabingRadius.borderRadiusSm,
+        border: Border.all(color: context.colors.darkBorder),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            LucideIcons.camera,
+            size: 22,
+            color: context.colors.textTertiary,
           ),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(
-                LucideIcons.camera,
-                size: 22,
-                color: context.colors.textTertiary,
-              ),
-              const SizedBox(height: KolabingSpacing.xxs),
-              Text(
-                '$remaining left',
-                style: KolabingTextStyles.labelSmall.copyWith(fontSize: 10, color: context.colors.textTertiary),
-              ),
-            ],
+          const SizedBox(height: KolabingSpacing.xxs),
+          Text(
+            '$remaining left',
+            style: KolabingTextStyles.labelSmall.copyWith(
+              fontSize: 10,
+              color: context.colors.textTertiary,
+            ),
           ),
-        ),
-      );
+        ],
+      ),
+    ),
+  );
 }

--- a/lib/features/kolab/widgets/multi_select_chips.dart
+++ b/lib/features/kolab/widgets/multi_select_chips.dart
@@ -42,8 +42,7 @@ class MultiSelectChips<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final maxReached =
-        maxSelect != null && selected.length >= maxSelect!;
+    final maxReached = maxSelect != null && selected.length >= maxSelect!;
 
     return Wrap(
       spacing: KolabingSpacing.xs,
@@ -80,16 +79,17 @@ class MultiSelectChips<T> extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   if (icon != null) ...[
-                    Icon(
-                      icon,
-                      size: 16,
-                      color: context.colors.onSurface,
-                    ),
+                    Icon(icon, size: 16, color: context.colors.onSurface),
                     const SizedBox(width: KolabingSpacing.xxs),
                   ],
                   Text(
                     labelBuilder(item),
-                    style: KolabingTextStyles.bodySmall.copyWith(fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400, color: context.colors.onSurface),
+                    style: KolabingTextStyles.bodySmall.copyWith(
+                      fontWeight: isSelected
+                          ? FontWeight.w600
+                          : FontWeight.w400,
+                      color: context.colors.onSurface,
+                    ),
                   ),
                 ],
               ),

--- a/lib/features/kolab/widgets/past_event_card.dart
+++ b/lib/features/kolab/widgets/past_event_card.dart
@@ -68,7 +68,10 @@ class PastEventCard extends StatelessWidget {
           const SizedBox(height: KolabingSpacing.xs),
           Text(
             'Add a past event',
-            style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w500, color: context.colors.onSurfaceVariant),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontWeight: FontWeight.w500,
+              color: context.colors.onSurfaceVariant,
+            ),
           ),
         ],
       ),
@@ -116,14 +119,20 @@ class PastEventCard extends StatelessWidget {
               children: [
                 Text(
                   e.name,
-                  style: KolabingTextStyles.bodySmall.copyWith(fontSize: 15, fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                    color: context.colors.onSurface,
+                  ),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),
                 const SizedBox(height: KolabingSpacing.xxxs),
                 Text(
                   formattedDate,
-                  style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant),
+                  style: KolabingTextStyles.captionSecondary.copyWith(
+                    color: context.colors.onSurfaceVariant,
+                  ),
                 ),
                 if (e.partnerName != null && e.partnerName!.isNotEmpty) ...[
                   const SizedBox(height: KolabingSpacing.xxxs),
@@ -138,7 +147,9 @@ class PastEventCard extends StatelessWidget {
                       Expanded(
                         child: Text(
                           e.partnerName!,
-                          style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant),
+                          style: KolabingTextStyles.captionSecondary.copyWith(
+                            color: context.colors.onSurfaceVariant,
+                          ),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         ),
@@ -168,7 +179,9 @@ class PastEventCard extends StatelessWidget {
                         const SizedBox(width: KolabingSpacing.xxs),
                         Text(
                           '${e.photos.length} photo${e.photos.length == 1 ? '' : 's'}',
-                          style: KolabingTextStyles.labelSmall.copyWith(color: context.colors.textTertiary),
+                          style: KolabingTextStyles.labelSmall.copyWith(
+                            color: context.colors.textTertiary,
+                          ),
                         ),
                       ],
                     ),
@@ -196,7 +209,9 @@ class PastEventCard extends StatelessWidget {
                         const SizedBox(width: KolabingSpacing.xxs),
                         Text(
                           '${e.videos.length} video${e.videos.length == 1 ? '' : 's'}',
-                          style: KolabingTextStyles.labelSmall.copyWith(color: context.colors.textTertiary),
+                          style: KolabingTextStyles.labelSmall.copyWith(
+                            color: context.colors.textTertiary,
+                          ),
                         ),
                       ],
                     ),

--- a/lib/features/kolab/widgets/profile_event_picker_sheet.dart
+++ b/lib/features/kolab/widgets/profile_event_picker_sheet.dart
@@ -28,14 +28,13 @@ class ProfileEventPickerSheet extends StatefulWidget {
     context: context,
     isScrollControlled: true,
     backgroundColor: Colors.transparent,
-    builder: (_) => ProfileEventPickerSheet(
-      events: events,
-      maxSelection: maxSelection,
-    ),
+    builder: (_) =>
+        ProfileEventPickerSheet(events: events, maxSelection: maxSelection),
   );
 
   @override
-  State<ProfileEventPickerSheet> createState() => _ProfileEventPickerSheetState();
+  State<ProfileEventPickerSheet> createState() =>
+      _ProfileEventPickerSheetState();
 }
 
 class _ProfileEventPickerSheetState extends State<ProfileEventPickerSheet> {
@@ -78,12 +77,18 @@ class _ProfileEventPickerSheetState extends State<ProfileEventPickerSheet> {
                   const SizedBox(height: KolabingSpacing.md),
                   Text(
                     l10n.profileEventPickerTitle,
-                    style: KolabingTextStyles.bodyMedium.copyWith(fontSize: 18, fontWeight: FontWeight.w700, color: context.colors.onSurface),
+                    style: KolabingTextStyles.bodyMedium.copyWith(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w700,
+                      color: context.colors.onSurface,
+                    ),
                   ),
                   const SizedBox(height: KolabingSpacing.xxs),
                   Text(
                     l10n.profileEventPickerSubtitle(widget.maxSelection),
-                    style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant),
+                    style: KolabingTextStyles.captionSecondary.copyWith(
+                      color: context.colors.onSurfaceVariant,
+                    ),
                   ),
                   const SizedBox(height: KolabingSpacing.md),
                   Expanded(
@@ -101,7 +106,9 @@ class _ProfileEventPickerSheetState extends State<ProfileEventPickerSheet> {
                             padding: const EdgeInsets.all(KolabingSpacing.sm),
                             decoration: BoxDecoration(
                               color: isSelected
-                                  ? context.colors.primary.withValues(alpha: 0.08)
+                                  ? context.colors.primary.withValues(
+                                      alpha: 0.08,
+                                    )
                                   : context.colors.surfaceVariant,
                               borderRadius: KolabingRadius.borderRadiusMd,
                               border: Border.all(
@@ -116,18 +123,31 @@ class _ProfileEventPickerSheetState extends State<ProfileEventPickerSheet> {
                                 const SizedBox(width: KolabingSpacing.sm),
                                 Expanded(
                                   child: Column(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
                                     children: [
                                       Text(
                                         event.name,
                                         maxLines: 1,
                                         overflow: TextOverflow.ellipsis,
-                                        style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurface),
+                                        style: KolabingTextStyles.bodySmall
+                                            .copyWith(
+                                              fontWeight: FontWeight.w700,
+                                              color: context.colors.onSurface,
+                                            ),
                                       ),
                                       const SizedBox(height: 4),
                                       Text(
-                                        DateFormat('MMM d, yyyy').format(event.date),
-                                        style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.onSurfaceVariant),
+                                        DateFormat(
+                                          'MMM d, yyyy',
+                                        ).format(event.date),
+                                        style: KolabingTextStyles.bodySmall
+                                            .copyWith(
+                                              fontSize: 12,
+                                              color: context
+                                                  .colors
+                                                  .onSurfaceVariant,
+                                            ),
                                       ),
                                       if (event.partner.name.isNotEmpty) ...[
                                         const SizedBox(height: 2),
@@ -135,7 +155,13 @@ class _ProfileEventPickerSheetState extends State<ProfileEventPickerSheet> {
                                           event.partner.name,
                                           maxLines: 1,
                                           overflow: TextOverflow.ellipsis,
-                                          style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.onSurfaceVariant),
+                                          style: KolabingTextStyles.bodySmall
+                                              .copyWith(
+                                                fontSize: 12,
+                                                color: context
+                                                    .colors
+                                                    .onSurfaceVariant,
+                                              ),
                                         ),
                                       ],
                                     ],

--- a/lib/features/missions/models/mission.dart
+++ b/lib/features/missions/models/mission.dart
@@ -40,7 +40,8 @@ class Mission {
       targetValue: _asInt(json['target_value']) ?? 0,
       repeatInterval: _asString(json['repeat_interval']),
       progressCount: _asInt(json['progress_count']) ?? 0,
-      completed: _asBool(json['completed']) || _asDate(json['completed_at']) != null,
+      completed:
+          _asBool(json['completed']) || _asDate(json['completed_at']) != null,
       completedAt: _asDate(json['completed_at']),
       periodKey: _asString(json['period_key']),
     );

--- a/lib/features/missions/services/missions_service.dart
+++ b/lib/features/missions/services/missions_service.dart
@@ -16,11 +16,9 @@ const String _baseUrl = ApiConfig.baseUrl;
 /// returns role-scoped, already-filtered missions, so the app just displays
 /// what it gets.
 class MissionsService {
-  MissionsService({
-    required AuthService authService,
-    http.Client? httpClient,
-  })  : _authService = authService,
-        _httpClient = httpClient ?? http.Client();
+  MissionsService({required AuthService authService, http.Client? httpClient})
+    : _authService = authService,
+      _httpClient = httpClient ?? http.Client();
 
   final AuthService _authService;
   final http.Client _httpClient;

--- a/lib/features/notification/screens/notifications_screen.dart
+++ b/lib/features/notification/screens/notifications_screen.dart
@@ -104,20 +104,15 @@ class _NotificationsScreenState extends ConsumerState<NotificationsScreen> {
       child: ListView.separated(
         controller: _scrollController,
         padding: const EdgeInsets.symmetric(vertical: KolabingSpacing.xs),
-        itemCount:
-            state.notifications.length + (state.isLoadingMore ? 1 : 0),
-        separatorBuilder: (_, __) => Divider(
-          height: 1,
-          indent: 72,
-          color: context.colors.darkBorder,
-        ),
+        itemCount: state.notifications.length + (state.isLoadingMore ? 1 : 0),
+        separatorBuilder: (_, __) =>
+            Divider(height: 1, indent: 72, color: context.colors.darkBorder),
         itemBuilder: (context, index) {
           if (index == state.notifications.length) {
             return Center(
               child: Padding(
                 padding: EdgeInsets.all(KolabingSpacing.md),
-                child:
-                    CircularProgressIndicator(color: context.colors.primary),
+                child: CircularProgressIndicator(color: context.colors.primary),
               ),
             );
           }
@@ -150,70 +145,68 @@ class _NotificationsScreenState extends ConsumerState<NotificationsScreen> {
     }
   }
 
-  Widget _buildLoadingState() => Center(
-        child: CircularProgressIndicator(color: context.colors.primary),
-      );
+  Widget _buildLoadingState() =>
+      Center(child: CircularProgressIndicator(color: context.colors.primary));
 
   Widget _buildErrorState(BuildContext context, String error) => Center(
-        child: Padding(
-          padding: const EdgeInsets.all(KolabingSpacing.xl),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                LucideIcons.alertCircle,
-                size: 48,
-                color: context.colors.textTertiary,
-              ),
-              const SizedBox(height: KolabingSpacing.md),
-              Text(
-                error,
-                style: KolabingTextStyles.bodyMedium.copyWith(
-                  color: context.colors.onSurfaceVariant,
-                ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: KolabingSpacing.md),
-              TextButton(
-                onPressed: () =>
-                    ref.read(notificationProvider.notifier).refresh(),
-                child: Text(AppLocalizations.of(context).commonRetry),
-              ),
-            ],
+    child: Padding(
+      padding: const EdgeInsets.all(KolabingSpacing.xl),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            LucideIcons.alertCircle,
+            size: 48,
+            color: context.colors.textTertiary,
           ),
-        ),
-      );
+          const SizedBox(height: KolabingSpacing.md),
+          Text(
+            error,
+            style: KolabingTextStyles.bodyMedium.copyWith(
+              color: context.colors.onSurfaceVariant,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: KolabingSpacing.md),
+          TextButton(
+            onPressed: () => ref.read(notificationProvider.notifier).refresh(),
+            child: Text(AppLocalizations.of(context).commonRetry),
+          ),
+        ],
+      ),
+    ),
+  );
 
   Widget _buildEmptyState(BuildContext context) => Center(
-        child: Padding(
-          padding: const EdgeInsets.all(KolabingSpacing.xl),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                LucideIcons.bellOff,
-                size: 48,
-                color: context.colors.textTertiary,
-              ),
-              const SizedBox(height: KolabingSpacing.md),
-              Text(
-                AppLocalizations.of(context).notificationsScreenEmptyTitle,
-                style: KolabingTextStyles.titleMedium.copyWith(
-                  color: context.colors.onSurfaceVariant,
-                ),
-              ),
-              const SizedBox(height: KolabingSpacing.xs),
-              Text(
-                AppLocalizations.of(context).notificationsScreenEmptyBody,
-                style: KolabingTextStyles.bodyMedium.copyWith(
-                  color: context.colors.textTertiary,
-                ),
-                textAlign: TextAlign.center,
-              ),
-            ],
+    child: Padding(
+      padding: const EdgeInsets.all(KolabingSpacing.xl),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            LucideIcons.bellOff,
+            size: 48,
+            color: context.colors.textTertiary,
           ),
-        ),
-      );
+          const SizedBox(height: KolabingSpacing.md),
+          Text(
+            AppLocalizations.of(context).notificationsScreenEmptyTitle,
+            style: KolabingTextStyles.titleMedium.copyWith(
+              color: context.colors.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: KolabingSpacing.xs),
+          Text(
+            AppLocalizations.of(context).notificationsScreenEmptyBody,
+            style: KolabingTextStyles.bodyMedium.copyWith(
+              color: context.colors.textTertiary,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    ),
+  );
 }
 
 // =============================================================================
@@ -221,10 +214,7 @@ class _NotificationsScreenState extends ConsumerState<NotificationsScreen> {
 // =============================================================================
 
 class _NotificationTile extends StatelessWidget {
-  const _NotificationTile({
-    required this.notification,
-    required this.onTap,
-  });
+  const _NotificationTile({required this.notification, required this.onTap});
 
   final AppNotification notification;
   final VoidCallback onTap;
@@ -339,44 +329,47 @@ class _NotificationTile extends StatelessWidget {
   }
 
   Widget _buildIconAvatar(BuildContext context) {
-    final (IconData icon, Color bgColor, Color iconColor) =
-        switch (notification.type) {
+    final (
+      IconData icon,
+      Color bgColor,
+      Color iconColor,
+    ) = switch (notification.type) {
       NotificationType.newMessage => (
-          LucideIcons.messageCircle,
-          context.colors.info.withValues(alpha: 0.12),
-          context.colors.info,
-        ),
+        LucideIcons.messageCircle,
+        context.colors.info.withValues(alpha: 0.12),
+        context.colors.info,
+      ),
       NotificationType.applicationReceived => (
-          LucideIcons.inbox,
-          context.colors.primary.withValues(alpha: 0.15),
-          context.colors.accentOrangeText,
-        ),
+        LucideIcons.inbox,
+        context.colors.primary.withValues(alpha: 0.15),
+        context.colors.accentOrangeText,
+      ),
       NotificationType.applicationAccepted => (
-          LucideIcons.checkCircle,
-          context.colors.success.withValues(alpha: 0.15),
-          context.colors.activeText,
-        ),
+        LucideIcons.checkCircle,
+        context.colors.success.withValues(alpha: 0.15),
+        context.colors.activeText,
+      ),
       NotificationType.applicationDeclined ||
       NotificationType.applicationWithdrawn => (
-          LucideIcons.xCircle,
-          context.colors.error.withValues(alpha: 0.12),
-          context.colors.error,
-        ),
+        LucideIcons.xCircle,
+        context.colors.error.withValues(alpha: 0.12),
+        context.colors.error,
+      ),
       NotificationType.badgeAwarded => (
-          LucideIcons.badgeCheck,
-          context.colors.primary.withValues(alpha: 0.12),
-          context.colors.primary,
-        ),
+        LucideIcons.badgeCheck,
+        context.colors.primary.withValues(alpha: 0.12),
+        context.colors.primary,
+      ),
       NotificationType.challengeVerified => (
-          LucideIcons.shieldCheck,
-          context.colors.info.withValues(alpha: 0.12),
-          context.colors.info,
-        ),
+        LucideIcons.shieldCheck,
+        context.colors.info.withValues(alpha: 0.12),
+        context.colors.info,
+      ),
       NotificationType.rewardWon => (
-          LucideIcons.gift,
-          context.colors.success.withValues(alpha: 0.15),
-          context.colors.activeText,
-        ),
+        LucideIcons.gift,
+        context.colors.success.withValues(alpha: 0.15),
+        context.colors.activeText,
+      ),
       NotificationType.collabDayReminder ||
       NotificationType.collabFollowUpReminder ||
       NotificationType.collaborationCreated ||
@@ -384,15 +377,15 @@ class _NotificationTile extends StatelessWidget {
       NotificationType.collaborationFeedbackReceived ||
       NotificationType.collaborationCompleted ||
       NotificationType.collaborationCancelled => (
-          LucideIcons.calendarCheck,
-          context.colors.primary.withValues(alpha: 0.15),
-          context.colors.accentOrangeText,
-        ),
+        LucideIcons.calendarCheck,
+        context.colors.primary.withValues(alpha: 0.15),
+        context.colors.accentOrangeText,
+      ),
       NotificationType.unknown => (
-          LucideIcons.bell,
-          context.colors.surfaceVariant,
-          context.colors.onSurfaceVariant,
-        ),
+        LucideIcons.bell,
+        context.colors.surfaceVariant,
+        context.colors.onSurfaceVariant,
+      ),
     };
 
     return Container(

--- a/lib/features/notification/services/notification_service.dart
+++ b/lib/features/notification/services/notification_service.dart
@@ -140,10 +140,7 @@ class NotificationService {
 
     try {
       final response = await _sendWithRefresh(
-        () async => _httpClient.post(
-          uri,
-          headers: await _getHeaders(),
-        ),
+        () async => _httpClient.post(uri, headers: await _getHeaders()),
         allowRetry: true,
       );
 
@@ -187,10 +184,7 @@ class NotificationService {
 
     try {
       final response = await _sendWithRefresh(
-        () async => _httpClient.post(
-          uri,
-          headers: await _getHeaders(),
-        ),
+        () async => _httpClient.post(uri, headers: await _getHeaders()),
         allowRetry: true,
       );
 

--- a/lib/features/notification/widgets/notification_bell.dart
+++ b/lib/features/notification/widgets/notification_bell.dart
@@ -13,11 +13,7 @@ import '../providers/notification_provider.dart';
 /// Place this in an AppBar's actions or as a standalone widget.
 /// Tapping navigates to the notifications screen.
 class NotificationBell extends ConsumerWidget {
-  const NotificationBell({
-    super.key,
-    this.color,
-    this.size = 24,
-  });
+  const NotificationBell({super.key, this.color, this.size = 24});
 
   /// Icon color override
   final Color? color;
@@ -48,10 +44,7 @@ class NotificationBell extends ConsumerWidget {
                 decoration: BoxDecoration(
                   color: context.colors.error,
                   borderRadius: BorderRadius.circular(9),
-                  border: Border.all(
-                    color: context.colors.surface,
-                    width: 1.5,
-                  ),
+                  border: Border.all(color: context.colors.surface, width: 1.5),
                 ),
                 child: Text(
                   unreadCount > 99 ? '99+' : unreadCount.toString(),

--- a/lib/features/onboarding/models/business_type.dart
+++ b/lib/features/onboarding/models/business_type.dart
@@ -47,13 +47,13 @@ class BusinessType {
   bool get isForProduct => appliesTo == 'product' || appliesTo == 'both';
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'name': name,
-        'slug': slug,
-        if (icon != null) 'icon': icon,
-        if (iconUrl != null) 'icon_url': iconUrl,
-        'applies_to': appliesTo,
-      };
+    'id': id,
+    'name': name,
+    'slug': slug,
+    if (icon != null) 'icon': icon,
+    if (iconUrl != null) 'icon_url': iconUrl,
+    'applies_to': appliesTo,
+  };
 
   @override
   bool operator ==(Object other) =>

--- a/lib/features/onboarding/models/city.dart
+++ b/lib/features/onboarding/models/city.dart
@@ -1,26 +1,22 @@
 /// City model from GET /cities
 class OnboardingCity {
-  const OnboardingCity({
-    required this.id,
-    required this.name,
-    this.country,
-  });
+  const OnboardingCity({required this.id, required this.name, this.country});
 
   factory OnboardingCity.fromJson(Map<String, dynamic> json) => OnboardingCity(
-        id: json['id']?.toString() ?? '',
-        name: json['name']?.toString() ?? '',
-        country: json['country']?.toString(),
-      );
+    id: json['id']?.toString() ?? '',
+    name: json['name']?.toString() ?? '',
+    country: json['country']?.toString(),
+  );
 
   final String id;
   final String name;
   final String? country;
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'name': name,
-        if (country != null) 'country': country,
-      };
+    'id': id,
+    'name': name,
+    if (country != null) 'country': country,
+  };
 
   @override
   bool operator ==(Object other) =>
@@ -33,5 +29,6 @@ class OnboardingCity {
   int get hashCode => id.hashCode;
 
   @override
-  String toString() => 'OnboardingCity(id: $id, name: $name, country: $country)';
+  String toString() =>
+      'OnboardingCity(id: $id, name: $name, country: $country)';
 }

--- a/lib/features/onboarding/models/community_type.dart
+++ b/lib/features/onboarding/models/community_type.dart
@@ -33,12 +33,12 @@ class CommunityType {
   final String? iconUrl;
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'name': name,
-        'slug': slug,
-        if (icon != null) 'icon': icon,
-        if (iconUrl != null) 'icon_url': iconUrl,
-      };
+    'id': id,
+    'name': name,
+    'slug': slug,
+    if (icon != null) 'icon': icon,
+    if (iconUrl != null) 'icon_url': iconUrl,
+  };
 
   @override
   bool operator ==(Object other) =>

--- a/lib/features/onboarding/models/place_suggestion.dart
+++ b/lib/features/onboarding/models/place_suggestion.dart
@@ -17,12 +17,15 @@ class PlaceSuggestion {
   factory PlaceSuggestion.fromJson(Map<String, dynamic> json) =>
       PlaceSuggestion(
         placeId: json['place_id']?.toString() ?? '',
-        title: json['title']?.toString() ??
+        title:
+            json['title']?.toString() ??
             json['main_text']?.toString() ??
             json['formatted_address']?.toString() ??
             '',
-        subtitle: json['subtitle']?.toString() ?? json['secondary_text']?.toString(),
-        formattedAddress: json['formatted_address']?.toString() ??
+        subtitle:
+            json['subtitle']?.toString() ?? json['secondary_text']?.toString(),
+        formattedAddress:
+            json['formatted_address']?.toString() ??
             json['description']?.toString() ??
             '',
         city: json['city']?.toString() ?? '',
@@ -33,14 +36,16 @@ class PlaceSuggestion {
       );
 
   factory PlaceSuggestion.fromCity(OnboardingCity city) => PlaceSuggestion(
-        placeId: 'city:${city.id}',
-        title: city.name,
-        subtitle: city.country,
-        formattedAddress: city.country == null ? city.name : '${city.name}, ${city.country}',
-        city: city.name,
-        country: city.country,
-        cityId: city.id,
-      );
+    placeId: 'city:${city.id}',
+    title: city.name,
+    subtitle: city.country,
+    formattedAddress: city.country == null
+        ? city.name
+        : '${city.name}, ${city.country}',
+    city: city.name,
+    country: city.country,
+    cityId: city.id,
+  );
 
   final String placeId;
   final String title;
@@ -63,16 +68,16 @@ class PlaceSuggestion {
   }
 
   Map<String, dynamic> toJson() => {
-        'place_id': placeId,
-        'title': title,
-        if (subtitle != null) 'subtitle': subtitle,
-        'formatted_address': formattedAddress,
-        'city': city,
-        if (country != null) 'country': country,
-        if (latitude != null) 'latitude': latitude,
-        if (longitude != null) 'longitude': longitude,
-        if (cityId != null) 'city_id': cityId,
-      };
+    'place_id': placeId,
+    'title': title,
+    if (subtitle != null) 'subtitle': subtitle,
+    'formatted_address': formattedAddress,
+    'city': city,
+    if (country != null) 'country': country,
+    if (latitude != null) 'latitude': latitude,
+    if (longitude != null) 'longitude': longitude,
+    if (cityId != null) 'city_id': cityId,
+  };
 
   static double? _parseDouble(Object? value) => tryParseDouble(value);
 

--- a/lib/features/onboarding/screens/attendee/attendee_step4_screen.dart
+++ b/lib/features/onboarding/screens/attendee/attendee_step4_screen.dart
@@ -23,7 +23,8 @@ class AttendeeStep4Screen extends ConsumerStatefulWidget {
   const AttendeeStep4Screen({super.key});
 
   @override
-  ConsumerState<AttendeeStep4Screen> createState() => _AttendeeStep4ScreenState();
+  ConsumerState<AttendeeStep4Screen> createState() =>
+      _AttendeeStep4ScreenState();
 }
 
 class _AttendeeStep4ScreenState extends ConsumerState<AttendeeStep4Screen> {
@@ -121,13 +122,14 @@ class _AttendeeStep4ScreenState extends ConsumerState<AttendeeStep4Screen> {
                 _JoinCard(
                   community: c,
                   selected: data.communityIds.contains(c.id),
-                  highlighted: c.matched ||
+                  highlighted:
+                      c.matched ||
                       (c.typeSlug != null &&
                           interests.contains(c.typeSlug!.toLowerCase())),
                   onToggle: c.joinPolicy.allowsSelfJoin
                       ? () => ref
-                          .read(attendeeOnboardingProvider.notifier)
-                          .toggleCommunity(c.id)
+                            .read(attendeeOnboardingProvider.notifier)
+                            .toggleCommunity(c.id)
                       : null,
                 ),
                 const SizedBox(height: KolabingSpacing.sm),
@@ -181,7 +183,10 @@ class _JoinCard extends StatelessWidget {
                   ? NetworkImage(community.avatarUrl!)
                   : null,
               child: community.avatarUrl == null
-                  ? const Icon(LucideIcons.users, color: KolabingColors.onSurface)
+                  ? const Icon(
+                      LucideIcons.users,
+                      color: KolabingColors.onSurface,
+                    )
                   : null,
             ),
             const SizedBox(width: KolabingSpacing.md),

--- a/lib/features/onboarding/screens/business/business_goal_screen.dart
+++ b/lib/features/onboarding/screens/business/business_goal_screen.dart
@@ -59,7 +59,9 @@ class _BusinessGoalScreenState extends ConsumerState<BusinessGoalScreen> {
   void _handleContinue() {
     final hasVenue = _hasVenue;
     if (hasVenue == null) return;
-    ref.read(onboardingProvider.notifier).selectBusinessGoal(hasVenue: hasVenue);
+    ref
+        .read(onboardingProvider.notifier)
+        .selectBusinessGoal(hasVenue: hasVenue);
     if (hasVenue) {
       context.push(KolabingRoutes.businessOnboardingStep5);
     } else {
@@ -140,9 +142,8 @@ class _BusinessGoalScreenState extends ConsumerState<BusinessGoalScreen> {
                     disabledBackgroundColor: context.colors.primary.withValues(
                       alpha: 0.5,
                     ),
-                    disabledForegroundColor: context.colors.onPrimary.withValues(
-                      alpha: 0.5,
-                    ),
+                    disabledForegroundColor: context.colors.onPrimary
+                        .withValues(alpha: 0.5),
                     elevation: 0,
                   ),
                   child: Text(
@@ -190,7 +191,9 @@ class _GoalCard extends StatelessWidget {
         color: isSelected ? context.colors.softYellow : context.colors.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: isSelected ? context.colors.primary : context.colors.darkBorder,
+          color: isSelected
+              ? context.colors.primary
+              : context.colors.darkBorder,
           width: isSelected ? 2.5 : 1.5,
         ),
       ),

--- a/lib/features/onboarding/screens/business/business_product_about_screen.dart
+++ b/lib/features/onboarding/screens/business/business_product_about_screen.dart
@@ -116,8 +116,8 @@ class _BusinessProductAboutScreenState
       if (!mounted) return;
       final l10n = AppLocalizations.of(context);
       final message = switch (e.code) {
-        'photo_access_denied' || 'photo_access_restricted' =>
-          l10n.businessStep2PhotoAccessDenied,
+        'photo_access_denied' ||
+        'photo_access_restricted' => l10n.businessStep2PhotoAccessDenied,
         _ => l10n.businessStep2PhotoLibraryError,
       };
       ScaffoldMessenger.of(context).showSnackBar(
@@ -238,7 +238,8 @@ class _BusinessProductAboutScreenState
                       photos: data?.venuePhotos ?? const [],
                       isUploading: _isPickingPhoto,
                       emptyTitle: l10n.businessProductPhotosEmptyTitle,
-                      emptyDescription: l10n.businessProductPhotosEmptyDescription,
+                      emptyDescription:
+                          l10n.businessProductPhotosEmptyDescription,
                       onAddPhoto: _pickPhoto,
                       onRemovePhoto: notifier.removeVenuePhoto,
                       onMovePhoto: notifier.moveVenuePhoto,
@@ -317,9 +318,8 @@ class _BusinessProductAboutScreenState
                     disabledBackgroundColor: context.colors.primary.withValues(
                       alpha: 0.5,
                     ),
-                    disabledForegroundColor: context.colors.onPrimary.withValues(
-                      alpha: 0.5,
-                    ),
+                    disabledForegroundColor: context.colors.onPrimary
+                        .withValues(alpha: 0.5),
                     elevation: 0,
                   ),
                   child: Text(

--- a/lib/features/onboarding/screens/business/business_product_identity_screen.dart
+++ b/lib/features/onboarding/screens/business/business_product_identity_screen.dart
@@ -185,30 +185,31 @@ class _BusinessProductIdentityScreenState
                       // non-venue business sees only product/both categories
                       // (admin-controlled via business_types.applies_to).
                       data: (allTypes) {
-                        final types =
-                            allTypes.where((t) => t.isForProduct).toList();
+                        final types = allTypes
+                            .where((t) => t.isForProduct)
+                            .toList();
                         return GridView.builder(
-                        shrinkWrap: true,
-                        physics: const NeverScrollableScrollPhysics(),
-                        gridDelegate:
-                            const SliverGridDelegateWithFixedCrossAxisCount(
-                              crossAxisCount: 3,
-                              crossAxisSpacing: 12,
-                              mainAxisSpacing: 12,
-                              childAspectRatio: 0.9,
-                            ),
-                        itemCount: types.length,
-                        itemBuilder: (context, index) {
-                          final type = types[index];
-                          return TypeSelectionCard(
-                            id: type.id,
-                            name: type.name,
-                            icon: type.icon,
-                            iconUrl: type.iconUrl,
-                            isSelected: selectedTypeIds.contains(type.id),
-                            onTap: () => notifier.toggleBusinessType(type),
-                          );
-                        },
+                          shrinkWrap: true,
+                          physics: const NeverScrollableScrollPhysics(),
+                          gridDelegate:
+                              const SliverGridDelegateWithFixedCrossAxisCount(
+                                crossAxisCount: 3,
+                                crossAxisSpacing: 12,
+                                mainAxisSpacing: 12,
+                                childAspectRatio: 0.9,
+                              ),
+                          itemCount: types.length,
+                          itemBuilder: (context, index) {
+                            final type = types[index];
+                            return TypeSelectionCard(
+                              id: type.id,
+                              name: type.name,
+                              icon: type.icon,
+                              iconUrl: type.iconUrl,
+                              isSelected: selectedTypeIds.contains(type.id),
+                              onTap: () => notifier.toggleBusinessType(type),
+                            );
+                          },
                         );
                       },
                       loading: () => Center(
@@ -329,9 +330,8 @@ class _BusinessProductIdentityScreenState
                     disabledBackgroundColor: context.colors.primary.withValues(
                       alpha: 0.5,
                     ),
-                    disabledForegroundColor: context.colors.onPrimary.withValues(
-                      alpha: 0.5,
-                    ),
+                    disabledForegroundColor: context.colors.onPrimary
+                        .withValues(alpha: 0.5),
                     elevation: 0,
                   ),
                   child: Text(
@@ -366,24 +366,26 @@ class _FieldLabel extends StatelessWidget {
   );
 }
 
-InputDecoration _inputDecoration(BuildContext context, {required String hint}) =>
-    InputDecoration(
-      hintText: hint,
-      hintStyle: KolabingTextStyles.bodyMedium.copyWith(
-        color: context.colors.textTertiary,
-      ),
-      filled: true,
-      fillColor: context.colors.surfaceContainerLow,
-      border: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(12),
-        borderSide: BorderSide(color: context.colors.outlineVariant),
-      ),
-      enabledBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(12),
-        borderSide: BorderSide(color: context.colors.outlineVariant),
-      ),
-      focusedBorder: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(12),
-        borderSide: BorderSide(color: context.colors.primary, width: 1.5),
-      ),
-    );
+InputDecoration _inputDecoration(
+  BuildContext context, {
+  required String hint,
+}) => InputDecoration(
+  hintText: hint,
+  hintStyle: KolabingTextStyles.bodyMedium.copyWith(
+    color: context.colors.textTertiary,
+  ),
+  filled: true,
+  fillColor: context.colors.surfaceContainerLow,
+  border: OutlineInputBorder(
+    borderRadius: BorderRadius.circular(12),
+    borderSide: BorderSide(color: context.colors.outlineVariant),
+  ),
+  enabledBorder: OutlineInputBorder(
+    borderRadius: BorderRadius.circular(12),
+    borderSide: BorderSide(color: context.colors.outlineVariant),
+  ),
+  focusedBorder: OutlineInputBorder(
+    borderRadius: BorderRadius.circular(12),
+    borderSide: BorderSide(color: context.colors.primary, width: 1.5),
+  ),
+);

--- a/lib/features/onboarding/screens/business/business_step2_screen.dart
+++ b/lib/features/onboarding/screens/business/business_step2_screen.dart
@@ -442,7 +442,9 @@ class _BusinessStep2ScreenState extends ConsumerState<BusinessStep2Screen> {
                           TextButton(
                             onPressed: () =>
                                 ref.invalidate(businessTypesProvider),
-                            child: Text(AppLocalizations.of(context).commonRetry),
+                            child: Text(
+                              AppLocalizations.of(context).commonRetry,
+                            ),
                           ),
                         ],
                       ),

--- a/lib/features/onboarding/screens/business/business_step3_screen.dart
+++ b/lib/features/onboarding/screens/business/business_step3_screen.dart
@@ -65,8 +65,8 @@ class _BusinessStep3ScreenState extends ConsumerState<BusinessStep3Screen> {
       if (!mounted) return;
       final l10n = AppLocalizations.of(context);
       final message = switch (e.code) {
-        'photo_access_denied' || 'photo_access_restricted' =>
-          l10n.businessStep3PhotoAccessDenied,
+        'photo_access_denied' ||
+        'photo_access_restricted' => l10n.businessStep3PhotoAccessDenied,
         _ => l10n.businessStep3PhotoLibraryError,
       };
       ScaffoldMessenger.of(context).showSnackBar(
@@ -125,13 +125,19 @@ class _BusinessStep3ScreenState extends ConsumerState<BusinessStep3Screen> {
                     const SizedBox(height: 32),
                     Text(
                       AppLocalizations.of(context).businessStep3Title,
-                      style: KolabingTextStyles.bodyLarge.copyWith(fontSize: 20, fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                      style: KolabingTextStyles.bodyLarge.copyWith(
+                        fontSize: 20,
+                        fontWeight: FontWeight.w600,
+                        color: context.colors.onSurface,
+                      ),
                       textAlign: TextAlign.center,
                     ),
                     const SizedBox(height: 8),
                     Text(
                       AppLocalizations.of(context).businessStep3Subtitle,
-                      style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
+                      style: KolabingTextStyles.bodySmall.copyWith(
+                        color: context.colors.onSurfaceVariant,
+                      ),
                       textAlign: TextAlign.center,
                     ),
                     const SizedBox(height: 24),
@@ -197,7 +203,10 @@ class _AddPhotoTile extends StatelessWidget {
           const SizedBox(height: 8),
           Text(
             AppLocalizations.of(context).businessStep3AddPhoto,
-            style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.onSurfaceVariant),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontSize: 12,
+              color: context.colors.onSurfaceVariant,
+            ),
           ),
         ],
       ),
@@ -214,10 +223,7 @@ class _VenuePhotoTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Stack(
     children: [
-      ClipRRect(
-        borderRadius: BorderRadius.circular(16),
-        child: _buildImage(),
-      ),
+      ClipRRect(borderRadius: BorderRadius.circular(16), child: _buildImage()),
       Positioned(
         top: 6,
         right: 6,

--- a/lib/features/onboarding/screens/business/business_step5_screen.dart
+++ b/lib/features/onboarding/screens/business/business_step5_screen.dart
@@ -177,9 +177,7 @@ class _BusinessStep5ScreenState extends ConsumerState<BusinessStep5Screen> {
   void _showImportFallbackToast() {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text(
-          AppLocalizations.of(context).businessStep5ImportFallback,
-        ),
+        content: Text(AppLocalizations.of(context).businessStep5ImportFallback),
         backgroundColor: context.colors.error,
       ),
     );
@@ -229,13 +227,19 @@ class _BusinessStep5ScreenState extends ConsumerState<BusinessStep5Screen> {
                           const SizedBox(height: 32),
                           Text(
                             AppLocalizations.of(context).businessStep5Title,
-                            style: KolabingTextStyles.bodyLarge.copyWith(fontSize: 20, fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                            style: KolabingTextStyles.bodyLarge.copyWith(
+                              fontSize: 20,
+                              fontWeight: FontWeight.w600,
+                              color: context.colors.onSurface,
+                            ),
                             textAlign: TextAlign.center,
                           ),
                           const SizedBox(height: 8),
                           Text(
                             AppLocalizations.of(context).businessStep5Subtitle,
-                            style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
+                            style: KolabingTextStyles.bodySmall.copyWith(
+                              color: context.colors.onSurfaceVariant,
+                            ),
                             textAlign: TextAlign.center,
                           ),
                           const SizedBox(height: 24),
@@ -250,12 +254,16 @@ class _BusinessStep5ScreenState extends ConsumerState<BusinessStep5Screen> {
                                 }
                               });
                             },
-                            style: KolabingTextStyles.bodyMedium.copyWith(color: context.colors.onSurface),
+                            style: KolabingTextStyles.bodyMedium.copyWith(
+                              color: context.colors.onSurface,
+                            ),
                             decoration: InputDecoration(
                               hintText: AppLocalizations.of(
                                 context,
                               ).businessStep5SearchHint,
-                              hintStyle: KolabingTextStyles.bodyMedium.copyWith(color: context.colors.textTertiary),
+                              hintStyle: KolabingTextStyles.bodyMedium.copyWith(
+                                color: context.colors.textTertiary,
+                              ),
                               prefixIcon: Icon(
                                 LucideIcons.search,
                                 size: 20,
@@ -309,7 +317,11 @@ class _BusinessStep5ScreenState extends ConsumerState<BusinessStep5Screen> {
                             alignment: Alignment.centerLeft,
                             child: Text(
                               'Powered by Google',
-                              style: KolabingTextStyles.bodySmall.copyWith(fontSize: 10, fontWeight: FontWeight.w500, color: context.colors.textTertiary),
+                              style: KolabingTextStyles.bodySmall.copyWith(
+                                fontSize: 10,
+                                fontWeight: FontWeight.w500,
+                                color: context.colors.textTertiary,
+                              ),
                             ),
                           ),
                           const SizedBox(height: 12),
@@ -332,11 +344,10 @@ class _BusinessStep5ScreenState extends ConsumerState<BusinessStep5Screen> {
                                 }
                                 return ListView.separated(
                                   itemCount: items.length,
-                                  separatorBuilder: (context, index) =>
-                                      Divider(
-                                        height: 1,
-                                        color: context.colors.darkBorder,
-                                      ),
+                                  separatorBuilder: (context, index) => Divider(
+                                    height: 1,
+                                    color: context.colors.darkBorder,
+                                  ),
                                   itemBuilder: (context, index) {
                                     final place = items[index];
                                     final isSelected =
@@ -359,11 +370,22 @@ class _BusinessStep5ScreenState extends ConsumerState<BusinessStep5Screen> {
                                       ),
                                       title: Text(
                                         place.title,
-                                        style: KolabingTextStyles.bodySmall.copyWith(fontSize: 15, fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                                        style: KolabingTextStyles.bodySmall
+                                            .copyWith(
+                                              fontSize: 15,
+                                              fontWeight: FontWeight.w600,
+                                              color: context.colors.onSurface,
+                                            ),
                                       ),
                                       subtitle: Text(
                                         place.formattedAddress,
-                                        style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant),
+                                        style: KolabingTextStyles
+                                            .captionSecondary
+                                            .copyWith(
+                                              color: context
+                                                  .colors
+                                                  .onSurfaceVariant,
+                                            ),
                                       ),
                                       onTap: () => _handlePlaceSelected(place),
                                     );
@@ -428,7 +450,11 @@ class _BusinessStep5ScreenState extends ConsumerState<BusinessStep5Screen> {
                           const SizedBox(height: 18),
                           Text(
                             AppLocalizations.of(context).businessStep5Importing,
-                            style: KolabingTextStyles.bodyMedium.copyWith(fontSize: 18, fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                            style: KolabingTextStyles.bodyMedium.copyWith(
+                              fontSize: 18,
+                              fontWeight: FontWeight.w600,
+                              color: context.colors.onSurface,
+                            ),
                             textAlign: TextAlign.center,
                           ),
                         ],
@@ -447,7 +473,9 @@ class _BusinessStep5ScreenState extends ConsumerState<BusinessStep5Screen> {
     padding: const EdgeInsets.only(top: 12),
     child: Text(
       message,
-      style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
+      style: KolabingTextStyles.bodySmall.copyWith(
+        color: context.colors.onSurfaceVariant,
+      ),
       textAlign: TextAlign.start,
     ),
   );
@@ -493,7 +521,11 @@ class _BusinessStep5ScreenState extends ConsumerState<BusinessStep5Screen> {
                     Center(
                       child: Text(
                         AppLocalizations.of(context).businessStep5PreviewTitle,
-                        style: KolabingTextStyles.bodyLarge.copyWith(fontSize: 20, fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                        style: KolabingTextStyles.bodyLarge.copyWith(
+                          fontSize: 20,
+                          fontWeight: FontWeight.w600,
+                          color: context.colors.onSurface,
+                        ),
                         textAlign: TextAlign.center,
                       ),
                     ),
@@ -503,16 +535,16 @@ class _BusinessStep5ScreenState extends ConsumerState<BusinessStep5Screen> {
                         AppLocalizations.of(
                           context,
                         ).businessStep5PreviewSubtitle,
-                        style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
+                        style: KolabingTextStyles.bodySmall.copyWith(
+                          color: context.colors.onSurfaceVariant,
+                        ),
                         textAlign: TextAlign.center,
                       ),
                     ),
                     const SizedBox(height: 24),
                     if (gridItems.isEmpty)
                       _buildHint(
-                        AppLocalizations.of(
-                          context,
-                        ).businessStep5NoPhotosLeft,
+                        AppLocalizations.of(context).businessStep5NoPhotosLeft,
                       )
                     else ...[
                       ImportedPhotoGrid(
@@ -570,19 +602,28 @@ class _SelectedAddressCard extends StatelessWidget {
             const SizedBox(width: 8),
             Text(
               AppLocalizations.of(context).businessStep5SelectedAddress,
-              style: KolabingTextStyles.captionSecondary.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurface),
+              style: KolabingTextStyles.captionSecondary.copyWith(
+                fontWeight: FontWeight.w700,
+                color: context.colors.onSurface,
+              ),
             ),
           ],
         ),
         const SizedBox(height: 8),
         Text(
           place.title,
-          style: KolabingTextStyles.bodySmall.copyWith(fontSize: 15, fontWeight: FontWeight.w600, color: context.colors.onSurface),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+            color: context.colors.onSurface,
+          ),
         ),
         const SizedBox(height: 4),
         Text(
           place.formattedAddress,
-          style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant),
+          style: KolabingTextStyles.captionSecondary.copyWith(
+            color: context.colors.onSurfaceVariant,
+          ),
         ),
       ],
     ),

--- a/lib/features/onboarding/screens/community/community_step1_screen.dart
+++ b/lib/features/onboarding/screens/community/community_step1_screen.dart
@@ -116,7 +116,11 @@ class _CommunityStep1ScreenState extends ConsumerState<CommunityStep1Screen> {
                     Center(
                       child: Text(
                         l10n.communityStep1Title,
-                        style: KolabingTextStyles.bodyLarge.copyWith(fontSize: 20, fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                        style: KolabingTextStyles.bodyLarge.copyWith(
+                          fontSize: 20,
+                          fontWeight: FontWeight.w600,
+                          color: context.colors.onSurface,
+                        ),
                         textAlign: TextAlign.center,
                       ),
                     ),
@@ -126,7 +130,9 @@ class _CommunityStep1ScreenState extends ConsumerState<CommunityStep1Screen> {
                     Center(
                       child: Text(
                         l10n.communityStep1Subtitle,
-                        style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
+                        style: KolabingTextStyles.bodySmall.copyWith(
+                          color: context.colors.onSurfaceVariant,
+                        ),
                         textAlign: TextAlign.center,
                       ),
                     ),
@@ -149,12 +155,18 @@ class _CommunityStep1ScreenState extends ConsumerState<CommunityStep1Screen> {
                       children: [
                         Text(
                           l10n.communityStep1DisplayNameLabel,
-                          style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                          style: KolabingTextStyles.bodySmall.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: context.colors.onSurface,
+                          ),
                         ),
                         const SizedBox(width: 4),
                         Text(
                           '*',
-                          style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w600, color: context.colors.error),
+                          style: KolabingTextStyles.bodySmall.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: context.colors.error,
+                          ),
                         ),
                       ],
                     ),
@@ -169,19 +181,27 @@ class _CommunityStep1ScreenState extends ConsumerState<CommunityStep1Screen> {
                         setState(() {});
                         ref.read(onboardingProvider.notifier).updateName(value);
                       },
-                      style: KolabingTextStyles.bodyMedium.copyWith(color: context.colors.onSurface),
+                      style: KolabingTextStyles.bodyMedium.copyWith(
+                        color: context.colors.onSurface,
+                      ),
                       decoration: InputDecoration(
                         hintText: l10n.communityStep1NameHint,
-                        hintStyle: KolabingTextStyles.bodyMedium.copyWith(color: context.colors.textTertiary),
+                        hintStyle: KolabingTextStyles.bodyMedium.copyWith(
+                          color: context.colors.textTertiary,
+                        ),
                         filled: true,
                         fillColor: context.colors.surfaceContainerLow,
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(8),
-                          borderSide: BorderSide(color: context.colors.outlineVariant),
+                          borderSide: BorderSide(
+                            color: context.colors.outlineVariant,
+                          ),
                         ),
                         enabledBorder: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(8),
-                          borderSide: BorderSide(color: context.colors.outlineVariant),
+                          borderSide: BorderSide(
+                            color: context.colors.outlineVariant,
+                          ),
                         ),
                         focusedBorder: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(8),
@@ -194,7 +214,10 @@ class _CommunityStep1ScreenState extends ConsumerState<CommunityStep1Screen> {
                           horizontal: 16,
                           vertical: 16,
                         ),
-                        counterStyle: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.textTertiary),
+                        counterStyle: KolabingTextStyles.bodySmall.copyWith(
+                          fontSize: 12,
+                          color: context.colors.textTertiary,
+                        ),
                       ),
                     ),
                     const SizedBox(height: 24),
@@ -202,12 +225,17 @@ class _CommunityStep1ScreenState extends ConsumerState<CommunityStep1Screen> {
                     // Community size label
                     Text(
                       l10n.communityInfoCommunitySizeLabel,
-                      style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                      style: KolabingTextStyles.bodySmall.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: context.colors.onSurface,
+                      ),
                     ),
                     const SizedBox(height: 4),
                     Text(
                       l10n.communityStep1SizeHelper,
-                      style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant),
+                      style: KolabingTextStyles.captionSecondary.copyWith(
+                        color: context.colors.onSurfaceVariant,
+                      ),
                     ),
                     const SizedBox(height: 8),
 
@@ -220,19 +248,27 @@ class _CommunityStep1ScreenState extends ConsumerState<CommunityStep1Screen> {
                       onChanged: (value) => ref
                           .read(onboardingProvider.notifier)
                           .updateCommunitySize(int.tryParse(value.trim())),
-                      style: KolabingTextStyles.bodyMedium.copyWith(color: context.colors.onSurface),
+                      style: KolabingTextStyles.bodyMedium.copyWith(
+                        color: context.colors.onSurface,
+                      ),
                       decoration: InputDecoration(
                         hintText: l10n.communityInfoCommunitySizeHint,
-                        hintStyle: KolabingTextStyles.bodyMedium.copyWith(color: context.colors.textTertiary),
+                        hintStyle: KolabingTextStyles.bodyMedium.copyWith(
+                          color: context.colors.textTertiary,
+                        ),
                         filled: true,
                         fillColor: context.colors.surfaceContainerLow,
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(8),
-                          borderSide: BorderSide(color: context.colors.outlineVariant),
+                          borderSide: BorderSide(
+                            color: context.colors.outlineVariant,
+                          ),
                         ),
                         enabledBorder: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(8),
-                          borderSide: BorderSide(color: context.colors.outlineVariant),
+                          borderSide: BorderSide(
+                            color: context.colors.outlineVariant,
+                          ),
                         ),
                         focusedBorder: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(8),
@@ -263,15 +299,19 @@ class _CommunityStep1ScreenState extends ConsumerState<CommunityStep1Screen> {
                   style: ElevatedButton.styleFrom(
                     backgroundColor: context.colors.primary,
                     foregroundColor: context.colors.onPrimary,
-                    disabledBackgroundColor:
-                        context.colors.primary.withValues(alpha: 0.5),
-                    disabledForegroundColor:
-                        context.colors.onPrimary.withValues(alpha: 0.5),
+                    disabledBackgroundColor: context.colors.primary.withValues(
+                      alpha: 0.5,
+                    ),
+                    disabledForegroundColor: context.colors.onPrimary
+                        .withValues(alpha: 0.5),
                     elevation: 0,
                   ),
                   child: Text(
                     l10n.commonContinue,
-                    style: KolabingTextStyles.button.copyWith(fontSize: 16, letterSpacing: 1.0),
+                    style: KolabingTextStyles.button.copyWith(
+                      fontSize: 16,
+                      letterSpacing: 1.0,
+                    ),
                   ),
                 ),
               ),

--- a/lib/features/onboarding/screens/community/community_step4_screen.dart
+++ b/lib/features/onboarding/screens/community/community_step4_screen.dart
@@ -89,242 +89,248 @@ class _CommunityStep4ScreenState extends ConsumerState<CommunityStep4Screen> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     return Scaffold(
-        backgroundColor: context.colors.background,
-        body: SafeArea(
-          child: Column(
-            children: [
-              // Header
-              OnboardingHeader(
-                currentStep: 4,
-                onBack: _handleBack,
-                onSkip: _handleSkip,
-                showSkip: true,
+      backgroundColor: context.colors.background,
+      body: SafeArea(
+        child: Column(
+          children: [
+            // Header
+            OnboardingHeader(
+              currentStep: 4,
+              onBack: _handleBack,
+              onSkip: _handleSkip,
+              showSkip: true,
+            ),
+
+            // Content
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const SizedBox(height: 32),
+
+                    // Title
+                    Center(
+                      child: Text(
+                        l10n.communityStep4Title,
+                        style: KolabingTextStyles.bodyLarge.copyWith(
+                          fontSize: 20,
+                          fontWeight: FontWeight.w600,
+                          color: context.colors.onSurface,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+
+                    // Subtitle
+                    Center(
+                      child: Text(
+                        l10n.communityStep4Subtitle,
+                        style: KolabingTextStyles.bodySmall.copyWith(
+                          color: context.colors.onSurfaceVariant,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                    const SizedBox(height: 32),
+
+                    // About field
+                    Text(
+                      l10n.communityStep4AboutLabel,
+                      style: KolabingTextStyles.bodySmall.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: context.colors.onSurface,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    TextField(
+                      controller: _aboutController,
+                      maxLength: 1000,
+                      maxLines: 5,
+                      minLines: 3,
+                      style: KolabingTextStyles.bodyMedium.copyWith(
+                        color: context.colors.onSurface,
+                      ),
+                      decoration: InputDecoration(
+                        hintText: l10n.communityStep4AboutHint,
+                        hintStyle: KolabingTextStyles.bodyMedium.copyWith(
+                          color: context.colors.textTertiary,
+                        ),
+                        filled: true,
+                        fillColor: context.colors.surfaceContainerLow,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(8),
+                          borderSide: BorderSide(
+                            color: context.colors.outlineVariant,
+                          ),
+                        ),
+                        contentPadding: const EdgeInsets.all(16),
+                        counterStyle: KolabingTextStyles.bodySmall.copyWith(
+                          fontSize: 12,
+                          color: context.colors.textTertiary,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+
+                    // Instagram field
+                    Text(
+                      'Instagram',
+                      style: KolabingTextStyles.bodySmall.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: context.colors.onSurface,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    TextField(
+                      controller: _instagramController,
+                      style: KolabingTextStyles.bodyMedium.copyWith(
+                        color: context.colors.onSurface,
+                      ),
+                      decoration: InputDecoration(
+                        hintText: l10n.communityStep4UsernameHint,
+                        hintStyle: KolabingTextStyles.bodyMedium.copyWith(
+                          color: context.colors.textTertiary,
+                        ),
+                        prefixIcon: Icon(
+                          LucideIcons.instagram,
+                          size: 20,
+                          color: context.colors.textTertiary,
+                        ),
+                        prefixText: '@ ',
+                        prefixStyle: KolabingTextStyles.bodyMedium.copyWith(
+                          color: context.colors.textTertiary,
+                        ),
+                        filled: true,
+                        fillColor: context.colors.surfaceContainerLow,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(8),
+                          borderSide: BorderSide(
+                            color: context.colors.outlineVariant,
+                          ),
+                        ),
+                        contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 16,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+
+                    // TikTok field
+                    Text(
+                      'TikTok',
+                      style: KolabingTextStyles.bodySmall.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: context.colors.onSurface,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    TextField(
+                      controller: _tiktokController,
+                      style: KolabingTextStyles.bodyMedium.copyWith(
+                        color: context.colors.onSurface,
+                      ),
+                      decoration: InputDecoration(
+                        hintText: l10n.communityStep4UsernameHint,
+                        hintStyle: KolabingTextStyles.bodyMedium.copyWith(
+                          color: context.colors.textTertiary,
+                        ),
+                        prefixIcon: Icon(
+                          LucideIcons.music,
+                          size: 20,
+                          color: context.colors.textTertiary,
+                        ),
+                        prefixText: '@ ',
+                        prefixStyle: KolabingTextStyles.bodyMedium.copyWith(
+                          color: context.colors.textTertiary,
+                        ),
+                        filled: true,
+                        fillColor: context.colors.surfaceContainerLow,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(8),
+                          borderSide: BorderSide(
+                            color: context.colors.outlineVariant,
+                          ),
+                        ),
+                        contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 16,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+
+                    // Website field
+                    Text(
+                      l10n.communityStep4WebsiteLabel,
+                      style: KolabingTextStyles.bodySmall.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: context.colors.onSurface,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    TextField(
+                      controller: _websiteController,
+                      keyboardType: TextInputType.url,
+                      style: KolabingTextStyles.bodyMedium.copyWith(
+                        color: context.colors.onSurface,
+                      ),
+                      decoration: InputDecoration(
+                        hintText: l10n.communityStep4WebsiteHint,
+                        hintStyle: KolabingTextStyles.bodyMedium.copyWith(
+                          color: context.colors.textTertiary,
+                        ),
+                        prefixIcon: Icon(
+                          LucideIcons.globe,
+                          size: 20,
+                          color: context.colors.textTertiary,
+                        ),
+                        filled: true,
+                        fillColor: context.colors.surfaceContainerLow,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(8),
+                          borderSide: BorderSide(
+                            color: context.colors.outlineVariant,
+                          ),
+                        ),
+                        contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 16,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+                  ],
+                ),
               ),
+            ),
 
-              // Content
-              Expanded(
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.symmetric(horizontal: 24),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      const SizedBox(height: 32),
-
-                      // Title
-                      Center(
-                        child: Text(
-                          l10n.communityStep4Title,
-                          style: KolabingTextStyles.bodyLarge.copyWith(
-                            fontSize: 20,
-                            fontWeight: FontWeight.w600,
-                            color: context.colors.onSurface,
-                          ),
-                          textAlign: TextAlign.center,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-
-                      // Subtitle
-                      Center(
-                        child: Text(
-                          l10n.communityStep4Subtitle,
-                          style: KolabingTextStyles.bodySmall.copyWith(
-                            color: context.colors.onSurfaceVariant,
-                          ),
-                          textAlign: TextAlign.center,
-                        ),
-                      ),
-                      const SizedBox(height: 32),
-
-                      // About field
-                      Text(
-                        l10n.communityStep4AboutLabel,
-                        style: KolabingTextStyles.bodySmall.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: context.colors.onSurface,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      TextField(
-                        controller: _aboutController,
-                        maxLength: 1000,
-                        maxLines: 5,
-                        minLines: 3,
-                        style: KolabingTextStyles.bodyMedium.copyWith(
-                          color: context.colors.onSurface,
-                        ),
-                        decoration: InputDecoration(
-                          hintText: l10n.communityStep4AboutHint,
-                          hintStyle: KolabingTextStyles.bodyMedium.copyWith(
-                            color: context.colors.textTertiary,
-                          ),
-                          filled: true,
-                          fillColor: context.colors.surfaceContainerLow,
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(8),
-                            borderSide: BorderSide(color: context.colors.outlineVariant),
-                          ),
-                          contentPadding: const EdgeInsets.all(16),
-                          counterStyle: KolabingTextStyles.bodySmall.copyWith(
-                            fontSize: 12,
-                            color: context.colors.textTertiary,
-                          ),
-                        ),
-                      ),
-                      const SizedBox(height: 24),
-
-                      // Instagram field
-                      Text(
-                        'Instagram',
-                        style: KolabingTextStyles.bodySmall.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: context.colors.onSurface,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      TextField(
-                        controller: _instagramController,
-                        style: KolabingTextStyles.bodyMedium.copyWith(
-                          color: context.colors.onSurface,
-                        ),
-                        decoration: InputDecoration(
-                          hintText: l10n.communityStep4UsernameHint,
-                          hintStyle: KolabingTextStyles.bodyMedium.copyWith(
-                            color: context.colors.textTertiary,
-                          ),
-                          prefixIcon: Icon(
-                            LucideIcons.instagram,
-                            size: 20,
-                            color: context.colors.textTertiary,
-                          ),
-                          prefixText: '@ ',
-                          prefixStyle: KolabingTextStyles.bodyMedium.copyWith(
-                            color: context.colors.textTertiary,
-                          ),
-                          filled: true,
-                          fillColor: context.colors.surfaceContainerLow,
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(8),
-                            borderSide: BorderSide(color: context.colors.outlineVariant),
-                          ),
-                          contentPadding: const EdgeInsets.symmetric(
-                            horizontal: 16,
-                            vertical: 16,
-                          ),
-                        ),
-                      ),
-                      const SizedBox(height: 24),
-
-                      // TikTok field
-                      Text(
-                        'TikTok',
-                        style: KolabingTextStyles.bodySmall.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: context.colors.onSurface,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      TextField(
-                        controller: _tiktokController,
-                        style: KolabingTextStyles.bodyMedium.copyWith(
-                          color: context.colors.onSurface,
-                        ),
-                        decoration: InputDecoration(
-                          hintText: l10n.communityStep4UsernameHint,
-                          hintStyle: KolabingTextStyles.bodyMedium.copyWith(
-                            color: context.colors.textTertiary,
-                          ),
-                          prefixIcon: Icon(
-                            LucideIcons.music,
-                            size: 20,
-                            color: context.colors.textTertiary,
-                          ),
-                          prefixText: '@ ',
-                          prefixStyle: KolabingTextStyles.bodyMedium.copyWith(
-                            color: context.colors.textTertiary,
-                          ),
-                          filled: true,
-                          fillColor: context.colors.surfaceContainerLow,
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(8),
-                            borderSide: BorderSide(color: context.colors.outlineVariant),
-                          ),
-                          contentPadding: const EdgeInsets.symmetric(
-                            horizontal: 16,
-                            vertical: 16,
-                          ),
-                        ),
-                      ),
-                      const SizedBox(height: 24),
-
-                      // Website field
-                      Text(
-                        l10n.communityStep4WebsiteLabel,
-                        style: KolabingTextStyles.bodySmall.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: context.colors.onSurface,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      TextField(
-                        controller: _websiteController,
-                        keyboardType: TextInputType.url,
-                        style: KolabingTextStyles.bodyMedium.copyWith(
-                          color: context.colors.onSurface,
-                        ),
-                        decoration: InputDecoration(
-                          hintText: l10n.communityStep4WebsiteHint,
-                          hintStyle: KolabingTextStyles.bodyMedium.copyWith(
-                            color: context.colors.textTertiary,
-                          ),
-                          prefixIcon: Icon(
-                            LucideIcons.globe,
-                            size: 20,
-                            color: context.colors.textTertiary,
-                          ),
-                          filled: true,
-                          fillColor: context.colors.surfaceContainerLow,
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(8),
-                            borderSide: BorderSide(color: context.colors.outlineVariant),
-                          ),
-                          contentPadding: const EdgeInsets.symmetric(
-                            horizontal: 16,
-                            vertical: 16,
-                          ),
-                        ),
-                      ),
-                      const SizedBox(height: 24),
-                    ],
+            // Bottom button
+            Padding(
+              padding: const EdgeInsets.all(24),
+              child: SizedBox(
+                width: double.infinity,
+                height: 52,
+                child: ElevatedButton(
+                  onPressed: _handleContinue,
+                  style: ElevatedButton.styleFrom(elevation: 0),
+                  child: Text(
+                    l10n.commonContinue,
+                    style: KolabingTextStyles.button.copyWith(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 1.0,
+                    ),
                   ),
                 ),
               ),
-
-              // Bottom button
-              Padding(
-                padding: const EdgeInsets.all(24),
-                child: SizedBox(
-                  width: double.infinity,
-                  height: 52,
-                  child: ElevatedButton(
-                    onPressed: _handleContinue,
-                    style: ElevatedButton.styleFrom(
-                      elevation: 0,
-                    ),
-                    child: Text(
-                      l10n.commonContinue,
-                      style: KolabingTextStyles.button.copyWith(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w700,
-                        letterSpacing: 1.0,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          ),
+            ),
+          ],
         ),
-      );
+      ),
+    );
   }
 }

--- a/lib/features/onboarding/services/onboarding_service.dart
+++ b/lib/features/onboarding/services/onboarding_service.dart
@@ -305,10 +305,10 @@ class OnboardingService {
       final failingKeys = apiError.errors!.keys
           .map((k) => k.split('.').first)
           .toSet();
-      final onlyNewFields = failingKeys.isNotEmpty &&
+      final onlyNewFields =
+          failingKeys.isNotEmpty &&
           failingKeys.every(_onboardingFieldsToStrip.contains);
-      final bodyHasNewFields =
-          body.keys.any(_onboardingFieldsToStrip.contains);
+      final bodyHasNewFields = body.keys.any(_onboardingFieldsToStrip.contains);
 
       if (onlyNewFields && bodyHasNewFields) {
         debugPrint(

--- a/lib/features/onboarding/widgets/city_list_item.dart
+++ b/lib/features/onboarding/widgets/city_list_item.dart
@@ -40,76 +40,79 @@ class _CityListItemState extends State<CityListItem> {
 
   @override
   Widget build(BuildContext context) => GestureDetector(
-        onTapDown: (_) => setState(() => _isPressed = true),
-        onTapUp: (_) => setState(() => _isPressed = false),
-        onTapCancel: () => setState(() => _isPressed = false),
-        onTap: () {
-          HapticFeedback.mediumImpact();
-          widget.onTap();
-        },
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 150),
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          decoration: BoxDecoration(
+    onTapDown: (_) => setState(() => _isPressed = true),
+    onTapUp: (_) => setState(() => _isPressed = false),
+    onTapCancel: () => setState(() => _isPressed = false),
+    onTap: () {
+      HapticFeedback.mediumImpact();
+      widget.onTap();
+    },
+    child: AnimatedContainer(
+      duration: const Duration(milliseconds: 150),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: widget.isSelected
+            ? context.colors.softYellow
+            : (_isPressed
+                  ? context.colors.surfaceVariant
+                  : context.colors.surface),
+        border: Border(
+          left: BorderSide(
             color: widget.isSelected
-                ? context.colors.softYellow
-                : (_isPressed
-                    ? context.colors.surfaceVariant
-                    : context.colors.surface),
-            border: Border(
-              left: BorderSide(
-                color:
-                    widget.isSelected ? context.colors.primary : Colors.transparent,
-                width: 4,
-              ),
-              bottom: BorderSide(
-                color: context.colors.darkBorder,
-                width: 1,
-              ),
+                ? context.colors.primary
+                : Colors.transparent,
+            width: 4,
+          ),
+          bottom: BorderSide(color: context.colors.darkBorder, width: 1),
+        ),
+      ),
+      child: Row(
+        children: [
+          // Location icon
+          Icon(
+            LucideIcons.mapPin,
+            size: 24,
+            color: widget.isSelected
+                ? context.colors.primary
+                : context.colors.textTertiary,
+          ),
+          const SizedBox(width: 12),
+
+          // City info
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  widget.name,
+                  style: KolabingTextStyles.bodyMedium.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: context.colors.onSurface,
+                  ),
+                ),
+                if (widget.country != null) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    widget.country!,
+                    style: KolabingTextStyles.bodySmall.copyWith(
+                      color: context.colors.textTertiary,
+                    ),
+                  ),
+                ],
+              ],
             ),
           ),
-          child: Row(
-            children: [
-              // Location icon
-              Icon(
-                LucideIcons.mapPin,
-                size: 24,
-                color: widget.isSelected
-                    ? context.colors.primary
-                    : context.colors.textTertiary,
-              ),
-              const SizedBox(width: 12),
 
-              // City info
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      widget.name,
-                      style: KolabingTextStyles.bodyMedium.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurface),
-                    ),
-                    if (widget.country != null) ...[
-                      const SizedBox(height: 2),
-                      Text(
-                        widget.country!,
-                        style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.textTertiary),
-                      ),
-                    ],
-                  ],
-                ),
-              ),
-
-              // Checkmark or arrow
-              Icon(
-                widget.isSelected ? LucideIcons.check : LucideIcons.chevronRight,
-                size: 20,
-                color: widget.isSelected
-                    ? context.colors.primary
-                    : context.colors.textTertiary,
-              ),
-            ],
+          // Checkmark or arrow
+          Icon(
+            widget.isSelected ? LucideIcons.check : LucideIcons.chevronRight,
+            size: 20,
+            color: widget.isSelected
+                ? context.colors.primary
+                : context.colors.textTertiary,
           ),
-        ),
-      );
+        ],
+      ),
+    ),
+  );
 }

--- a/lib/features/onboarding/widgets/google_photos_preview_sheet.dart
+++ b/lib/features/onboarding/widgets/google_photos_preview_sheet.dart
@@ -28,8 +28,7 @@ class GooglePhotosPreviewSheet extends StatefulWidget {
       useSafeArea: true,
       builder: (context) => GooglePhotosPreviewSheet(photos: photos),
     );
-    return result ??
-        photos.map((photo) => photo.resourceName).toSet();
+    return result ?? photos.map((photo) => photo.resourceName).toSet();
   }
 
   @override
@@ -95,12 +94,19 @@ class _GooglePhotosPreviewSheetState extends State<GooglePhotosPreviewSheet> {
                 children: [
                   Text(
                     'Review photos from Google',
-                    style: KolabingTextStyles.bodyLarge.copyWith(fontSize: 20, fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                    style: KolabingTextStyles.bodyLarge.copyWith(
+                      fontSize: 20,
+                      fontWeight: FontWeight.w600,
+                      color: context.colors.onSurface,
+                    ),
                   ),
                   const SizedBox(height: 6),
                   Text(
                     'Tap any photo to remove it before we add it to your venue. You can always edit photos later.',
-                    style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant, height: 1.4),
+                    style: KolabingTextStyles.captionSecondary.copyWith(
+                      color: context.colors.onSurfaceVariant,
+                      height: 1.4,
+                    ),
                   ),
                 ],
               ),
@@ -109,12 +115,11 @@ class _GooglePhotosPreviewSheetState extends State<GooglePhotosPreviewSheet> {
             Expanded(
               child: GridView.builder(
                 padding: const EdgeInsets.fromLTRB(20, 0, 20, 16),
-                gridDelegate:
-                    const SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: 3,
-                      mainAxisSpacing: 10,
-                      crossAxisSpacing: 10,
-                    ),
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 3,
+                  mainAxisSpacing: 10,
+                  crossAxisSpacing: 10,
+                ),
                 itemCount: widget.photos.length,
                 itemBuilder: (context, index) {
                   final photo = widget.photos[index];
@@ -154,7 +159,9 @@ class _GooglePhotosPreviewSheetState extends State<GooglePhotosPreviewSheet> {
                       Expanded(
                         child: Text(
                           'Photos from Google. Credits are kept with each photo.',
-                          style: KolabingTextStyles.labelSmall.copyWith(color: context.colors.textTertiary),
+                          style: KolabingTextStyles.labelSmall.copyWith(
+                            color: context.colors.textTertiary,
+                          ),
                         ),
                       ),
                     ],
@@ -172,7 +179,10 @@ class _GooglePhotosPreviewSheetState extends State<GooglePhotosPreviewSheet> {
                       ),
                       child: Text(
                         buttonLabel,
-                        style: KolabingTextStyles.button.copyWith(fontSize: 15, letterSpacing: 1),
+                        style: KolabingTextStyles.button.copyWith(
+                          fontSize: 15,
+                          letterSpacing: 1,
+                        ),
                       ),
                     ),
                   ),
@@ -209,15 +219,28 @@ class _PhotoTile extends StatelessWidget {
             borderRadius: BorderRadius.circular(12),
             child: ColorFiltered(
               colorFilter: isKept
-                  ? const ColorFilter.mode(
-                      Colors.transparent,
-                      BlendMode.dst,
-                    )
+                  ? const ColorFilter.mode(Colors.transparent, BlendMode.dst)
                   : const ColorFilter.matrix(<double>[
-                      0.2126, 0.7152, 0.0722, 0, 0,
-                      0.2126, 0.7152, 0.0722, 0, 0,
-                      0.2126, 0.7152, 0.0722, 0, 0,
-                      0, 0, 0, 1, 0,
+                      0.2126,
+                      0.7152,
+                      0.0722,
+                      0,
+                      0,
+                      0.2126,
+                      0.7152,
+                      0.0722,
+                      0,
+                      0,
+                      0.2126,
+                      0.7152,
+                      0.0722,
+                      0,
+                      0,
+                      0,
+                      0,
+                      0,
+                      1,
+                      0,
                     ]),
               child: Image.network(
                 photo.previewUrl,

--- a/lib/features/onboarding/widgets/progress_indicator.dart
+++ b/lib/features/onboarding/widgets/progress_indicator.dart
@@ -21,24 +21,21 @@ class OnboardingProgressIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => SizedBox(
-        height: 24,
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: List.generate(
-            totalSteps * 2 - 1,
-            (index) {
-              // Even indices are circles, odd indices are lines
-              if (index.isEven) {
-                final stepNumber = (index ~/ 2) + 1;
-                return _buildCircle(context, stepNumber);
-              } else {
-                final stepNumber = (index ~/ 2) + 1;
-                return _buildLine(context, stepNumber);
-              }
-            },
-          ),
-        ),
-      );
+    height: 24,
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(totalSteps * 2 - 1, (index) {
+        // Even indices are circles, odd indices are lines
+        if (index.isEven) {
+          final stepNumber = (index ~/ 2) + 1;
+          return _buildCircle(context, stepNumber);
+        } else {
+          final stepNumber = (index ~/ 2) + 1;
+          return _buildLine(context, stepNumber);
+        }
+      }),
+    ),
+  );
 
   Widget _buildCircle(BuildContext context, int stepNumber) {
     final isActive = stepNumber <= currentStep;
@@ -50,18 +47,18 @@ class OnboardingProgressIndicator extends StatelessWidget {
       height: 12,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
-        color: isActive ? context.colors.primary : context.colors.surfaceVariant,
+        color: isActive
+            ? context.colors.primary
+            : context.colors.surfaceVariant,
         border: Border.all(
-          color: isActive ? context.colors.primary : context.colors.outlineVariant,
+          color: isActive
+              ? context.colors.primary
+              : context.colors.outlineVariant,
           width: 2,
         ),
       ),
       child: isCompleted
-          ? Icon(
-              Icons.check,
-              size: 8,
-              color: context.colors.onSurface,
-            )
+          ? Icon(Icons.check, size: 8, color: context.colors.onSurface)
           : null,
     );
   }
@@ -75,7 +72,9 @@ class OnboardingProgressIndicator extends StatelessWidget {
       height: 2,
       margin: const EdgeInsets.symmetric(horizontal: 4),
       decoration: BoxDecoration(
-        color: isActive ? context.colors.primary : context.colors.outlineVariant,
+        color: isActive
+            ? context.colors.primary
+            : context.colors.outlineVariant,
         borderRadius: BorderRadius.circular(1),
       ),
     );

--- a/lib/features/onboarding/widgets/summary_card.dart
+++ b/lib/features/onboarding/widgets/summary_card.dart
@@ -74,12 +74,17 @@ class SummaryCard extends StatelessWidget {
                     children: [
                       Text(
                         data.name ?? 'No name',
-                        style: KolabingTextStyles.bodyMedium.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                        style: KolabingTextStyles.bodyMedium.copyWith(
+                          fontWeight: FontWeight.w600,
+                          color: context.colors.onSurface,
+                        ),
                       ),
                       const SizedBox(height: 2),
                       Text(
                         '${data.isBusiness ? data.businessTypesSummary : (data.typeName ?? 'Unknown type')} \u2022 ${data.location?.city ?? data.cityName ?? 'Unknown city'}',
-                        style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant),
+                        style: KolabingTextStyles.bodySmall.copyWith(
+                          color: context.colors.onSurfaceVariant,
+                        ),
                       ),
                     ],
                   ),
@@ -128,7 +133,10 @@ class SummaryCard extends StatelessWidget {
               if (data.about != null && data.about!.isNotEmpty) ...[
                 Text(
                   data.about!,
-                  style: KolabingTextStyles.bodySmall.copyWith(color: context.colors.onSurfaceVariant, height: 1.4),
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    color: context.colors.onSurfaceVariant,
+                    height: 1.4,
+                  ),
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                 ),
@@ -192,7 +200,11 @@ class _SummaryDetailItem extends StatelessWidget {
         Expanded(
           child: Text(
             text,
-            style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.onSurfaceVariant, height: 1.35),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontSize: 12,
+              color: context.colors.onSurfaceVariant,
+              height: 1.35,
+            ),
             softWrap: true,
           ),
         ),
@@ -224,7 +236,10 @@ class _SummaryInlineItem extends StatelessWidget {
             text,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
-            style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.onSurfaceVariant),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontSize: 12,
+              color: context.colors.onSurfaceVariant,
+            ),
           ),
         ),
       ],

--- a/lib/features/onboarding/widgets/type_selection_card.dart
+++ b/lib/features/onboarding/widgets/type_selection_card.dart
@@ -44,9 +44,10 @@ class _TypeSelectionCardState extends State<TypeSelectionCard>
       duration: const Duration(milliseconds: 120),
       vsync: this,
     );
-    _scaleAnimation = Tween<double>(begin: 1.0, end: 0.95).animate(
-      CurvedAnimation(parent: _controller, curve: Curves.easeOut),
-    );
+    _scaleAnimation = Tween<double>(
+      begin: 1.0,
+      end: 0.95,
+    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
   }
 
   @override
@@ -66,69 +67,76 @@ class _TypeSelectionCardState extends State<TypeSelectionCard>
 
   @override
   Widget build(BuildContext context) => GestureDetector(
-        onTapDown: _handleTapDown,
-        onTapUp: _handleTapUp,
-        onTapCancel: _handleTapCancel,
-        onTap: _handleTap,
-        child: AnimatedBuilder(
-          animation: _scaleAnimation,
-          builder: (context, child) =>
-              Transform.scale(scale: _scaleAnimation.value, child: child),
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 180),
-            decoration: BoxDecoration(
+    onTapDown: _handleTapDown,
+    onTapUp: _handleTapUp,
+    onTapCancel: _handleTapCancel,
+    onTap: _handleTap,
+    child: AnimatedBuilder(
+      animation: _scaleAnimation,
+      builder: (context, child) =>
+          Transform.scale(scale: _scaleAnimation.value, child: child),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 180),
+        decoration: BoxDecoration(
+          color: widget.isSelected ? context.colors.softYellow : Colors.white,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: widget.isSelected
+                ? context.colors.primary
+                : const Color(0xFFE2E8F0),
+            width: widget.isSelected ? 2.5 : 1.5,
+          ),
+          boxShadow: [
+            BoxShadow(
               color: widget.isSelected
-                  ? context.colors.softYellow
-                  : Colors.white,
-              borderRadius: BorderRadius.circular(16),
-              border: Border.all(
-                color: widget.isSelected
-                    ? context.colors.primary
-                    : const Color(0xFFE2E8F0),
-                width: widget.isSelected ? 2.5 : 1.5,
+                  ? context.colors.primary.withValues(alpha: 0.18)
+                  : Colors.black.withValues(alpha: 0.05),
+              blurRadius: widget.isSelected ? 12 : 6,
+              offset: const Offset(0, 3),
+            ),
+          ],
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              // Category illustration
+              CategoryIcon(
+                name: widget.name,
+                iconUrl: widget.iconUrl,
+                size: 40,
               ),
-              boxShadow: [
-                BoxShadow(
-                  color: widget.isSelected
-                      ? context.colors.primary.withValues(alpha: 0.18)
-                      : Colors.black.withValues(alpha: 0.05),
-                  blurRadius: widget.isSelected ? 12 : 6,
-                  offset: const Offset(0, 3),
+              const SizedBox(height: 6),
+              // Name — full text, up to 2 lines, centred
+              Text(
+                widget.name,
+                style: KolabingTextStyles.bodySmall.copyWith(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  color: context.colors.onSurface,
+                  height: 1.25,
+                ),
+                textAlign: TextAlign.center,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              // Selection indicator dot
+              if (widget.isSelected) ...[
+                const SizedBox(height: 8),
+                Container(
+                  width: 8,
+                  height: 8,
+                  decoration: BoxDecoration(
+                    color: context.colors.primary,
+                    shape: BoxShape.circle,
+                  ),
                 ),
               ],
-            ),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  // Category illustration
-                  CategoryIcon(name: widget.name, iconUrl: widget.iconUrl, size: 40),
-                  const SizedBox(height: 6),
-                  // Name — full text, up to 2 lines, centred
-                  Text(
-                    widget.name,
-                    style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: FontWeight.w700, color: context.colors.onSurface, height: 1.25),
-                    textAlign: TextAlign.center,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  // Selection indicator dot
-                  if (widget.isSelected) ...[
-                    const SizedBox(height: 8),
-                    Container(
-                      width: 8,
-                      height: 8,
-                      decoration: BoxDecoration(
-                        color: context.colors.primary,
-                        shape: BoxShape.circle,
-                      ),
-                    ),
-                  ],
-                ],
-              ),
-            ),
+            ],
           ),
         ),
-      );
+      ),
+    ),
+  );
 }

--- a/lib/features/onboarding/widgets/venue_photo_manager.dart
+++ b/lib/features/onboarding/widgets/venue_photo_manager.dart
@@ -85,7 +85,11 @@ class VenuePhotoManager extends StatelessWidget {
           const SizedBox(height: 12),
           Text(
             AppLocalizations.of(context).venuePhotoPoweredByGoogle,
-            style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: FontWeight.w600, color: context.colors.textTertiary),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: context.colors.textTertiary,
+            ),
           ),
         ],
       ],
@@ -123,12 +127,19 @@ class _EmptyPhotoState extends StatelessWidget {
         const SizedBox(height: 12),
         Text(
           title ?? AppLocalizations.of(context).venuePhotoEmptyTitle,
-          style: KolabingTextStyles.bodyMedium.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurface),
+          style: KolabingTextStyles.bodyMedium.copyWith(
+            fontWeight: FontWeight.w600,
+            color: context.colors.onSurface,
+          ),
         ),
         const SizedBox(height: 6),
         Text(
-          description ?? AppLocalizations.of(context).venuePhotoEmptyDescription,
-          style: KolabingTextStyles.captionSecondary.copyWith(color: context.colors.onSurfaceVariant, height: 1.4),
+          description ??
+              AppLocalizations.of(context).venuePhotoEmptyDescription,
+          style: KolabingTextStyles.captionSecondary.copyWith(
+            color: context.colors.onSurfaceVariant,
+            height: 1.4,
+          ),
           textAlign: TextAlign.center,
         ),
         const SizedBox(height: 14),
@@ -194,11 +205,13 @@ class _VenuePhotoCard extends StatelessWidget {
                 Row(
                   children: [
                     Text(
-                      AppLocalizations.of(context).venuePhotoPositionLabel(
-                        index + 1,
-                        total,
+                      AppLocalizations.of(
+                        context,
+                      ).venuePhotoPositionLabel(index + 1, total),
+                      style: KolabingTextStyles.bodySmall.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: context.colors.onSurface,
                       ),
-                      style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurface),
                     ),
                     const SizedBox(width: 8),
                     Container(
@@ -214,7 +227,10 @@ class _VenuePhotoCard extends StatelessWidget {
                       ),
                       child: Text(
                         _sourceLabel(context),
-                        style: KolabingTextStyles.labelSmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurface),
+                        style: KolabingTextStyles.labelSmall.copyWith(
+                          fontWeight: FontWeight.w700,
+                          color: context.colors.onSurface,
+                        ),
                       ),
                     ),
                   ],
@@ -228,7 +244,9 @@ class _VenuePhotoCard extends StatelessWidget {
                       color: onMoveLeft == null
                           ? context.colors.textTertiary
                           : context.colors.onSurface,
-                      tooltip: AppLocalizations.of(context).venuePhotoMoveEarlier,
+                      tooltip: AppLocalizations.of(
+                        context,
+                      ).venuePhotoMoveEarlier,
                     ),
                     IconButton(
                       onPressed: onMoveRight,
@@ -243,7 +261,9 @@ class _VenuePhotoCard extends StatelessWidget {
                       onPressed: onRemove,
                       icon: const Icon(LucideIcons.trash2, size: 18),
                       color: context.colors.error,
-                      tooltip: AppLocalizations.of(context).venuePhotoRemovePhoto,
+                      tooltip: AppLocalizations.of(
+                        context,
+                      ).venuePhotoRemovePhoto,
                     ),
                   ],
                 ),
@@ -257,7 +277,11 @@ class _VenuePhotoCard extends StatelessWidget {
                     ),
                     label: Text(
                       AppLocalizations.of(context).venuePhotoCredits,
-                      style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: FontWeight.w600, color: context.colors.primary),
+                      style: KolabingTextStyles.bodySmall.copyWith(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        color: context.colors.primary,
+                      ),
                     ),
                   ),
               ],
@@ -297,20 +321,30 @@ class _VenuePhotoCard extends StatelessWidget {
               const SizedBox(height: 16),
               Text(
                 AppLocalizations.of(context).venuePhotoCreditsSheetTitle,
-                style: KolabingTextStyles.bodyMedium.copyWith(fontSize: 18, fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                style: KolabingTextStyles.bodyMedium.copyWith(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                  color: context.colors.onSurface,
+                ),
               ),
               const SizedBox(height: 8),
               for (final item in photo.authorAttributions) ...[
                 Text(
                   item.displayName,
-                  style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurface),
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: context.colors.onSurface,
+                  ),
                 ),
                 if (item.uri != null && item.uri!.isNotEmpty)
                   Padding(
                     padding: const EdgeInsets.only(top: 2),
                     child: SelectableText(
                       item.uri!,
-                      style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.onSurfaceVariant),
+                      style: KolabingTextStyles.bodySmall.copyWith(
+                        fontSize: 12,
+                        color: context.colors.onSurfaceVariant,
+                      ),
                     ),
                   ),
                 if (item.photoUri != null && item.photoUri!.isNotEmpty)
@@ -318,14 +352,21 @@ class _VenuePhotoCard extends StatelessWidget {
                     padding: const EdgeInsets.only(top: 2),
                     child: SelectableText(
                       item.photoUri!,
-                      style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.onSurfaceVariant),
+                      style: KolabingTextStyles.bodySmall.copyWith(
+                        fontSize: 12,
+                        color: context.colors.onSurfaceVariant,
+                      ),
                     ),
                   ),
                 const SizedBox(height: 12),
               ],
               Text(
                 AppLocalizations.of(context).venuePhotoPoweredByGoogle,
-                style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: FontWeight.w600, color: context.colors.textTertiary),
+                style: KolabingTextStyles.bodySmall.copyWith(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: context.colors.textTertiary,
+                ),
               ),
             ],
           ),

--- a/lib/features/opportunity/models/opportunity_filter.dart
+++ b/lib/features/opportunity/models/opportunity_filter.dart
@@ -59,23 +59,22 @@ class OpportunityFilters {
     bool clearVenueMode = false,
     bool clearAvailabilityMode = false,
     bool clearDateRange = false,
-  }) =>
-      OpportunityFilters(
-        searchQuery: searchQuery ?? this.searchQuery,
-        creatorType:
-            clearCreatorType ? null : (creatorType ?? this.creatorType),
-        selectedCategories: selectedCategories ?? this.selectedCategories,
-        selectedCity: clearCity ? null : (selectedCity ?? this.selectedCity),
-        venueMode: clearVenueMode ? null : (venueMode ?? this.venueMode),
-        availabilityMode: clearAvailabilityMode
-            ? null
-            : (availabilityMode ?? this.availabilityMode),
-        availabilityFrom: clearDateRange
-            ? null
-            : (availabilityFrom ?? this.availabilityFrom),
-        availabilityTo:
-            clearDateRange ? null : (availabilityTo ?? this.availabilityTo),
-      );
+  }) => OpportunityFilters(
+    searchQuery: searchQuery ?? this.searchQuery,
+    creatorType: clearCreatorType ? null : (creatorType ?? this.creatorType),
+    selectedCategories: selectedCategories ?? this.selectedCategories,
+    selectedCity: clearCity ? null : (selectedCity ?? this.selectedCity),
+    venueMode: clearVenueMode ? null : (venueMode ?? this.venueMode),
+    availabilityMode: clearAvailabilityMode
+        ? null
+        : (availabilityMode ?? this.availabilityMode),
+    availabilityFrom: clearDateRange
+        ? null
+        : (availabilityFrom ?? this.availabilityFrom),
+    availabilityTo: clearDateRange
+        ? null
+        : (availabilityTo ?? this.availabilityTo),
+  );
 
   /// Reset all filters
   static const OpportunityFilters empty = OpportunityFilters();
@@ -91,19 +90,21 @@ class OpportunityFilters {
       params['availability_mode'] = availabilityMode!;
     }
     if (availabilityFrom != null) {
-      params['availability_from'] =
-          availabilityFrom!.toIso8601String().split('T').first;
+      params['availability_from'] = availabilityFrom!
+          .toIso8601String()
+          .split('T')
+          .first;
     }
     if (availabilityTo != null) {
-      params['availability_to'] =
-          availabilityTo!.toIso8601String().split('T').first;
+      params['availability_to'] = availabilityTo!
+          .toIso8601String()
+          .split('T')
+          .first;
     }
     return params;
   }
 
   /// Category query parameters need special handling (array)
   List<MapEntry<String, String>> toCategoryParams() =>
-      selectedCategories
-          .map((c) => MapEntry('categories[]', c))
-          .toList();
+      selectedCategories.map((c) => MapEntry('categories[]', c)).toList();
 }

--- a/lib/features/profile/widgets/past_collaboration_card.dart
+++ b/lib/features/profile/widgets/past_collaboration_card.dart
@@ -78,7 +78,10 @@ class PastCollaborationCard extends StatelessWidget {
               const SizedBox(width: 4),
               Text(
                 DateFormat('MMM yyyy').format(collaboration.completedAt),
-                style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.textTertiary),
+                style: KolabingTextStyles.bodySmall.copyWith(
+                  fontSize: 12,
+                  color: context.colors.textTertiary,
+                ),
               ),
               const Spacer(),
               Container(
@@ -98,7 +101,11 @@ class PastCollaborationCard extends StatelessWidget {
                     const SizedBox(width: 3),
                     Text(
                       'Completed',
-                      style: KolabingTextStyles.labelSmall.copyWith(fontSize: 10, fontWeight: FontWeight.w600, color: context.colors.success),
+                      style: KolabingTextStyles.labelSmall.copyWith(
+                        fontSize: 10,
+                        fontWeight: FontWeight.w600,
+                        color: context.colors.success,
+                      ),
                     ),
                   ],
                 ),
@@ -159,7 +166,10 @@ class _InitialCircle extends StatelessWidget {
     child: Center(
       child: Text(
         initial,
-        style: KolabingTextStyles.bodyMedium.copyWith(fontWeight: FontWeight.w600, color: context.colors.onSurface),
+        style: KolabingTextStyles.bodyMedium.copyWith(
+          fontWeight: FontWeight.w600,
+          color: context.colors.onSurface,
+        ),
       ),
     ),
   );

--- a/lib/features/rewards/models/ledger_entry.dart
+++ b/lib/features/rewards/models/ledger_entry.dart
@@ -103,13 +103,14 @@ class LedgerEntry {
   });
 
   factory LedgerEntry.fromJson(Map<String, dynamic> json) => LedgerEntry(
-        id: json['id']?.toString() ?? '',
-        points: _parseInt(json['points']) ?? 0,
-        eventType: PointEventType.fromString(
-            json['event_type']?.toString() ?? 'collaboration_complete'),
-        description: json['description']?.toString() ?? '',
-        createdAt: _parseDateTime(json['created_at']),
-      );
+    id: json['id']?.toString() ?? '',
+    points: _parseInt(json['points']) ?? 0,
+    eventType: PointEventType.fromString(
+      json['event_type']?.toString() ?? 'collaboration_complete',
+    ),
+    description: json['description']?.toString() ?? '',
+    createdAt: _parseDateTime(json['created_at']),
+  );
 
   final String id;
   final int points;

--- a/lib/features/rewards/models/wallet_model.dart
+++ b/lib/features/rewards/models/wallet_model.dart
@@ -15,10 +15,10 @@ class XpModel {
   });
 
   factory XpModel.fromJson(Map<String, dynamic> json) => XpModel(
-        totalXp: _parseInt(json['points']) ?? 0,
-        redeemedPoints: _parseInt(json['redeemed_points']) ?? 0,
-        pendingWithdrawal: json['pending_withdrawal'] == true,
-      );
+    totalXp: _parseInt(json['points']) ?? 0,
+    redeemedPoints: _parseInt(json['redeemed_points']) ?? 0,
+    pendingWithdrawal: json['pending_withdrawal'] == true,
+  );
 
   /// Total XP earned (lifetime).
   final int totalXp;

--- a/lib/features/rewards/screens/referral_screen.dart
+++ b/lib/features/rewards/screens/referral_screen.dart
@@ -38,7 +38,11 @@ class ReferralScreen extends ConsumerWidget {
         surfaceTintColor: Colors.transparent,
         title: Text(
           AppLocalizations.of(context).referralScreenTitle,
-          style: KolabingTextStyles.bodyMedium.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurface, letterSpacing: 1.0),
+          style: KolabingTextStyles.bodyMedium.copyWith(
+            fontWeight: FontWeight.w700,
+            color: context.colors.onSurface,
+            letterSpacing: 1.0,
+          ),
         ),
         centerTitle: true,
         leading: IconButton(
@@ -100,13 +104,23 @@ class ReferralScreen extends ConsumerWidget {
       children: [
         Text(
           AppLocalizations.of(context).referralScreenYourCode,
-          style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: FontWeight.w600, color: context.colors.onPrimary.withValues(alpha: 0.7), letterSpacing: 1.2),
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            color: context.colors.onPrimary.withValues(alpha: 0.7),
+            letterSpacing: 1.2,
+          ),
         ),
         const SizedBox(height: KolabingSpacing.sm),
         Text(
           code,
           textAlign: TextAlign.center,
-          style: KolabingTextStyles.bodyLarge.copyWith(fontSize: 32, fontWeight: FontWeight.w700, color: context.colors.onPrimary, letterSpacing: 3.0),
+          style: KolabingTextStyles.bodyLarge.copyWith(
+            fontSize: 32,
+            fontWeight: FontWeight.w700,
+            color: context.colors.onPrimary,
+            letterSpacing: 3.0,
+          ),
         ),
       ],
     ),
@@ -199,7 +213,11 @@ class ReferralScreen extends ConsumerWidget {
         children: [
           Text(
             l10n.referralScreenHowItWorks,
-            style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontWeight: FontWeight.w700,
+              color: context.colors.onSurfaceVariant,
+              letterSpacing: 1.0,
+            ),
           ),
           const SizedBox(height: KolabingSpacing.lg),
 
@@ -252,7 +270,10 @@ class ReferralScreen extends ConsumerWidget {
         child: Center(
           child: Text(
             '$number',
-            style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onPrimary),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontWeight: FontWeight.w700,
+              color: context.colors.onPrimary,
+            ),
           ),
         ),
       ),
@@ -305,7 +326,11 @@ class ReferralScreen extends ConsumerWidget {
         children: [
           Text(
             l10n.referralScreenRewardTiers,
-            style: KolabingTextStyles.bodySmall.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurfaceVariant, letterSpacing: 1.0),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontWeight: FontWeight.w700,
+              color: context.colors.onSurfaceVariant,
+              letterSpacing: 1.0,
+            ),
           ),
           const SizedBox(height: KolabingSpacing.md),
 

--- a/lib/features/rewards/screens/wallet_screen.dart
+++ b/lib/features/rewards/screens/wallet_screen.dart
@@ -83,28 +83,36 @@ class _WalletScreenState extends ConsumerState<WalletScreen> {
             const SizedBox(height: KolabingSpacing.lg),
 
             // 2 — Ways to earn
-            _buildSectionHeader(AppLocalizations.of(context).walletScreenWaysToEarn),
+            _buildSectionHeader(
+              AppLocalizations.of(context).walletScreenWaysToEarn,
+            ),
             const SizedBox(height: KolabingSpacing.sm),
             _buildMissionsCard(),
 
             const SizedBox(height: KolabingSpacing.lg),
 
             // 3 — Badges
-            _buildSectionHeader(AppLocalizations.of(context).walletScreenBadges),
+            _buildSectionHeader(
+              AppLocalizations.of(context).walletScreenBadges,
+            ),
             const SizedBox(height: KolabingSpacing.sm),
             _buildBadgesGrid(state),
 
             const SizedBox(height: KolabingSpacing.lg),
 
             // 4 — Cash referral milestone (separate from XP)
-            _buildSectionHeader(AppLocalizations.of(context).walletScreenCashReferral),
+            _buildSectionHeader(
+              AppLocalizations.of(context).walletScreenCashReferral,
+            ),
             const SizedBox(height: KolabingSpacing.sm),
             _buildReferralMilestoneCard(state),
 
             const SizedBox(height: KolabingSpacing.lg),
 
             // 5 — XP History
-            _buildSectionHeader(AppLocalizations.of(context).walletScreenXpHistory),
+            _buildSectionHeader(
+              AppLocalizations.of(context).walletScreenXpHistory,
+            ),
             const SizedBox(height: KolabingSpacing.sm),
             _buildXpHistory(state),
 
@@ -231,9 +239,7 @@ class _WalletScreenState extends ConsumerState<WalletScreen> {
             value: level.progress(points),
             minHeight: 6,
             backgroundColor: context.colors.onPrimary.withValues(alpha: 0.15),
-            valueColor: AlwaysStoppedAnimation<Color>(
-              context.colors.onPrimary,
-            ),
+            valueColor: AlwaysStoppedAnimation<Color>(context.colors.onPrimary),
           ),
         ),
         if (!level.isMaxLevel) ...[
@@ -438,11 +444,9 @@ class _WalletScreenState extends ConsumerState<WalletScreen> {
           Text(
             conversions >= goal
                 ? AppLocalizations.of(context).walletScreenMilestoneReached
-                : AppLocalizations.of(context).walletScreenMilestoneProgress(
-                    conversions,
-                    goal,
-                    remaining,
-                  ),
+                : AppLocalizations.of(
+                    context,
+                  ).walletScreenMilestoneProgress(conversions, goal, remaining),
             style: KolabingTextStyles.bodySmall.copyWith(
               color: context.colors.onSurfaceVariant,
             ),
@@ -715,7 +719,9 @@ class _BadgeCard extends StatelessWidget {
         color: context.colors.surface,
         borderRadius: KolabingRadius.borderRadiusLg,
         border: Border.all(
-          color: isUnlocked ? context.colors.primary : context.colors.darkBorder,
+          color: isUnlocked
+              ? context.colors.primary
+              : context.colors.darkBorder,
           width: isUnlocked ? 2 : 1,
         ),
         boxShadow: isUnlocked
@@ -854,12 +860,12 @@ class _LedgerRow extends StatelessWidget {
               ),
               child: Text(
                 isEarned
-                    ? AppLocalizations.of(context).walletScreenXpGain(
-                        entry.points,
-                      )
-                    : AppLocalizations.of(context).walletScreenXpAmount(
-                        entry.points,
-                      ),
+                    ? AppLocalizations.of(
+                        context,
+                      ).walletScreenXpGain(entry.points)
+                    : AppLocalizations.of(
+                        context,
+                      ).walletScreenXpAmount(entry.points),
                 style: KolabingTextStyles.captionSecondary.copyWith(
                   fontWeight: FontWeight.w700,
                   color: isEarned

--- a/lib/features/rewards/screens/withdrawal_request_screen.dart
+++ b/lib/features/rewards/screens/withdrawal_request_screen.dart
@@ -99,7 +99,11 @@ class _WithdrawalRequestScreenState
         surfaceTintColor: Colors.transparent,
         title: Text(
           AppLocalizations.of(context).withdrawalScreenTitle,
-          style: KolabingTextStyles.bodyMedium.copyWith(fontWeight: FontWeight.w700, color: context.colors.onSurface, letterSpacing: 1.0),
+          style: KolabingTextStyles.bodyMedium.copyWith(
+            fontWeight: FontWeight.w700,
+            color: context.colors.onSurface,
+            letterSpacing: 1.0,
+          ),
         ),
         centerTitle: true,
         leading: IconButton(
@@ -241,7 +245,11 @@ class _WithdrawalRequestScreenState
                     const SizedBox(height: 2),
                     Text(
                       'EUR ${eurValue.toStringAsFixed(2)}',
-                      style: KolabingTextStyles.bodyLarge.copyWith(fontSize: 24, fontWeight: FontWeight.w700, color: context.colors.onSurface),
+                      style: KolabingTextStyles.bodyLarge.copyWith(
+                        fontSize: 24,
+                        fontWeight: FontWeight.w700,
+                        color: context.colors.onSurface,
+                      ),
                     ),
                   ],
                 ),
@@ -292,9 +300,9 @@ class _WithdrawalRequestScreenState
 
         // Submit button
         KolabingButton(
-          label: AppLocalizations.of(context).withdrawalSubmitButton(
-            eurValue.toStringAsFixed(2),
-          ),
+          label: AppLocalizations.of(
+            context,
+          ).withdrawalSubmitButton(eurValue.toStringAsFixed(2)),
           onPressed: _isFormValid && !state.isWithdrawing
               ? _handleSubmit
               : null,

--- a/lib/features/rewards/services/rewards_service.dart
+++ b/lib/features/rewards/services/rewards_service.dart
@@ -171,7 +171,8 @@ class RewardsService {
 
   /// GET /api/v1/gamification/referral-code
   /// Returns code, referral link, and total qualified conversions.
-  Future<({String code, String link, int totalConversions})> getReferralCode() async {
+  Future<({String code, String link, int totalConversions})>
+  getReferralCode() async {
     final uri = Uri.parse('$_baseUrl/gamification/referral-code');
     debugPrint('RewardsService: GET $uri');
 

--- a/lib/features/rewards/widgets/badge_celebration_overlay.dart
+++ b/lib/features/rewards/widgets/badge_celebration_overlay.dart
@@ -103,103 +103,110 @@ class _BadgeCelebrationOverlayState extends State<BadgeCelebrationOverlay>
 
   @override
   Widget build(BuildContext context) => Material(
-      color: Colors.transparent,
-      child: Stack(
-        children: [
-          // Black scrim — tap to dismiss
-          GestureDetector(
-            onTap: widget.onDismiss,
-            child: Container(
-              color: Colors.black.withValues(alpha: 0.70),
-            ),
-          ),
+    color: Colors.transparent,
+    child: Stack(
+      children: [
+        // Black scrim — tap to dismiss
+        GestureDetector(
+          onTap: widget.onDismiss,
+          child: Container(color: Colors.black.withValues(alpha: 0.70)),
+        ),
 
-          // Content
-          Center(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: KolabingSpacing.xl),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  // Animated badge icon
-                  ScaleTransition(
-                    scale: _scaleAnimation,
-                    child: Container(
-                      width: 96,
-                      height: 96,
-                      decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        color: context.colors.softYellow,
-                      ),
-                      child: Icon(
-                        widget.badge.slug.icon,
-                        size: 44,
-                        color: context.colors.onSurface,
-                      ),
+        // Content
+        Center(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: KolabingSpacing.xl),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // Animated badge icon
+                ScaleTransition(
+                  scale: _scaleAnimation,
+                  child: Container(
+                    width: 96,
+                    height: 96,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: context.colors.softYellow,
+                    ),
+                    child: Icon(
+                      widget.badge.slug.icon,
+                      size: 44,
+                      color: context.colors.onSurface,
                     ),
                   ),
+                ),
 
-                  const SizedBox(height: KolabingSpacing.lg),
+                const SizedBox(height: KolabingSpacing.lg),
 
-                  // "New Badge Unlocked!"
-                  Text(
-                    'New Badge Unlocked!',
-                    style: KolabingTextStyles.bodyLarge.copyWith(fontSize: 24, fontWeight: FontWeight.w700, color: Colors.white),
+                // "New Badge Unlocked!"
+                Text(
+                  'New Badge Unlocked!',
+                  style: KolabingTextStyles.bodyLarge.copyWith(
+                    fontSize: 24,
+                    fontWeight: FontWeight.w700,
+                    color: Colors.white,
                   ),
+                ),
 
-                  const SizedBox(height: KolabingSpacing.xs),
+                const SizedBox(height: KolabingSpacing.xs),
 
-                  // Badge display name
-                  Text(
-                    widget.badge.slug.displayName,
-                    style: KolabingTextStyles.bodyMedium.copyWith(fontSize: 18, fontWeight: FontWeight.w600, color: context.colors.primary),
+                // Badge display name
+                Text(
+                  widget.badge.slug.displayName,
+                  style: KolabingTextStyles.bodyMedium.copyWith(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                    color: context.colors.primary,
                   ),
+                ),
 
-                  const SizedBox(height: KolabingSpacing.xs),
+                const SizedBox(height: KolabingSpacing.xs),
 
-                  // Badge description
-                  Text(
-                    widget.badge.slug.description,
-                    textAlign: TextAlign.center,
-                    style: KolabingTextStyles.bodySmall.copyWith(color: Colors.white.withValues(alpha: 0.70),
-                    ),
+                // Badge description
+                Text(
+                  widget.badge.slug.description,
+                  textAlign: TextAlign.center,
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    color: Colors.white.withValues(alpha: 0.70),
                   ),
+                ),
 
-                  const SizedBox(height: KolabingSpacing.lg),
+                const SizedBox(height: KolabingSpacing.lg),
 
-                  // CTA button
-                  KolabingButton(
-                    label: 'SEE MY BADGES',
-                    onPressed: widget.onDismiss,
-                    variant: KolabingButtonVariant.primary,
-                    size: KolabingButtonSize.compact,
-                  ),
-                ],
-              ),
-            ),
-          ),
-
-          // Confetti burst from top center
-          Align(
-            alignment: Alignment.topCenter,
-            child: ConfettiWidget(
-              confettiController: _confettiController,
-              blastDirectionality: BlastDirectionality.explosive,
-              maxBlastForce: 15,
-              minBlastForce: 5,
-              numberOfParticles: 25,
-              gravity: 0.15,
-              emissionFrequency: 0.06,
-              colors: [
-                context.colors.primary,
-                context.colors.success,
-                Color(0xFFFF6B6B),
-                Color(0xFF6BC5FF),
-                Color(0xFFFFE082),
+                // CTA button
+                KolabingButton(
+                  label: 'SEE MY BADGES',
+                  onPressed: widget.onDismiss,
+                  variant: KolabingButtonVariant.primary,
+                  size: KolabingButtonSize.compact,
+                ),
               ],
             ),
           ),
-        ],
-      ),
-    );
+        ),
+
+        // Confetti burst from top center
+        Align(
+          alignment: Alignment.topCenter,
+          child: ConfettiWidget(
+            confettiController: _confettiController,
+            blastDirectionality: BlastDirectionality.explosive,
+            maxBlastForce: 15,
+            minBlastForce: 5,
+            numberOfParticles: 25,
+            gravity: 0.15,
+            emissionFrequency: 0.06,
+            colors: [
+              context.colors.primary,
+              context.colors.success,
+              Color(0xFFFF6B6B),
+              Color(0xFF6BC5FF),
+              Color(0xFFFFE082),
+            ],
+          ),
+        ),
+      ],
+    ),
+  );
 }

--- a/lib/features/rewards/widgets/referral_banner_card.dart
+++ b/lib/features/rewards/widgets/referral_banner_card.dart
@@ -123,8 +123,9 @@ class ReferralBannerCard extends ConsumerWidget {
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
                         Text(
-                          AppLocalizations.of(context)
-                              .referralBannerStepReferLabel,
+                          AppLocalizations.of(
+                            context,
+                          ).referralBannerStepReferLabel,
                           style: KolabingTextStyles.bodyMedium.copyWith(
                             fontSize: 13,
                             fontWeight: FontWeight.w600,
@@ -133,8 +134,9 @@ class ReferralBannerCard extends ConsumerWidget {
                           ),
                         ),
                         Text(
-                          AppLocalizations.of(context)
-                              .referralBannerStepReferValue,
+                          AppLocalizations.of(
+                            context,
+                          ).referralBannerStepReferValue,
                           style: KolabingTextStyles.bodyMedium.copyWith(
                             fontSize: 15,
                             fontWeight: FontWeight.w800,
@@ -183,8 +185,9 @@ class ReferralBannerCard extends ConsumerWidget {
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
                         Text(
-                          AppLocalizations.of(context)
-                              .referralBannerStepEarnLabel,
+                          AppLocalizations.of(
+                            context,
+                          ).referralBannerStepEarnLabel,
                           style: KolabingTextStyles.bodyMedium.copyWith(
                             fontSize: 13,
                             fontWeight: FontWeight.w600,
@@ -193,8 +196,9 @@ class ReferralBannerCard extends ConsumerWidget {
                           ),
                         ),
                         Text(
-                          AppLocalizations.of(context)
-                              .referralBannerStepEarnAmount,
+                          AppLocalizations.of(
+                            context,
+                          ).referralBannerStepEarnAmount,
                           style: KolabingTextStyles.displaySmall.copyWith(
                             fontSize: 32,
                             color: inkColor,
@@ -202,8 +206,9 @@ class ReferralBannerCard extends ConsumerWidget {
                           ),
                         ),
                         Text(
-                          AppLocalizations.of(context)
-                              .referralBannerStepEarnSuffix,
+                          AppLocalizations.of(
+                            context,
+                          ).referralBannerStepEarnSuffix,
                           style: KolabingTextStyles.bodyMedium.copyWith(
                             fontSize: 13,
                             fontWeight: FontWeight.w600,
@@ -297,10 +302,7 @@ class _StepBox extends StatelessWidget {
               decoration: BoxDecoration(
                 color: badgeFill,
                 shape: BoxShape.circle,
-                border: Border.all(
-                  color: KolabingColors.primary,
-                  width: 1.5,
-                ),
+                border: Border.all(color: KolabingColors.primary, width: 1.5),
               ),
               child: Center(
                 child: Text(
@@ -355,7 +357,12 @@ class _ReferralCodeSheet extends StatelessWidget {
           const SizedBox(height: KolabingSpacing.lg),
           Text(
             AppLocalizations.of(context).referralSheetYourCode,
-            style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: FontWeight.w700, color: context.colors.textTertiary, letterSpacing: 1.2),
+            style: KolabingTextStyles.bodySmall.copyWith(
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              color: context.colors.textTertiary,
+              letterSpacing: 1.2,
+            ),
           ),
           const SizedBox(height: KolabingSpacing.sm),
           Container(
@@ -372,7 +379,12 @@ class _ReferralCodeSheet extends StatelessWidget {
             child: Text(
               code,
               textAlign: TextAlign.center,
-              style: KolabingTextStyles.bodyLarge.copyWith(fontSize: 28, fontWeight: FontWeight.w700, color: context.colors.onSurface, letterSpacing: 2.5),
+              style: KolabingTextStyles.bodyLarge.copyWith(
+                fontSize: 28,
+                fontWeight: FontWeight.w700,
+                color: context.colors.onSurface,
+                letterSpacing: 2.5,
+              ),
             ),
           ),
           const SizedBox(height: KolabingSpacing.sm),
@@ -488,7 +500,11 @@ class _CompactReferralCard extends StatelessWidget {
               color: context.colors.softYellow,
               shape: BoxShape.circle,
             ),
-            child: const Icon(LucideIcons.gift, size: 18, color: Color(0xFF19150F)),
+            child: const Icon(
+              LucideIcons.gift,
+              size: 18,
+              color: Color(0xFF19150F),
+            ),
           ),
           const SizedBox(width: KolabingSpacing.sm),
           Expanded(

--- a/lib/features/rewards/widgets/reward_badge_card.dart
+++ b/lib/features/rewards/widgets/reward_badge_card.dart
@@ -13,11 +13,7 @@ import '../models/reward_badge.dart';
 /// style border. Unlocked badges have a white background, yellow border, and a
 /// subtle shadow.
 class RewardBadgeCard extends StatelessWidget {
-  const RewardBadgeCard({
-    required this.badge,
-    this.compact = false,
-    super.key,
-  });
+  const RewardBadgeCard({required this.badge, this.compact = false, super.key});
 
   /// The badge to display.
   final RewardBadge badge;
@@ -81,23 +77,30 @@ class RewardBadgeCard extends StatelessWidget {
               textAlign: TextAlign.center,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
-              style: KolabingTextStyles.bodySmall.copyWith(fontSize: 13, fontWeight: FontWeight.w600, color: isUnlocked
+              style: KolabingTextStyles.bodySmall.copyWith(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: isUnlocked
                     ? context.colors.onSurface
-                    : context.colors.textTertiary),
+                    : context.colors.textTertiary,
+              ),
             ),
             const SizedBox(height: KolabingSpacing.xxxs),
             Text(
               isUnlocked
                   ? (badge.earnedAt != null
-                      ? 'Earned ${badge.earnedDateFormatted}'
-                      : badge.slug.description)
+                        ? 'Earned ${badge.earnedDateFormatted}'
+                        : badge.slug.description)
                   : badge.slug.requirement,
               textAlign: TextAlign.center,
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
-              style: KolabingTextStyles.labelSmall.copyWith(fontWeight: FontWeight.w400, color: isUnlocked
+              style: KolabingTextStyles.labelSmall.copyWith(
+                fontWeight: FontWeight.w400,
+                color: isUnlocked
                     ? context.colors.onSurfaceVariant
-                    : context.colors.textTertiary),
+                    : context.colors.textTertiary,
+              ),
             ),
           ],
         ),
@@ -133,9 +136,13 @@ class RewardBadgeCard extends StatelessWidget {
               textAlign: TextAlign.center,
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
-              style: KolabingTextStyles.bodySmall.copyWith(fontSize: 10, fontWeight: FontWeight.w600, color: isUnlocked
+              style: KolabingTextStyles.bodySmall.copyWith(
+                fontSize: 10,
+                fontWeight: FontWeight.w600,
+                color: isUnlocked
                     ? context.colors.onSurface
-                    : context.colors.textTertiary),
+                    : context.colors.textTertiary,
+              ),
             ),
           ],
         ),
@@ -152,27 +159,26 @@ class RewardBadgeCard extends StatelessWidget {
     required double size,
     required double iconSize,
     required bool isUnlocked,
-  }) =>
-      Container(
-        width: size,
-        height: size,
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          color: isUnlocked
-              ? context.colors.softYellow
-              : context.colors.surfaceVariant,
-          border: Border.all(
-            color: isUnlocked
-                ? context.colors.softYellowBorder
-                : context.colors.darkBorder,
-          ),
-        ),
-        child: Icon(
-          badge.slug.icon,
-          size: iconSize,
-          color: isUnlocked
-              ? context.colors.onSurface
-              : context.colors.textTertiary,
-        ),
-      );
+  }) => Container(
+    width: size,
+    height: size,
+    decoration: BoxDecoration(
+      shape: BoxShape.circle,
+      color: isUnlocked
+          ? context.colors.softYellow
+          : context.colors.surfaceVariant,
+      border: Border.all(
+        color: isUnlocked
+            ? context.colors.softYellowBorder
+            : context.colors.darkBorder,
+      ),
+    ),
+    child: Icon(
+      badge.slug.icon,
+      size: iconSize,
+      color: isUnlocked
+          ? context.colors.onSurface
+          : context.colors.textTertiary,
+    ),
+  );
 }

--- a/lib/features/rewards/widgets/xp_progress_card.dart
+++ b/lib/features/rewards/widgets/xp_progress_card.dart
@@ -46,7 +46,11 @@ class XpProgressCard extends ConsumerWidget {
                 _LevelChip(level: level),
                 Text(
                   '${wallet.totalXp} XP',
-                  style: KolabingTextStyles.bodyLarge.copyWith(fontSize: 22, fontWeight: FontWeight.w800, color: context.colors.onSurface),
+                  style: KolabingTextStyles.bodyLarge.copyWith(
+                    fontSize: 22,
+                    fontWeight: FontWeight.w800,
+                    color: context.colors.onSurface,
+                  ),
                 ),
               ],
             ),
@@ -63,8 +67,9 @@ class XpProgressCard extends ConsumerWidget {
                 builder: (_, value, _) => LinearProgressIndicator(
                   value: value,
                   minHeight: 8,
-                  backgroundColor:
-                      context.colors.secondary.withValues(alpha: 0.2),
+                  backgroundColor: context.colors.secondary.withValues(
+                    alpha: 0.2,
+                  ),
                   valueColor: AlwaysStoppedAnimation<Color>(
                     context.colors.secondary,
                   ),
@@ -82,14 +87,21 @@ class XpProgressCard extends ConsumerWidget {
                   level.isMaxLevel
                       ? 'Max level reached!'
                       : '$xpToNext XP to ${level.next?.title ?? ''}',
-                  style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, color: context.colors.onSurfaceVariant),
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    fontSize: 12,
+                    color: context.colors.onSurfaceVariant,
+                  ),
                 ),
                 if (onTap != null && showNavigationCta)
                   Row(
                     children: [
                       Text(
                         'View progress',
-                        style: KolabingTextStyles.bodySmall.copyWith(fontSize: 12, fontWeight: FontWeight.w600, color: context.colors.onSurface),
+                        style: KolabingTextStyles.bodySmall.copyWith(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: context.colors.onSurface,
+                        ),
                       ),
                       const SizedBox(width: 2),
                       Icon(
@@ -119,28 +131,29 @@ class _LevelChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Container(
-        padding: const EdgeInsets.symmetric(
-          horizontal: KolabingSpacing.sm,
-          vertical: KolabingSpacing.xxs,
+    padding: const EdgeInsets.symmetric(
+      horizontal: KolabingSpacing.sm,
+      vertical: KolabingSpacing.xxs,
+    ),
+    decoration: BoxDecoration(
+      color: context.colors.secondary.withValues(alpha: 0.15),
+      borderRadius: KolabingRadius.borderRadiusRound,
+    ),
+    child: Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(LucideIcons.shield, size: 12, color: context.colors.secondary),
+        const SizedBox(width: 4),
+        Text(
+          'LVL ${level.number} · ${level.title}',
+          style: KolabingTextStyles.bodySmall.copyWith(
+            fontSize: 11,
+            fontWeight: FontWeight.w600,
+            color: context.colors.secondary,
+            letterSpacing: 0.3,
+          ),
         ),
-        decoration: BoxDecoration(
-          color: context.colors.secondary.withValues(alpha: 0.15),
-          borderRadius: KolabingRadius.borderRadiusRound,
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              LucideIcons.shield,
-              size: 12,
-              color: context.colors.secondary,
-            ),
-            const SizedBox(width: 4),
-            Text(
-              'LVL ${level.number} · ${level.title}',
-              style: KolabingTextStyles.bodySmall.copyWith(fontSize: 11, fontWeight: FontWeight.w600, color: context.colors.secondary, letterSpacing: 0.3),
-            ),
-          ],
-        ),
-      );
+      ],
+    ),
+  );
 }

--- a/lib/features/settings/providers/locale_provider.dart
+++ b/lib/features/settings/providers/locale_provider.dart
@@ -5,10 +5,7 @@ import '../services/locale_service.dart';
 
 /// Locale state. A null [locale] means "follow the system language".
 class LocaleState {
-  const LocaleState({
-    this.locale,
-    this.isLoading = true,
-  });
+  const LocaleState({this.locale, this.isLoading = true});
 
   /// The pinned app language, or null to follow the device language.
   final Locale? locale;
@@ -18,11 +15,10 @@ class LocaleState {
     Locale? locale,
     bool clearLocale = false,
     bool? isLoading,
-  }) =>
-      LocaleState(
-        locale: clearLocale ? null : (locale ?? this.locale),
-        isLoading: isLoading ?? this.isLoading,
-      );
+  }) => LocaleState(
+    locale: clearLocale ? null : (locale ?? this.locale),
+    isLoading: isLoading ?? this.isLoading,
+  );
 }
 
 /// Notifier for the app language preference, persisted via [LocaleService].
@@ -53,5 +49,6 @@ class LocaleNotifier extends Notifier<LocaleState> {
 }
 
 /// Provider for the app language preference.
-final localeProvider =
-    NotifierProvider<LocaleNotifier, LocaleState>(LocaleNotifier.new);
+final localeProvider = NotifierProvider<LocaleNotifier, LocaleState>(
+  LocaleNotifier.new,
+);

--- a/lib/features/settings/providers/notification_settings_provider.dart
+++ b/lib/features/settings/providers/notification_settings_provider.dart
@@ -20,7 +20,8 @@ class NotificationSettingsNotifier
   Future<void> reload() async {
     state = const AsyncLoading();
     state = await AsyncValue.guard(
-        () => ref.read(profileServiceProvider).getNotificationPreferences());
+      () => ref.read(profileServiceProvider).getNotificationPreferences(),
+    );
   }
 
   /// Persist one toggle. Optimistically reflects the new value, then writes the
@@ -41,17 +42,19 @@ class NotificationSettingsNotifier
   }
 
   Map<String, bool> _payload(NotificationPreferences p) => {
-        'message_notifications': p.messagesEnabled,
-        'messages_enabled': p.messagesEnabled,
-        'new_application_alerts': p.applicationsEnabled,
-        'applications_enabled': p.applicationsEnabled,
-        'collaboration_updates': p.collaborationsEnabled,
-        'collaborations_enabled': p.collaborationsEnabled,
-        'marketing_tips': p.marketingEnabled,
-        'marketing_enabled': p.marketingEnabled,
-      };
+    'message_notifications': p.messagesEnabled,
+    'messages_enabled': p.messagesEnabled,
+    'new_application_alerts': p.applicationsEnabled,
+    'applications_enabled': p.applicationsEnabled,
+    'collaboration_updates': p.collaborationsEnabled,
+    'collaborations_enabled': p.collaborationsEnabled,
+    'marketing_tips': p.marketingEnabled,
+    'marketing_enabled': p.marketingEnabled,
+  };
 }
 
-final notificationSettingsProvider = NotifierProvider<
-    NotificationSettingsNotifier,
-    AsyncValue<NotificationPreferences>>(NotificationSettingsNotifier.new);
+final notificationSettingsProvider =
+    NotifierProvider<
+      NotificationSettingsNotifier,
+      AsyncValue<NotificationPreferences>
+    >(NotificationSettingsNotifier.new);

--- a/lib/features/settings/providers/theme_provider.dart
+++ b/lib/features/settings/providers/theme_provider.dart
@@ -5,22 +5,15 @@ import '../services/theme_service.dart';
 
 /// Theme state
 class ThemeState {
-  const ThemeState({
-    this.themeMode = ThemeMode.light,
-    this.isLoading = true,
-  });
+  const ThemeState({this.themeMode = ThemeMode.light, this.isLoading = true});
 
   final ThemeMode themeMode;
   final bool isLoading;
 
-  ThemeState copyWith({
-    ThemeMode? themeMode,
-    bool? isLoading,
-  }) =>
-      ThemeState(
-        themeMode: themeMode ?? this.themeMode,
-        isLoading: isLoading ?? this.isLoading,
-      );
+  ThemeState copyWith({ThemeMode? themeMode, bool? isLoading}) => ThemeState(
+    themeMode: themeMode ?? this.themeMode,
+    isLoading: isLoading ?? this.isLoading,
+  );
 }
 
 /// Theme notifier for managing app theme
@@ -37,10 +30,7 @@ class ThemeNotifier extends Notifier<ThemeState> {
 
   Future<void> _loadTheme() async {
     // Dark mode is temporarily disabled — always force light mode.
-    state = state.copyWith(
-      themeMode: ThemeMode.light,
-      isLoading: false,
-    );
+    state = state.copyWith(themeMode: ThemeMode.light, isLoading: false);
   }
 
   /// Set theme mode and persist (dark mode temporarily disabled)
@@ -55,5 +45,6 @@ class ThemeNotifier extends Notifier<ThemeState> {
 }
 
 /// Provider for theme state
-final themeProvider =
-    NotifierProvider<ThemeNotifier, ThemeState>(ThemeNotifier.new);
+final themeProvider = NotifierProvider<ThemeNotifier, ThemeState>(
+  ThemeNotifier.new,
+);

--- a/lib/features/settings/screens/notification_settings_screen.dart
+++ b/lib/features/settings/screens/notification_settings_screen.dart
@@ -29,10 +29,13 @@ class NotificationSettingsScreen extends ConsumerWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text(e.toString().replaceFirst('Exception: ', ''),
-                    textAlign: TextAlign.center,
-                    style: KolabingTextStyles.bodySmall
-                        .copyWith(color: context.colors.onSurfaceVariant)),
+                Text(
+                  e.toString().replaceFirst('Exception: ', ''),
+                  textAlign: TextAlign.center,
+                  style: KolabingTextStyles.bodySmall.copyWith(
+                    color: context.colors.onSurfaceVariant,
+                  ),
+                ),
                 const SizedBox(height: KolabingSpacing.lg),
                 OutlinedButton(
                   onPressed: () =>
@@ -66,7 +69,9 @@ class _Toggles extends ConsumerWidget {
     } catch (_) {
       if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context).notifSettingsSaveError)),
+        SnackBar(
+          content: Text(AppLocalizations.of(context).notifSettingsSaveError),
+        ),
       );
     }
   }

--- a/lib/features/settings/widgets/theme_selector_section.dart
+++ b/lib/features/settings/widgets/theme_selector_section.dart
@@ -122,19 +122,21 @@ class _ThemeOption extends StatelessWidget {
   Widget build(BuildContext context) {
     final backgroundColor = isSelected
         ? (isDark
-            ? context.colors.primary.withValues(alpha: 0.15)
-            : context.colors.softYellow)
+              ? context.colors.primary.withValues(alpha: 0.15)
+              : context.colors.softYellow)
         : (isDark ? context.colors.surface : context.colors.surfaceVariant);
 
     final borderColor = isSelected
         ? context.colors.primary
         : (isDark ? context.colors.darkBorder : context.colors.darkBorder);
 
-    final textColor =
-        isDark ? context.colors.textOnDark : context.colors.onSurface;
+    final textColor = isDark
+        ? context.colors.textOnDark
+        : context.colors.onSurface;
 
-    final subtitleColor =
-        isDark ? context.colors.textTertiary : context.colors.onSurfaceVariant;
+    final subtitleColor = isDark
+        ? context.colors.textTertiary
+        : context.colors.onSurfaceVariant;
 
     return InkWell(
       onTap: onTap,
@@ -145,10 +147,7 @@ class _ThemeOption extends StatelessWidget {
         decoration: BoxDecoration(
           color: backgroundColor,
           borderRadius: KolabingRadius.borderRadiusMd,
-          border: Border.all(
-            color: borderColor,
-            width: isSelected ? 2 : 1,
-          ),
+          border: Border.all(color: borderColor, width: isSelected ? 2 : 1),
         ),
         child: Row(
           children: [
@@ -160,8 +159,8 @@ class _ThemeOption extends StatelessWidget {
                 color: isSelected
                     ? context.colors.primary
                     : (isDark
-                        ? context.colors.darkSurface
-                        : context.colors.surface),
+                          ? context.colors.darkSurface
+                          : context.colors.surface),
                 borderRadius: KolabingRadius.borderRadiusSm,
               ),
               child: Icon(
@@ -170,8 +169,8 @@ class _ThemeOption extends StatelessWidget {
                 color: isSelected
                     ? context.colors.onPrimary
                     : (isDark
-                        ? context.colors.textOnDark
-                        : context.colors.onSurfaceVariant),
+                          ? context.colors.textOnDark
+                          : context.colors.onSurfaceVariant),
               ),
             ),
             const SizedBox(width: KolabingSpacing.sm),
@@ -185,7 +184,9 @@ class _ThemeOption extends StatelessWidget {
                     label,
                     style: KolabingTextStyles.titleSmall.copyWith(
                       color: textColor,
-                      fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
+                      fontWeight: isSelected
+                          ? FontWeight.w600
+                          : FontWeight.w500,
                     ),
                   ),
                   Text(

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -2507,5 +2507,12 @@
   "claimCodeNotNewAccount": "Els codis només funcionen en un compte nou.",
   "claimCodeSelf": "Aquesta és la teva pròpia invitació.",
   "claimCodeFailed": "No ha funcionat. Torna-ho a provar.",
-  "claimCodeClaimed": "Punts bescanviats"
+  "claimCodeClaimed": "Punts bescanviats",
+  "createChallengeEditTitle": "Editar el repte",
+  "createChallengeSaveChanges": "Desar els canvis",
+  "createChallengeUpdated": "Repte actualitzat",
+  "createChallengeProofTypeLabel": "Quan la parella accepta",
+  "createChallengeProofTypeText": "Sense càmera",
+  "createChallengeProofTypePhoto": "Obrir la càmera",
+  "createChallengeProofTypeHint": "Només tria la pantalla que obre l'app. Un repte confirmat sense foto compta igual, així que una càmera denegada o mala cobertura no li costen mai els punts a ningú."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -10123,5 +10123,19 @@
   "claimCodeFailed": "That didn't work. Please try again.",
   "@claimCodeFailed": {"description": "Generic failure redeeming an invite code."},
   "claimCodeClaimed": "Points claimed",
-  "@claimCodeClaimed": {"description": "Title of the invite-code sheet once the code has been redeemed."}
+  "@claimCodeClaimed": {"description": "Title of the invite-code sheet once the code has been redeemed."},
+  "createChallengeEditTitle": "Edit challenge",
+  "@createChallengeEditTitle": {"description": "App bar title when editing an existing custom challenge."},
+  "createChallengeSaveChanges": "Save changes",
+  "@createChallengeSaveChanges": {"description": "Submit label in edit mode."},
+  "createChallengeUpdated": "Challenge updated",
+  "@createChallengeUpdated": {"description": "Snackbar after an edit saves."},
+  "createChallengeProofTypeLabel": "When the pair agrees",
+  "@createChallengeProofTypeLabel": {"description": "Label for the camera choice on a challenge."},
+  "createChallengeProofTypeText": "No camera",
+  "@createChallengeProofTypeText": {"description": "Option: the app opens no camera (proof_type text)."},
+  "createChallengeProofTypePhoto": "Open the camera",
+  "@createChallengeProofTypePhoto": {"description": "Option: the app opens the camera (proof_type photo)."},
+  "createChallengeProofTypeHint": "Picks the screen the app opens, nothing more. A challenge confirmed without a photo still counts, so a denied camera or bad signal never costs anybody their points.",
+  "@createChallengeProofTypeHint": {"description": "Explains that the camera choice is not a requirement."}
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2507,5 +2507,12 @@
   "claimCodeNotNewAccount": "Los códigos solo funcionan en una cuenta nueva.",
   "claimCodeSelf": "Esa es tu propia invitación.",
   "claimCodeFailed": "No ha funcionado. Inténtalo de nuevo.",
-  "claimCodeClaimed": "Puntos canjeados"
+  "claimCodeClaimed": "Puntos canjeados",
+  "createChallengeEditTitle": "Editar reto",
+  "createChallengeSaveChanges": "Guardar cambios",
+  "createChallengeUpdated": "Reto actualizado",
+  "createChallengeProofTypeLabel": "Cuando la pareja acepta",
+  "createChallengeProofTypeText": "Sin cámara",
+  "createChallengeProofTypePhoto": "Abrir la cámara",
+  "createChallengeProofTypeHint": "Solo elige la pantalla que abre la app. Un reto confirmado sin foto cuenta igual, así que una cámara denegada o mala cobertura nunca le cuestan los puntos a nadie."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -15025,6 +15025,48 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Points claimed'**
   String get claimCodeClaimed;
+
+  /// App bar title when editing an existing custom challenge.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit challenge'**
+  String get createChallengeEditTitle;
+
+  /// Submit label in edit mode.
+  ///
+  /// In en, this message translates to:
+  /// **'Save changes'**
+  String get createChallengeSaveChanges;
+
+  /// Snackbar after an edit saves.
+  ///
+  /// In en, this message translates to:
+  /// **'Challenge updated'**
+  String get createChallengeUpdated;
+
+  /// Label for the camera choice on a challenge.
+  ///
+  /// In en, this message translates to:
+  /// **'When the pair agrees'**
+  String get createChallengeProofTypeLabel;
+
+  /// Option: the app opens no camera (proof_type text).
+  ///
+  /// In en, this message translates to:
+  /// **'No camera'**
+  String get createChallengeProofTypeText;
+
+  /// Option: the app opens the camera (proof_type photo).
+  ///
+  /// In en, this message translates to:
+  /// **'Open the camera'**
+  String get createChallengeProofTypePhoto;
+
+  /// Explains that the camera choice is not a requirement.
+  ///
+  /// In en, this message translates to:
+  /// **'Picks the screen the app opens, nothing more. A challenge confirmed without a photo still counts, so a denied camera or bad signal never costs anybody their points.'**
+  String get createChallengeProofTypeHint;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -8660,4 +8660,26 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get claimCodeClaimed => 'Punts bescanviats';
+
+  @override
+  String get createChallengeEditTitle => 'Editar el repte';
+
+  @override
+  String get createChallengeSaveChanges => 'Desar els canvis';
+
+  @override
+  String get createChallengeUpdated => 'Repte actualitzat';
+
+  @override
+  String get createChallengeProofTypeLabel => 'Quan la parella accepta';
+
+  @override
+  String get createChallengeProofTypeText => 'Sense càmera';
+
+  @override
+  String get createChallengeProofTypePhoto => 'Obrir la càmera';
+
+  @override
+  String get createChallengeProofTypeHint =>
+      'Només tria la pantalla que obre l\'app. Un repte confirmat sense foto compta igual, així que una càmera denegada o mala cobertura no li costen mai els punts a ningú.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8533,4 +8533,26 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get claimCodeClaimed => 'Points claimed';
+
+  @override
+  String get createChallengeEditTitle => 'Edit challenge';
+
+  @override
+  String get createChallengeSaveChanges => 'Save changes';
+
+  @override
+  String get createChallengeUpdated => 'Challenge updated';
+
+  @override
+  String get createChallengeProofTypeLabel => 'When the pair agrees';
+
+  @override
+  String get createChallengeProofTypeText => 'No camera';
+
+  @override
+  String get createChallengeProofTypePhoto => 'Open the camera';
+
+  @override
+  String get createChallengeProofTypeHint =>
+      'Picks the screen the app opens, nothing more. A challenge confirmed without a photo still counts, so a denied camera or bad signal never costs anybody their points.';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -8616,4 +8616,26 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get claimCodeClaimed => 'Puntos canjeados';
+
+  @override
+  String get createChallengeEditTitle => 'Editar reto';
+
+  @override
+  String get createChallengeSaveChanges => 'Guardar cambios';
+
+  @override
+  String get createChallengeUpdated => 'Reto actualizado';
+
+  @override
+  String get createChallengeProofTypeLabel => 'Cuando la pareja acepta';
+
+  @override
+  String get createChallengeProofTypeText => 'Sin cámara';
+
+  @override
+  String get createChallengeProofTypePhoto => 'Abrir la cámara';
+
+  @override
+  String get createChallengeProofTypeHint =>
+      'Solo elige la pantalla que abre la app. Un reto confirmado sin foto cuenta igual, así que una cámara denegada o mala cobertura nunca le cuestan los puntos a nadie.';
 }

--- a/lib/services/upload_service.dart
+++ b/lib/services/upload_service.dart
@@ -40,10 +40,8 @@ class UploadService {
   /// Returns the URL string on success.
   /// Throws [ApiException] on validation error (422).
   /// Throws [NetworkException] on network failure.
-  Future<String> upload({
-    required String filePath,
-    required String folder,
-  }) => _upload(filePath: filePath, folder: folder, allowRetry: true);
+  Future<String> upload({required String filePath, required String folder}) =>
+      _upload(filePath: filePath, folder: folder, allowRetry: true);
 
   Future<String> _upload({
     required String filePath,

--- a/test/features/application/services/application_service_test.dart
+++ b/test/features/application/services/application_service_test.dart
@@ -227,72 +227,69 @@ void main() {
     },
   );
 
-  test(
-    'submitApplication refreshes once on 401 before succeeding',
-    () async {
-      FlutterSecureStorage.setMockInitialValues(<String, String>{
-        'auth_token': 'token-123',
-        'auth_refresh_token': 'refresh-123',
-      });
+  test('submitApplication refreshes once on 401 before succeeding', () async {
+    FlutterSecureStorage.setMockInitialValues(<String, String>{
+      'auth_token': 'token-123',
+      'auth_refresh_token': 'refresh-123',
+    });
 
-      final client = _QueuedClient(
-        responses: [
-          _QueuedResponse(
-            statusCode: 401,
-            body: jsonEncode(<String, dynamic>{'message': 'Unauthenticated'}),
-          ),
-          _QueuedResponse(
-            statusCode: 200,
-            body: jsonEncode(<String, dynamic>{
-              'data': <String, dynamic>{
-                'token': 'token-456',
-                'refresh_token': 'refresh-456',
-                'token_type': 'Bearer',
-              },
-            }),
-          ),
-          _QueuedResponse(
-            statusCode: 201,
-            body: jsonEncode(<String, dynamic>{
-              'data': <String, dynamic>{
-                'id': 'app-3',
-                'collab_opportunity_id': 'opp-3',
-                'message': 'Count us in',
-                'availability': 'Saturday morning',
-                'status': 'pending',
-                'created_at': '2026-05-01T10:00:00Z',
-              },
-            }),
-          ),
-        ],
-      );
+    final client = _QueuedClient(
+      responses: [
+        _QueuedResponse(
+          statusCode: 401,
+          body: jsonEncode(<String, dynamic>{'message': 'Unauthenticated'}),
+        ),
+        _QueuedResponse(
+          statusCode: 200,
+          body: jsonEncode(<String, dynamic>{
+            'data': <String, dynamic>{
+              'token': 'token-456',
+              'refresh_token': 'refresh-456',
+              'token_type': 'Bearer',
+            },
+          }),
+        ),
+        _QueuedResponse(
+          statusCode: 201,
+          body: jsonEncode(<String, dynamic>{
+            'data': <String, dynamic>{
+              'id': 'app-3',
+              'collab_opportunity_id': 'opp-3',
+              'message': 'Count us in',
+              'availability': 'Saturday morning',
+              'status': 'pending',
+              'created_at': '2026-05-01T10:00:00Z',
+            },
+          }),
+        ),
+      ],
+    );
 
-      final authService = AuthService(
-        secureStorage: const FlutterSecureStorage(),
-        httpClient: client,
-      );
-      final service = ApplicationService(
-        authService: authService,
-        httpClient: client,
-      );
+    final authService = AuthService(
+      secureStorage: const FlutterSecureStorage(),
+      httpClient: client,
+    );
+    final service = ApplicationService(
+      authService: authService,
+      httpClient: client,
+    );
 
-      final application = await service.submitApplication(
-        opportunityId: 'opp-3',
-        message: 'Count us in',
-        availability: 'Saturday morning',
-      );
+    final application = await service.submitApplication(
+      opportunityId: 'opp-3',
+      message: 'Count us in',
+      availability: 'Saturday morning',
+    );
 
-      expect(application.id, 'app-3');
-      expect(application.status.name, 'pending');
-      expect(await authService.getToken(), 'token-456');
-      expect(await authService.getRefreshToken(), 'refresh-456');
-      expect(client.sentAuthHeaders, <String?>[
-        'Bearer token-123',
-        null,
-        'Bearer token-456',
-      ]);
-    },
-  );
+    expect(application.id, 'app-3');
+    expect(application.status.name, 'pending');
+    expect(await authService.getToken(), 'token-456');
+    expect(await authService.getRefreshToken(), 'refresh-456');
+    expect(client.sentAuthHeaders, <String?>[
+      'Bearer token-123',
+      null,
+      'Bearer token-456',
+    ]);
+  });
 
   test(
     'getApplication refreshes once on 401 before returning details',

--- a/test/features/auth/providers/social_user_type_test.dart
+++ b/test/features/auth/providers/social_user_type_test.dart
@@ -11,18 +11,18 @@ class _RecordingAuthService extends AuthService {
   String? appleUserType;
 
   AuthResponse _attendee() => const AuthResponse(
-        success: true,
-        message: 'ok',
-        token: 't-1',
-        tokenType: 'Bearer',
-        isNewUser: true,
-        user: UserModel(
-          id: 'a-1',
-          email: 'a@example.com',
-          userType: UserType.attendee,
-          name: 'Jane Doe',
-        ),
-      );
+    success: true,
+    message: 'ok',
+    token: 't-1',
+    tokenType: 'Bearer',
+    isNewUser: true,
+    user: UserModel(
+      id: 'a-1',
+      email: 'a@example.com',
+      userType: UserType.attendee,
+      name: 'Jane Doe',
+    ),
+  );
 
   @override
   Future<AuthResponse> loginWithGoogle({String? userType}) async {
@@ -44,23 +44,26 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   setUp(() => FlutterSecureStorage.setMockInitialValues(<String, String>{}));
 
-  test('signInWithGoogle forwards attendee hint and honors is_new_user', () async {
-    final service = _RecordingAuthService();
-    final container = ProviderContainer(
-      overrides: [authServiceProvider.overrideWith((ref) => service)],
-    );
-    addTearDown(container.dispose);
+  test(
+    'signInWithGoogle forwards attendee hint and honors is_new_user',
+    () async {
+      final service = _RecordingAuthService();
+      final container = ProviderContainer(
+        overrides: [authServiceProvider.overrideWith((ref) => service)],
+      );
+      addTearDown(container.dispose);
 
-    final result = await container
-        .read(authProvider.notifier)
-        .signInWithGoogle(userTypeHint: UserType.attendee);
-    await Future<void>.delayed(Duration.zero);
+      final result = await container
+          .read(authProvider.notifier)
+          .signInWithGoogle(userTypeHint: UserType.attendee);
+      await Future<void>.delayed(Duration.zero);
 
-    expect(service.googleUserType, 'attendee');
-    expect(result.success, isTrue);
-    expect(result.isNewUser, isTrue);
-    expect(result.user?.isAttendee, isTrue);
-  });
+      expect(service.googleUserType, 'attendee');
+      expect(result.success, isTrue);
+      expect(result.isNewUser, isTrue);
+      expect(result.user?.isAttendee, isTrue);
+    },
+  );
 
   test(
     'signInWithGoogle WITHOUT a hint keeps isNewUser false (login screens '
@@ -72,8 +75,9 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final result =
-          await container.read(authProvider.notifier).signInWithGoogle();
+      final result = await container
+          .read(authProvider.notifier)
+          .signInWithGoogle();
       await Future<void>.delayed(Duration.zero);
 
       expect(service.googleUserType, isNull);

--- a/test/features/auth/services/apple_user_type_test.dart
+++ b/test/features/auth/services/apple_user_type_test.dart
@@ -11,20 +11,20 @@ void main() {
   setUp(() => FlutterSecureStorage.setMockInitialValues(<String, String>{}));
 
   http.Response ok() => http.Response(
-        jsonEncode(<String, dynamic>{
-          'data': <String, dynamic>{
-            'token': 't-1',
-            'token_type': 'Bearer',
-            'is_new_user': true,
-            'user': <String, dynamic>{
-              'id': 'a-1',
-              'email': 'a@example.com',
-              'user_type': 'attendee',
-            },
-          },
-        }),
-        200,
-      );
+    jsonEncode(<String, dynamic>{
+      'data': <String, dynamic>{
+        'token': 't-1',
+        'token_type': 'Bearer',
+        'is_new_user': true,
+        'user': <String, dynamic>{
+          'id': 'a-1',
+          'email': 'a@example.com',
+          'user_type': 'attendee',
+        },
+      },
+    }),
+    200,
+  );
 
   test('authenticateWithApple includes user_type when provided', () async {
     Map<String, dynamic>? sentBody;

--- a/test/features/business/models/notification_preferences_test.dart
+++ b/test/features/business/models/notification_preferences_test.dart
@@ -29,14 +29,17 @@ void main() {
     expect(prefs.timezone, 'Europe/Istanbul');
   });
 
-  test('fromJson prefers message_notifications over messages_enabled (NF-16)', () {
-    final prefs = NotificationPreferences.fromJson(<String, dynamic>{
-      'message_notifications': false,
-      'messages_enabled': true,
-    });
-    expect(prefs.messagesEnabled, isFalse);
-    expect(prefs.messageNotifications, isFalse);
-  });
+  test(
+    'fromJson prefers message_notifications over messages_enabled (NF-16)',
+    () {
+      final prefs = NotificationPreferences.fromJson(<String, dynamic>{
+        'message_notifications': false,
+        'messages_enabled': true,
+      });
+      expect(prefs.messagesEnabled, isFalse);
+      expect(prefs.messageNotifications, isFalse);
+    },
+  );
 
   test('message_notifications defaults on when both keys absent', () {
     final prefs = NotificationPreferences.fromJson(<String, dynamic>{});

--- a/test/features/chat/models/chat_thread_test.dart
+++ b/test/features/chat/models/chat_thread_test.dart
@@ -76,15 +76,18 @@ void main() {
     expect(withPreview.hasMessages, isTrue);
   });
 
-  test('last_message preview is null when the backend omits it (#8 fallback)', () {
-    final noPreview = ChatThread.fromJson(<String, dynamic>{
-      'id': 't2',
-      'type': 'community_custom',
-      'created_at': '2026-06-01T10:00:00Z',
-      'last_message_at': '2026-06-02T09:00:00Z',
-    });
-    // Older backend: has a timestamp but no preview → list shows "Tap to open".
-    expect(noPreview.lastMessagePreview, isNull);
-    expect(noPreview.hasMessages, isTrue);
-  });
+  test(
+    'last_message preview is null when the backend omits it (#8 fallback)',
+    () {
+      final noPreview = ChatThread.fromJson(<String, dynamic>{
+        'id': 't2',
+        'type': 'community_custom',
+        'created_at': '2026-06-01T10:00:00Z',
+        'last_message_at': '2026-06-02T09:00:00Z',
+      });
+      // Older backend: has a timestamp but no preview → list shows "Tap to open".
+      expect(noPreview.lastMessagePreview, isNull);
+      expect(noPreview.hasMessages, isTrue);
+    },
+  );
 }

--- a/test/features/chat/services/chat_management_service_test.dart
+++ b/test/features/chat/services/chat_management_service_test.dart
@@ -17,37 +17,37 @@ void main() {
   });
 
   ChatService serviceWith(http.Client client) => ChatService(
-        authService: AuthService(
-          secureStorage: const FlutterSecureStorage(),
-          httpClient: client,
-        ),
-        httpClient: client,
-      );
+    authService: AuthService(
+      secureStorage: const FlutterSecureStorage(),
+      httpClient: client,
+    ),
+    httpClient: client,
+  );
 
   Map<String, dynamic> threadJson({
     String type = 'community_custom',
     String? name = 'Renamed',
-  }) =>
-      <String, dynamic>{
-        'id': 'thread-1',
-        'type': type,
-        'name': name,
-        'is_open': true,
-        'can_manage': true,
-        'is_member': true,
-        'is_participant': false,
-        'unread_count': 0,
-        'participant_summary': const <dynamic>[],
-        'created_at': '2026-06-01T10:00:00Z',
-      };
+  }) => <String, dynamic>{
+    'id': 'thread-1',
+    'type': type,
+    'name': name,
+    'is_open': true,
+    'can_manage': true,
+    'is_member': true,
+    'is_participant': false,
+    'unread_count': 0,
+    'participant_summary': const <dynamic>[],
+    'created_at': '2026-06-01T10:00:00Z',
+  };
 
   test('renameCommunityChat PATCHes /chats/{id} with the new name', () async {
     final client = _CaptureClient(
       jsonEncode(<String, dynamic>{'data': threadJson()}),
     );
 
-    final thread =
-        await serviceWith(client).renameCommunityChat('thread-1', 'Renamed');
+    final thread = await serviceWith(
+      client,
+    ).renameCommunityChat('thread-1', 'Renamed');
 
     expect(client.lastMethod, 'PATCH');
     expect(client.lastUrl, contains('/chats/thread-1'));
@@ -56,9 +56,7 @@ void main() {
   });
 
   test('deleteCommunityChat DELETEs /chats/{id}', () async {
-    final client = _CaptureClient(
-      jsonEncode(<String, dynamic>{'data': null}),
-    );
+    final client = _CaptureClient(jsonEncode(<String, dynamic>{'data': null}));
 
     await serviceWith(client).deleteCommunityChat('thread-1');
 
@@ -92,8 +90,11 @@ void main() {
     expect(
       () => serviceWith(client).renameCommunityChat('thread-1', 'X'),
       throwsA(
-        isA<ChatException>()
-            .having((e) => e.code, 'code', 'cannot_rename_thread_type'),
+        isA<ChatException>().having(
+          (e) => e.code,
+          'code',
+          'cannot_rename_thread_type',
+        ),
       ),
     );
   });

--- a/test/features/chat/widgets/chat_management_test.dart
+++ b/test/features/chat/widgets/chat_management_test.dart
@@ -16,15 +16,14 @@ import 'package:kolabing_app/l10n/app_localizations.dart';
 ChatThread _thread({
   ChatThreadType type = ChatThreadType.communityCustom,
   String name = 'Socials',
-}) =>
-    ChatThread(
-      id: 'thread-1',
-      type: type,
-      name: name,
-      communityId: 'community-1',
-      canManage: true,
-      createdAt: DateTime(2026, 6, 1),
-    );
+}) => ChatThread(
+  id: 'thread-1',
+  type: type,
+  name: name,
+  communityId: 'community-1',
+  canManage: true,
+  createdAt: DateTime(2026, 6, 1),
+);
 
 Future<void> _pump(
   WidgetTester tester, {
@@ -71,8 +70,9 @@ void main() {
     });
   });
 
-  testWidgets('createCustomChat prompts then POSTs the community chat',
-      (tester) async {
+  testWidgets('createCustomChat prompts then POSTs the community chat', (
+    tester,
+  ) async {
     final client = _CaptureClient(
       jsonEncode(<String, dynamic>{'data': _threadJson(name: 'New')}),
     );
@@ -125,9 +125,7 @@ void main() {
   });
 
   testWidgets('deleteChat confirms (recoverable) then DELETEs', (tester) async {
-    final client = _CaptureClient(
-      jsonEncode(<String, dynamic>{'data': null}),
-    );
+    final client = _CaptureClient(jsonEncode(<String, dynamic>{'data': null}));
     await _pump(
       tester,
       client: client,
@@ -155,11 +153,8 @@ void main() {
     await _pump(
       tester,
       client: client,
-      onTap: (context, ref) => ChatManagement.joinChat(
-        context,
-        ref,
-        _thread(name: 'Open'),
-      ),
+      onTap: (context, ref) =>
+          ChatManagement.joinChat(context, ref, _thread(name: 'Open')),
     );
 
     await tester.tap(find.text('go'));
@@ -171,18 +166,18 @@ void main() {
 }
 
 Map<String, dynamic> _threadJson({required String name}) => <String, dynamic>{
-      'id': 'thread-1',
-      'type': 'community_custom',
-      'name': name,
-      'community_id': 'community-1',
-      'is_open': true,
-      'can_manage': true,
-      'is_member': true,
-      'is_participant': false,
-      'unread_count': 0,
-      'participant_summary': const <dynamic>[],
-      'created_at': '2026-06-01T10:00:00Z',
-    };
+  'id': 'thread-1',
+  'type': 'community_custom',
+  'name': name,
+  'community_id': 'community-1',
+  'is_open': true,
+  'can_manage': true,
+  'is_member': true,
+  'is_participant': false,
+  'unread_count': 0,
+  'participant_summary': const <dynamic>[],
+  'created_at': '2026-06-01T10:00:00Z',
+};
 
 /// A single captured request (method, url, optional body).
 class _Call {

--- a/test/features/discovery/screens/explore_mixed_feed_capture.dart
+++ b/test/features/discovery/screens/explore_mixed_feed_capture.dart
@@ -176,7 +176,10 @@ void main() {
       tester,
       'explore_community_offer',
       viewerType: UserType.community,
-      feedItems: [offer(), role(id: 'role-1')],
+      feedItems: [
+        offer(),
+        role(id: 'role-1'),
+      ],
     );
   });
 

--- a/test/features/discovery/screens/explore_mixed_feed_test.dart
+++ b/test/features/discovery/screens/explore_mixed_feed_test.dart
@@ -429,10 +429,7 @@ void main() {
       // pushed users into a separate Multi-Kolab Explore screen.
       expect(find.text('Multi-Kolab Events'), findsNothing);
       expect(find.text('Recruit or join multi-partner events'), findsNothing);
-      expect(
-        find.byKey(const Key('multi-kolab-explore-banner')),
-        findsNothing,
-      );
+      expect(find.byKey(const Key('multi-kolab-explore-banner')), findsNothing);
     });
 
     testWidgets('a role card carries the small Multi-Kolab indicator that '

--- a/test/features/event/screens/create_event_repro_test.dart
+++ b/test/features/event/screens/create_event_repro_test.dart
@@ -6,8 +6,9 @@ import 'package:kolabing_app/config/theme/theme.dart';
 import 'package:kolabing_app/features/event/screens/create_event_screen.dart';
 
 void main() {
-  testWidgets('create event lays out without an exception (phone width)',
-      (tester) async {
+  testWidgets('create event lays out without an exception (phone width)', (
+    tester,
+  ) async {
     tester.view.physicalSize = const Size(1179, 2556); // iPhone @3x
     tester.view.devicePixelRatio = 3.0;
     addTearDown(tester.view.resetPhysicalSize);

--- a/test/features/event/services/event_signups_service_test.dart
+++ b/test/features/event/services/event_signups_service_test.dart
@@ -18,12 +18,12 @@ void main() {
   });
 
   EventService serviceWith(http.Client client) => EventService(
-        authService: AuthService(
-          secureStorage: const FlutterSecureStorage(),
-          httpClient: client,
-        ),
-        httpClient: client,
-      );
+    authService: AuthService(
+      secureStorage: const FlutterSecureStorage(),
+      httpClient: client,
+    ),
+    httpClient: client,
+  );
 
   test('getSignups parses the going + waitlist roster', () async {
     final client = _JsonClient(
@@ -57,35 +57,38 @@ void main() {
     expect(signups.waitlist.single.waitlistPosition, 1);
   });
 
-  test('addEventPhotos posts multipart photos[] and returns the event',
-      () async {
-    final photoPath = await _createTempFile('poster.jpg');
-    addTearDown(() async {
-      final f = File(photoPath);
-      if (await f.exists()) await f.delete();
-    });
+  test(
+    'addEventPhotos posts multipart photos[] and returns the event',
+    () async {
+      final photoPath = await _createTempFile('poster.jpg');
+      addTearDown(() async {
+        final f = File(photoPath);
+        if (await f.exists()) await f.delete();
+      });
 
-    final client = _MultipartCaptureClient(
-      responseBody: jsonEncode(<String, dynamic>{
-        'data': <String, dynamic>{
-          'id': 'event-1',
-          'name': 'Sat Long Run',
-          'partner_name': 'Run Club',
-          'partner_type': 'community',
-          'date': '2026-06-14',
-          'attendee_count': 0,
-          'photos': const <Map<String, dynamic>>[],
-          'created_at': '2026-06-01T10:00:00Z',
-        },
-      }),
-    );
+      final client = _MultipartCaptureClient(
+        responseBody: jsonEncode(<String, dynamic>{
+          'data': <String, dynamic>{
+            'id': 'event-1',
+            'name': 'Sat Long Run',
+            'partner_name': 'Run Club',
+            'partner_type': 'community',
+            'date': '2026-06-14',
+            'attendee_count': 0,
+            'photos': const <Map<String, dynamic>>[],
+            'created_at': '2026-06-01T10:00:00Z',
+          },
+        }),
+      );
 
-    final event =
-        await serviceWith(client).addEventPhotos('event-1', [photoPath]);
+      final event = await serviceWith(
+        client,
+      ).addEventPhotos('event-1', [photoPath]);
 
-    expect(client.multipartFieldNames, contains('photos[]'));
-    expect(event.id, 'event-1');
-  });
+      expect(client.multipartFieldNames, contains('photos[]'));
+      expect(event.id, 'event-1');
+    },
+  );
 }
 
 Future<String> _createTempFile(String fileName) async {

--- a/test/features/gamification/challenge_camera_authoring_test.dart
+++ b/test/features/gamification/challenge_camera_authoring_test.dart
@@ -1,0 +1,133 @@
+// Authoring the camera setting from the app (#188).
+//
+// `proof_type` decided whether the camera opens (kolabing-v2#216) and nothing in
+// either client could set it: the admin panel had no field (kolabing-v2#248) and
+// the app's challenge form had no control. These tests cover the app half — the
+// control exists, it defaults to no camera, and editing an existing challenge
+// arrives pre-set to whatever that challenge already says.
+//
+// Also here: the screen doubles as the editor. `EventChallengesScreen` has
+// pushed `/challenges/{id}/edit` since it shipped, and that route was never
+// registered, so an organizer tapping their own custom challenge landed on the
+// not-found page.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kolabing_app/config/theme/theme.dart';
+import 'package:kolabing_app/features/gamification/models/challenge.dart';
+import 'package:kolabing_app/features/gamification/screens/create_challenge_screen.dart';
+import 'package:kolabing_app/l10n/app_localizations.dart';
+
+Challenge _challenge({
+  ChallengeProofType proofType = ChallengeProofType.text,
+  String name = 'Take a selfie together',
+}) => Challenge(
+  id: 'c-1',
+  name: name,
+  description: 'Both of you in one frame',
+  difficulty: ChallengeDifficulty.easy,
+  points: 15,
+  // Custom is the inverse of system, and only a custom challenge is editable.
+  isSystem: false,
+  createdAt: DateTime(2026, 8, 27),
+  updatedAt: DateTime(2026, 8, 27),
+  proofType: proofType,
+);
+
+Future<void> _pump(WidgetTester tester, Widget child) async {
+  tester.view.physicalSize = const Size(1179, 2556); // iPhone @3x
+  tester.view.devicePixelRatio = 3.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        theme: KolabingTheme.lightTheme,
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: child,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// The option's border is 2px wide and primary-coloured when it is the choice.
+bool _isSelected(WidgetTester tester, String label) {
+  final container = tester.widget<Container>(
+    find.ancestor(of: find.text(label), matching: find.byType(Container)).first,
+  );
+  final decoration = container.decoration! as BoxDecoration;
+  return decoration.border!.top.width > 1.5;
+}
+
+void main() {
+  testWidgets('creating a challenge offers the camera choice, defaulting off', (
+    tester,
+  ) async {
+    await _pump(tester, const CreateChallengeScreen(eventId: 'e-1'));
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('When the pair agrees'), findsOneWidget);
+    expect(find.text('No camera'), findsOneWidget);
+    expect(find.text('Open the camera'), findsOneWidget);
+
+    // Off by default: a challenge nobody thought about must not open a camera.
+    expect(_isSelected(tester, 'No camera'), isTrue);
+    expect(_isSelected(tester, 'Open the camera'), isFalse);
+  });
+
+  testWidgets('tapping the camera option selects it', (tester) async {
+    await _pump(tester, const CreateChallengeScreen(eventId: 'e-1'));
+
+    await tester.tap(find.text('Open the camera'));
+    await tester.pumpAndSettle();
+
+    expect(_isSelected(tester, 'Open the camera'), isTrue);
+    expect(_isSelected(tester, 'No camera'), isFalse);
+  });
+
+  testWidgets('editing a camera challenge arrives with the camera on', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      CreateChallengeScreen(
+        eventId: 'e-1',
+        challenge: _challenge(proofType: ChallengeProofType.photo),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    // Edit mode announces itself, rather than looking like a fresh form that
+    // would create a second challenge.
+    expect(find.text('Edit challenge'), findsOneWidget);
+    expect(find.text('Save changes'), findsOneWidget);
+    expect(_isSelected(tester, 'Open the camera'), isTrue);
+  });
+
+  testWidgets('editing prefills what the challenge already says', (
+    tester,
+  ) async {
+    await _pump(
+      tester,
+      CreateChallengeScreen(eventId: 'e-1', challenge: _challenge()),
+    );
+
+    expect(find.text('Take a selfie together'), findsOneWidget);
+    expect(find.text('Both of you in one frame'), findsOneWidget);
+    // Its own points, not the difficulty's default.
+    expect(find.text('15'), findsOneWidget);
+    expect(_isSelected(tester, 'No camera'), isTrue);
+  });
+
+  testWidgets('creating still says create', (tester) async {
+    await _pump(tester, const CreateChallengeScreen(eventId: 'e-1'));
+
+    expect(find.text('Edit challenge'), findsNothing);
+    expect(find.text('Save changes'), findsNothing);
+  });
+}

--- a/test/features/kolab/constants/default_covers_test.dart
+++ b/test/features/kolab/constants/default_covers_test.dart
@@ -26,30 +26,39 @@ void main() {
       );
     });
 
-    test('returns a product cover path for communitySeeking (default fallback)', () {
-      final path = pickDefaultCoverPathFor(IntentType.communitySeeking);
-      expect(path, contains('product_cover_'));
-    });
+    test(
+      'returns a product cover path for communitySeeking (default fallback)',
+      () {
+        final path = pickDefaultCoverPathFor(IntentType.communitySeeking);
+        expect(path, contains('product_cover_'));
+      },
+    );
   });
 
   group('isDefaultCoverUrl', () {
     test('matches a normalized absolute product cover URL', () {
       expect(
-        isDefaultCoverUrl('https://api.kolabing.com/storage/default-kolab-covers/product_cover_1.png'),
+        isDefaultCoverUrl(
+          'https://api.kolabing.com/storage/default-kolab-covers/product_cover_1.png',
+        ),
         isTrue,
       );
     });
 
     test('matches a normalized absolute venue cover URL', () {
       expect(
-        isDefaultCoverUrl('https://api.kolabing.com/storage/default-kolab-covers/venue_2.png'),
+        isDefaultCoverUrl(
+          'https://api.kolabing.com/storage/default-kolab-covers/venue_2.png',
+        ),
         isTrue,
       );
     });
 
     test('does not match a real uploaded photo URL', () {
       expect(
-        isDefaultCoverUrl('https://api.kolabing.com/storage/kolabs/some-upload.jpg'),
+        isDefaultCoverUrl(
+          'https://api.kolabing.com/storage/kolabs/some-upload.jpg',
+        ),
         isFalse,
       );
     });

--- a/test/features/kolab/models/kolab_test.dart
+++ b/test/features/kolab/models/kolab_test.dart
@@ -19,14 +19,17 @@ void main() {
       expect(parsed.highlights, ['good_location', 'free_samples']);
     });
 
-    test('goal and highlights default to null/empty and are omitted from toJson', () {
-      final kolab = Kolab.empty(IntentType.venuePromotion);
+    test(
+      'goal and highlights default to null/empty and are omitted from toJson',
+      () {
+        final kolab = Kolab.empty(IntentType.venuePromotion);
 
-      expect(kolab.goal, isNull);
-      expect(kolab.highlights, isEmpty);
-      expect(kolab.toJson().containsKey('goal'), isFalse);
-      expect(kolab.toJson().containsKey('highlights'), isFalse);
-    });
+        expect(kolab.goal, isNull);
+        expect(kolab.highlights, isEmpty);
+        expect(kolab.toJson().containsKey('goal'), isFalse);
+        expect(kolab.toJson().containsKey('highlights'), isFalse);
+      },
+    );
   });
 
   group('Kolab expects/offersInReturn (dynamic deliverable slugs)', () {
@@ -45,29 +48,36 @@ void main() {
       expect(parsed.offersInReturn, ['social_media']);
     });
 
-    test('an unrecognized deliverable slug round-trips unchanged, never miscoded', () {
-      // A slug the app has never seen (e.g. a brand-new admin-added option)
-      // must survive parsing untouched -- not silently collapse to some
-      // other option's slug.
-      final kolab = Kolab.fromJson(const {
-        'expects': ['brand_new_admin_option'],
-        'offers_in_return': ['another_unknown_option'],
-      });
+    test(
+      'an unrecognized deliverable slug round-trips unchanged, never miscoded',
+      () {
+        // A slug the app has never seen (e.g. a brand-new admin-added option)
+        // must survive parsing untouched -- not silently collapse to some
+        // other option's slug.
+        final kolab = Kolab.fromJson(const {
+          'expects': ['brand_new_admin_option'],
+          'offers_in_return': ['another_unknown_option'],
+        });
 
-      expect(kolab.expects, ['brand_new_admin_option']);
-      expect(kolab.offersInReturn, ['another_unknown_option']);
-    });
+        expect(kolab.expects, ['brand_new_admin_option']);
+        expect(kolab.offersInReturn, ['another_unknown_option']);
+      },
+    );
   });
 
   group('KolabMedia.isDefaultCover', () {
     test('defaults to false for a regular constructed instance', () {
-      const media = KolabMedia(url: 'https://example.com/real-photo.jpg', type: 'image');
+      const media = KolabMedia(
+        url: 'https://example.com/real-photo.jpg',
+        type: 'image',
+      );
       expect(media.isDefaultCover, isFalse);
     });
 
     test('fromJson detects a default cover URL', () {
       final media = KolabMedia.fromJson({
-        'url': 'https://api.kolabing.com/storage/default-kolab-covers/venue_1.png',
+        'url':
+            'https://api.kolabing.com/storage/default-kolab-covers/venue_1.png',
         'type': 'image',
         'sort_order': 0,
       });
@@ -85,7 +95,8 @@ void main() {
 
     test('toJson omits isDefaultCover (client-only flag)', () {
       const media = KolabMedia(
-        url: 'https://api.kolabing.com/storage/default-kolab-covers/venue_1.png',
+        url:
+            'https://api.kolabing.com/storage/default-kolab-covers/venue_1.png',
         type: 'image',
         isDefaultCover: true,
       );
@@ -94,7 +105,11 @@ void main() {
     });
 
     test('copyWith preserves isDefaultCover when not overridden', () {
-      const media = KolabMedia(url: 'https://example.com/a.jpg', type: 'image', isDefaultCover: true);
+      const media = KolabMedia(
+        url: 'https://example.com/a.jpg',
+        type: 'image',
+        isDefaultCover: true,
+      );
       final copy = media.copyWith(sortOrder: 5);
       expect(copy.isDefaultCover, isTrue);
       expect(copy.sortOrder, 5);

--- a/test/features/kolab/screens/business/ideal_community_screen_test.dart
+++ b/test/features/kolab/screens/business/ideal_community_screen_test.dart
@@ -7,23 +7,30 @@ import 'package:kolabing_app/features/onboarding/models/community_type.dart';
 import 'package:kolabing_app/features/onboarding/providers/onboarding_provider.dart';
 
 void main() {
-  testWidgets('shows community-type chips fetched from communityTypesProvider', (
-    tester,
-  ) async {
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          communityTypesProvider.overrideWith(
-            (ref) async => const [
-              CommunityType(id: '1', name: 'Business / Coworking', slug: 'business_coworking'),
-            ],
+  testWidgets(
+    'shows community-type chips fetched from communityTypesProvider',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            communityTypesProvider.overrideWith(
+              (ref) async => const [
+                CommunityType(
+                  id: '1',
+                  name: 'Business / Coworking',
+                  slug: 'business_coworking',
+                ),
+              ],
+            ),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(body: IdealCommunityScreen()),
           ),
-        ],
-        child: const MaterialApp(home: Scaffold(body: IdealCommunityScreen())),
-      ),
-    );
-    await tester.pumpAndSettle();
+        ),
+      );
+      await tester.pumpAndSettle();
 
-    expect(find.text('Business / Coworking'), findsOneWidget);
-  });
+      expect(find.text('Business / Coworking'), findsOneWidget);
+    },
+  );
 }

--- a/test/features/kolab/screens/business/media_screen_test.dart
+++ b/test/features/kolab/screens/business/media_screen_test.dart
@@ -8,19 +8,23 @@ import 'package:kolabing_app/features/kolab/providers/kolab_form_provider.dart';
 import 'package:kolabing_app/features/kolab/screens/business/media_screen.dart';
 
 Widget _wrap(ProviderContainer container) => UncontrolledProviderScope(
-      container: container,
-      child: const MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: Scaffold(body: MediaScreen()),
-      ),
-    );
+  container: container,
+  child: const MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(body: MediaScreen()),
+  ),
+);
 
 void main() {
-  testWidgets('shows two choice cards when no photo is selected yet', (tester) async {
+  testWidgets('shows two choice cards when no photo is selected yet', (
+    tester,
+  ) async {
     final container = ProviderContainer();
     addTearDown(container.dispose);
-    container.read(kolabFormProvider.notifier).selectIntent(IntentType.productPromotion);
+    container
+        .read(kolabFormProvider.notifier)
+        .selectIntent(IntentType.productPromotion);
 
     await tester.pumpWidget(_wrap(container));
     await tester.pumpAndSettle();
@@ -28,7 +32,9 @@ void main() {
     expect(find.text('Upload my photo'), findsOneWidget);
     expect(find.text('Use default cover'), findsOneWidget);
     expect(
-      find.text('Kolabs need a cover image. You can upload your own or use a Kolabing default.'),
+      find.text(
+        'Kolabs need a cover image. You can upload your own or use a Kolabing default.',
+      ),
       findsOneWidget,
     );
     // No hard error shown on initial load.
@@ -36,27 +42,38 @@ void main() {
 
     // The "Use default cover" card shows a local preview thumbnail of the
     // bundled default-cover asset for the active intent type.
-    final previewImage = tester.widgetList<Image>(find.byType(Image)).firstWhere(
-          (image) => (image.image as AssetImage).assetName ==
+    final previewImage = tester
+        .widgetList<Image>(find.byType(Image))
+        .firstWhere(
+          (image) =>
+              (image.image as AssetImage).assetName ==
               'assets/images/defaults/product_cover_1.png',
         );
     expect(previewImage, isNotNull);
   });
 
-  testWidgets('tapping "Use default cover" adds a badged default photo and hides the choice cards', (tester) async {
-    final container = ProviderContainer();
-    addTearDown(container.dispose);
-    container.read(kolabFormProvider.notifier).selectIntent(IntentType.venuePromotion);
+  testWidgets(
+    'tapping "Use default cover" adds a badged default photo and hides the choice cards',
+    (tester) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container
+          .read(kolabFormProvider.notifier)
+          .selectIntent(IntentType.venuePromotion);
 
-    await tester.pumpWidget(_wrap(container));
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(_wrap(container));
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Use default cover'));
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('Use default cover'));
+      await tester.pumpAndSettle();
 
-    expect(find.text('Upload my photo'), findsNothing);
-    expect(find.text('Use default cover'), findsNothing);
-    expect(find.text('Default'), findsOneWidget);
-    expect(container.read(kolabFormProvider).kolab.media.single.isDefaultCover, isTrue);
-  });
+      expect(find.text('Upload my photo'), findsNothing);
+      expect(find.text('Use default cover'), findsNothing);
+      expect(find.text('Default'), findsOneWidget);
+      expect(
+        container.read(kolabFormProvider).kolab.media.single.isDefaultCover,
+        isTrue,
+      );
+    },
+  );
 }

--- a/test/features/missions/mission_test.dart
+++ b/test/features/missions/mission_test.dart
@@ -2,62 +2,74 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:kolabing_app/features/missions/models/mission.dart';
 
 void main() {
-  test('treats mission as completed when completed_at is set but completed key is missing', () {
-    final mission = Mission.fromJson({
-      'id': '1',
-      'slug': 'test-mission',
-      'name': 'Test',
-      'category': 'onboarding',
-      'points': 10,
-      'target_value': 1,
-      'progress_count': 1,
-      'completed_at': '2026-06-20T10:00:00Z',
-    });
+  test(
+    'treats mission as completed when completed_at is set but completed key is missing',
+    () {
+      final mission = Mission.fromJson({
+        'id': '1',
+        'slug': 'test-mission',
+        'name': 'Test',
+        'category': 'onboarding',
+        'points': 10,
+        'target_value': 1,
+        'progress_count': 1,
+        'completed_at': '2026-06-20T10:00:00Z',
+      });
 
-    expect(mission.completed, isTrue);
-  });
+      expect(mission.completed, isTrue);
+    },
+  );
 
-  test('treats mission as completed when completed is literally true and completed_at is absent', () {
-    final mission = Mission.fromJson({
-      'id': '1',
-      'slug': 'test-mission',
-      'name': 'Test',
-      'category': 'onboarding',
-      'points': 10,
-      'target_value': 1,
-      'progress_count': 1,
-      'completed': true,
-    });
+  test(
+    'treats mission as completed when completed is literally true and completed_at is absent',
+    () {
+      final mission = Mission.fromJson({
+        'id': '1',
+        'slug': 'test-mission',
+        'name': 'Test',
+        'category': 'onboarding',
+        'points': 10,
+        'target_value': 1,
+        'progress_count': 1,
+        'completed': true,
+      });
 
-    expect(mission.completed, isTrue);
-  });
+      expect(mission.completed, isTrue);
+    },
+  );
 
-  test('treats mission as not completed when both completed and completed_at are absent', () {
-    final mission = Mission.fromJson({
-      'id': '1',
-      'slug': 'test-mission',
-      'name': 'Test',
-      'category': 'onboarding',
-      'points': 10,
-      'target_value': 1,
-      'progress_count': 0,
-    });
+  test(
+    'treats mission as not completed when both completed and completed_at are absent',
+    () {
+      final mission = Mission.fromJson({
+        'id': '1',
+        'slug': 'test-mission',
+        'name': 'Test',
+        'category': 'onboarding',
+        'points': 10,
+        'target_value': 1,
+        'progress_count': 0,
+      });
 
-    expect(mission.completed, isFalse);
-  });
+      expect(mission.completed, isFalse);
+    },
+  );
 
-  test('treats mission as not completed when completed_at is unparseable and completed is absent', () {
-    final mission = Mission.fromJson({
-      'id': '1',
-      'slug': 'test-mission',
-      'name': 'Test',
-      'category': 'onboarding',
-      'points': 10,
-      'target_value': 1,
-      'progress_count': 0,
-      'completed_at': 'soon',
-    });
+  test(
+    'treats mission as not completed when completed_at is unparseable and completed is absent',
+    () {
+      final mission = Mission.fromJson({
+        'id': '1',
+        'slug': 'test-mission',
+        'name': 'Test',
+        'category': 'onboarding',
+        'points': 10,
+        'target_value': 1,
+        'progress_count': 0,
+        'completed_at': 'soon',
+      });
 
-    expect(mission.completed, isFalse);
-  });
+      expect(mission.completed, isFalse);
+    },
+  );
 }

--- a/test/features/missions/missions_service_test.dart
+++ b/test/features/missions/missions_service_test.dart
@@ -15,37 +15,46 @@ void main() {
     });
   });
 
-  test('throws MissionException when data.missions is missing on a 200', () async {
-    final client = MockClient((request) async {
-      return http.Response('{"success": true, "data": {"oops": []}}', 200);
-    });
+  test(
+    'throws MissionException when data.missions is missing on a 200',
+    () async {
+      final client = MockClient((request) async {
+        return http.Response('{"success": true, "data": {"oops": []}}', 200);
+      });
 
-    final service = MissionsService(
-      authService: AuthService(
-        secureStorage: const FlutterSecureStorage(),
+      final service = MissionsService(
+        authService: AuthService(
+          secureStorage: const FlutterSecureStorage(),
+          httpClient: client,
+        ),
         httpClient: client,
-      ),
-      httpClient: client,
-    );
+      );
 
-    expect(() => service.getMyMissions(), throwsA(isA<MissionException>()));
-  });
+      expect(() => service.getMyMissions(), throwsA(isA<MissionException>()));
+    },
+  );
 
-  test('returns an empty list when data.missions is genuinely empty on a 200', () async {
-    final client = MockClient((request) async {
-      return http.Response('{"success": true, "data": {"missions": []}}', 200);
-    });
+  test(
+    'returns an empty list when data.missions is genuinely empty on a 200',
+    () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          '{"success": true, "data": {"missions": []}}',
+          200,
+        );
+      });
 
-    final service = MissionsService(
-      authService: AuthService(
-        secureStorage: const FlutterSecureStorage(),
+      final service = MissionsService(
+        authService: AuthService(
+          secureStorage: const FlutterSecureStorage(),
+          httpClient: client,
+        ),
         httpClient: client,
-      ),
-      httpClient: client,
-    );
+      );
 
-    final missions = await service.getMyMissions();
+      final missions = await service.getMyMissions();
 
-    expect(missions, isEmpty);
-  });
+      expect(missions, isEmpty);
+    },
+  );
 }

--- a/test/features/multi_kolab/multi_kolab_entitlement_gate_test.dart
+++ b/test/features/multi_kolab/multi_kolab_entitlement_gate_test.dart
@@ -45,7 +45,8 @@ void main() {
       ),
       if (entitlement != null)
         multiKolabEntitlementProvider.overrideWith((ref) async => entitlement),
-      if (user != null) authProvider.overrideWith(() => _TestAuthNotifier(user)),
+      if (user != null)
+        authProvider.overrideWith(() => _TestAuthNotifier(user)),
     ],
     child: MaterialApp(
       locale: locale,

--- a/test/features/multi_kolab/multi_kolab_my_kolabs_integration_test.dart
+++ b/test/features/multi_kolab/multi_kolab_my_kolabs_integration_test.dart
@@ -136,7 +136,10 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.byKey(const Key('multiKolabOrganizerEntryRow')), findsNothing);
+      expect(
+        find.byKey(const Key('multiKolabOrganizerEntryRow')),
+        findsNothing,
+      );
       expect(find.text('Multi-Kolab events'), findsNothing);
       expect(find.text('One event, several partners'), findsNothing);
     });
@@ -232,12 +235,12 @@ void main() {
         host(
           home: const MyKollabsScreen(embedded: true),
           events: [
-              event('event-1'),
-              event(
-                'event-2',
-                status: MultiKolabEventStatus.draft,
-                title: 'Winter Market',
-              ),
+            event('event-1'),
+            event(
+              'event-2',
+              status: MultiKolabEventStatus.draft,
+              title: 'Winter Market',
+            ),
           ],
         ),
       );
@@ -371,9 +374,7 @@ void main() {
     testWidgets('empty state survives when there is nothing at all', (
       tester,
     ) async {
-      await tester.pumpWidget(
-        bucketHost(CollaborationBucket.active, const []),
-      );
+      await tester.pumpWidget(bucketHost(CollaborationBucket.active, const []));
       await tester.pumpAndSettle();
 
       expect(find.text('Nothing here'), findsOneWidget);

--- a/test/features/multi_kolab/multi_kolab_organizer_capture.dart
+++ b/test/features/multi_kolab/multi_kolab_organizer_capture.dart
@@ -92,7 +92,9 @@ void main() {
         ..add('${family}_regular')
         ..add('${family}_italic');
       for (final weight in const [100, 200, 300, 500, 600, 700, 800, 900]) {
-        families..add('${family}_$weight')..add('${family}_${weight}italic');
+        families
+          ..add('${family}_$weight')
+          ..add('${family}_${weight}italic');
       }
     }
 
@@ -108,9 +110,7 @@ void main() {
     bool entitled = true,
   }) {
     final router = GoRouter(
-      routes: [
-        GoRoute(path: '/', builder: (_, _) => child),
-      ],
+      routes: [GoRoute(path: '/', builder: (_, _) => child)],
     );
     addTearDown(router.dispose);
 
@@ -120,9 +120,8 @@ void main() {
           MockMultiKolabRepository(),
         ),
         multiKolabEntitlementProvider.overrideWith(
-          (ref) async => EventCreatorEntitlement(
-            hasEventCreatorEntitlement: entitled,
-          ),
+          (ref) async =>
+              EventCreatorEntitlement(hasEventCreatorEntitlement: entitled),
         ),
       ],
       child: MaterialApp.router(

--- a/test/features/multi_kolab/multi_kolab_organizer_data_test.dart
+++ b/test/features/multi_kolab/multi_kolab_organizer_data_test.dart
@@ -43,29 +43,26 @@ void main() {
   group('role update / status', () {
     test('updateRole PATCHes the role endpoint and parses §4 back', () async {
       late http.Request captured;
-      final repo = repoReturning(
-        {
-          'success': true,
-          'data': {
-            'id': 'role-uuid',
-            'multi_kolab_event_id': 'event-uuid',
-            'status': 'open',
-            'title': 'Run Club Partner',
-            'eligible_account_type': 'community',
-            'positions_needed': 2,
-            'positions_filled': 1,
-            'required': true,
-            'need': 'A running route',
-            'receive': 'Free venue',
-            'compensation_type': 'value_exchange',
-            'requirements': null,
-            'details': null,
-            'created_at': '2026-08-12T09:05:00Z',
-            'updated_at': '2026-08-12T09:06:00Z',
-          },
+      final repo = repoReturning({
+        'success': true,
+        'data': {
+          'id': 'role-uuid',
+          'multi_kolab_event_id': 'event-uuid',
+          'status': 'open',
+          'title': 'Run Club Partner',
+          'eligible_account_type': 'community',
+          'positions_needed': 2,
+          'positions_filled': 1,
+          'required': true,
+          'need': 'A running route',
+          'receive': 'Free venue',
+          'compensation_type': 'value_exchange',
+          'requirements': null,
+          'details': null,
+          'created_at': '2026-08-12T09:05:00Z',
+          'updated_at': '2026-08-12T09:06:00Z',
         },
-        onRequest: (r) => captured = r,
-      );
+      }, onRequest: (r) => captured = r);
 
       final role = await repo.updateRole(
         'role-uuid',
@@ -82,22 +79,19 @@ void main() {
 
     test('setRoleStatus sends only the status field', () async {
       late http.Request captured;
-      final repo = repoReturning(
-        {
-          'success': true,
-          'data': {
-            'id': 'role-uuid',
-            'multi_kolab_event_id': 'event-uuid',
-            'status': 'closed',
-            'title': 'Run Club Partner',
-            'eligible_account_type': 'community',
-            'positions_needed': 1,
-            'positions_filled': 0,
-            'required': true,
-          },
+      final repo = repoReturning({
+        'success': true,
+        'data': {
+          'id': 'role-uuid',
+          'multi_kolab_event_id': 'event-uuid',
+          'status': 'closed',
+          'title': 'Run Club Partner',
+          'eligible_account_type': 'community',
+          'positions_needed': 1,
+          'positions_filled': 0,
+          'required': true,
         },
-        onRequest: (r) => captured = r,
-      );
+      }, onRequest: (r) => captured = r);
 
       final role = await repo.setRoleStatus(
         'role-uuid',
@@ -136,42 +130,34 @@ void main() {
   group('role applications (organizer review)', () {
     test('roleApplications parses the §7 list envelope', () async {
       late http.Request captured;
-      final repo = repoReturning(
-        {
-          'success': true,
-          'data': [
-            {
-              'id': 'application-uuid',
-              'multi_kolab_role_id': 'role-uuid',
-              'applicant_profile_id': 'profile-uuid',
-              'applicant_profile_type': 'community',
-              'status': 'pending',
-              'pitch': 'We run a 150-member Saturday run club.',
-              'availability': 'Any Saturday in September',
-              'kolab_id': null,
-              'created_at': '2026-08-12T09:10:00Z',
-            },
-            {
-              'id': 'application-2',
-              'multi_kolab_role_id': 'role-uuid',
-              'applicant_profile_id': 'profile-2',
-              'applicant_profile_type': 'business',
-              'status': 'accepted',
-              'pitch': 'We can host.',
-              'availability': null,
-              'kolab_id': 'kolab-uuid',
-              'created_at': '2026-08-12T09:11:00Z',
-            },
-          ],
-          'meta': {
-            'current_page': 1,
-            'last_page': 1,
-            'per_page': 15,
-            'total': 2,
+      final repo = repoReturning({
+        'success': true,
+        'data': [
+          {
+            'id': 'application-uuid',
+            'multi_kolab_role_id': 'role-uuid',
+            'applicant_profile_id': 'profile-uuid',
+            'applicant_profile_type': 'community',
+            'status': 'pending',
+            'pitch': 'We run a 150-member Saturday run club.',
+            'availability': 'Any Saturday in September',
+            'kolab_id': null,
+            'created_at': '2026-08-12T09:10:00Z',
           },
-        },
-        onRequest: (r) => captured = r,
-      );
+          {
+            'id': 'application-2',
+            'multi_kolab_role_id': 'role-uuid',
+            'applicant_profile_id': 'profile-2',
+            'applicant_profile_type': 'business',
+            'status': 'accepted',
+            'pitch': 'We can host.',
+            'availability': null,
+            'kolab_id': 'kolab-uuid',
+            'created_at': '2026-08-12T09:11:00Z',
+          },
+        ],
+        'meta': {'current_page': 1, 'last_page': 1, 'per_page': 15, 'total': 2},
+      }, onRequest: (r) => captured = r);
 
       final applications = await repo.roleApplications('role-uuid');
 
@@ -181,7 +167,10 @@ void main() {
         endsWith('/multi-kolab-roles/role-uuid/applications'),
       );
       expect(applications, hasLength(2));
-      expect(applications.first.status, MultiKolabRoleApplicationStatus.pending);
+      expect(
+        applications.first.status,
+        MultiKolabRoleApplicationStatus.pending,
+      );
       expect(applications.first.pitch, contains('run club'));
       // The organizer resource never carries withdrawal_reason (contract §12).
       expect(applications.last.kolabId, 'kolab-uuid');
@@ -213,50 +202,50 @@ void main() {
   group('lifecycle', () {
     test('confirmEvent POSTs /confirm and parses the event back', () async {
       late http.Request captured;
-      final repo = repoReturning(
-        {
-          'success': true,
-          'data': {
-            'id': 'event-uuid',
-            'status': 'confirmed',
-            'creator_profile_id': 'profile-uuid',
-            'title': 'Kolabing Launch Weekend',
-            'eligible_account_type': 'either',
-            'roles': [],
-            'role_counts': {'total': 0, 'open': 0, 'filled': 0},
-          },
+      final repo = repoReturning({
+        'success': true,
+        'data': {
+          'id': 'event-uuid',
+          'status': 'confirmed',
+          'creator_profile_id': 'profile-uuid',
+          'title': 'Kolabing Launch Weekend',
+          'eligible_account_type': 'either',
+          'roles': [],
+          'role_counts': {'total': 0, 'open': 0, 'filled': 0},
         },
-        onRequest: (r) => captured = r,
-      );
+      }, onRequest: (r) => captured = r);
 
       final event = await repo.confirmEvent('event-uuid');
 
       expect(captured.method, 'POST');
-      expect(captured.url.path, endsWith('/multi-kolab-events/event-uuid/confirm'));
+      expect(
+        captured.url.path,
+        endsWith('/multi-kolab-events/event-uuid/confirm'),
+      );
       expect(event.status, MultiKolabEventStatus.confirmed);
     });
 
     test('completeEvent POSTs /complete', () async {
       late http.Request captured;
-      final repo = repoReturning(
-        {
-          'success': true,
-          'data': {
-            'id': 'event-uuid',
-            'status': 'completed',
-            'creator_profile_id': 'profile-uuid',
-            'title': 'Kolabing Launch Weekend',
-            'eligible_account_type': 'either',
-            'roles': [],
-            'role_counts': {'total': 0, 'open': 0, 'filled': 0},
-          },
+      final repo = repoReturning({
+        'success': true,
+        'data': {
+          'id': 'event-uuid',
+          'status': 'completed',
+          'creator_profile_id': 'profile-uuid',
+          'title': 'Kolabing Launch Weekend',
+          'eligible_account_type': 'either',
+          'roles': [],
+          'role_counts': {'total': 0, 'open': 0, 'filled': 0},
         },
-        onRequest: (r) => captured = r,
-      );
+      }, onRequest: (r) => captured = r);
 
       final event = await repo.completeEvent('event-uuid');
 
-      expect(captured.url.path, endsWith('/multi-kolab-events/event-uuid/complete'));
+      expect(
+        captured.url.path,
+        endsWith('/multi-kolab-events/event-uuid/complete'),
+      );
       expect(event.status, MultiKolabEventStatus.completed);
     });
 
@@ -284,26 +273,29 @@ void main() {
       },
     );
 
-    test('publish without entitlement surfaces event_creator_required', () async {
-      final repo = repoReturning({
-        'success': false,
-        'message': 'Event Creator access is required to publish.',
-        'errors': {
-          'entitlement': ['event_creator_required'],
-        },
-      }, status: 403);
+    test(
+      'publish without entitlement surfaces event_creator_required',
+      () async {
+        final repo = repoReturning({
+          'success': false,
+          'message': 'Event Creator access is required to publish.',
+          'errors': {
+            'entitlement': ['event_creator_required'],
+          },
+        }, status: 403);
 
-      await expectLater(
-        repo.publish('event-uuid'),
-        throwsA(
-          isA<ApiException>().having(
-            (e) => e.error.stableCode,
-            'stableCode',
-            'event_creator_required',
+        await expectLater(
+          repo.publish('event-uuid'),
+          throwsA(
+            isA<ApiException>().having(
+              (e) => e.error.stableCode,
+              'stableCode',
+              'event_creator_required',
+            ),
           ),
-        ),
-      );
-    });
+        );
+      },
+    );
   });
 
   group('mock repository — deterministic organizer fixtures', () {
@@ -371,22 +363,25 @@ void main() {
       expect(result.collaborationId, isNotNull);
     });
 
-    test('roleApplications returns the applications filed for that role', () async {
-      final repo = MockMultiKolabRepository();
-      await repo.apply(
-        'role-1',
-        const CreateMultiKolabApplicationInput(pitch: 'First'),
-      );
-      await repo.apply(
-        'role-3',
-        const CreateMultiKolabApplicationInput(pitch: 'Other role'),
-      );
+    test(
+      'roleApplications returns the applications filed for that role',
+      () async {
+        final repo = MockMultiKolabRepository();
+        await repo.apply(
+          'role-1',
+          const CreateMultiKolabApplicationInput(pitch: 'First'),
+        );
+        await repo.apply(
+          'role-3',
+          const CreateMultiKolabApplicationInput(pitch: 'Other role'),
+        );
 
-      final applications = await repo.roleApplications('role-1');
+        final applications = await repo.roleApplications('role-1');
 
-      expect(applications, hasLength(1));
-      expect(applications.single.pitch, 'First');
-    });
+        expect(applications, hasLength(1));
+        expect(applications.single.pitch, 'First');
+      },
+    );
   });
 
   group('repository selection', () {

--- a/test/ios/crashlytics_ios_integration_test.dart
+++ b/test/ios/crashlytics_ios_integration_test.dart
@@ -12,18 +12,9 @@ void main() {
       projectContents,
       contains('[firebase_crashlytics] Crashlytics Upload Symbols'),
     );
-    expect(
-      projectContents,
-      contains('FirebaseCrashlytics/upload-symbols'),
-    );
-    expect(
-      projectContents,
-      contains('--flutter-project'),
-    );
-    expect(
-      projectContents,
-      contains('firebase_app_id_file.json'),
-    );
+    expect(projectContents, contains('FirebaseCrashlytics/upload-symbols'));
+    expect(projectContents, contains('--flutter-project'));
+    expect(projectContents, contains('firebase_app_id_file.json'));
     expect(
       projectContents,
       contains(r'$(PROJECT_DIR)/firebase_app_id_file.json'),
@@ -41,8 +32,9 @@ void main() {
 
     final appIdJson =
         json.decode(appIdFile.readAsStringSync()) as Map<String, dynamic>;
-    final googleServiceInfo =
-        File('ios/Runner/GoogleService-Info.plist').readAsStringSync();
+    final googleServiceInfo = File(
+      'ios/Runner/GoogleService-Info.plist',
+    ).readAsStringSync();
 
     expect(
       appIdJson['GOOGLE_APP_ID'],


### PR DESCRIPTION
> **Stacked on #184.** Base branch is `feat/camera-challenges-people-layer`, not `master`: #184 is what introduces `ChallengeProofType` to the client, and this authors it. Merge #184 first, then this.

## 🎯 What does this PR do?

The app half of "manage challenges from the app dashboard, with the camera on or off". The admin half is **kolabing-v2#249**, merged.

| | change |
|---|---|
| `ChallengeService.createChallenge` | always sends `proof_type` — explicit, so an edit that turns the camera **off** actually says so |
| `ChallengeService.updateChallenge` | sends it only when given; `null` there means "leave it alone" |
| `CreateChallengeScreen` | **"When the pair agrees"** → *No camera* / *Open the camera*, placed next to difficulty because it is the same kind of decision |
| the same screen | **doubles as the editor**, taking an optional `challenge` |
| `routes.dart` | registers the edit route that has been pushed all along |
| `EventChallengesScreen` | passes the challenge object in `extra` |

The field's hint says what it is **not**, because that is the part people get wrong: a challenge confirmed without a photo still counts, so a denied camera or bad signal never costs anybody their points. That matches `ChallengeProofType`'s own docblock on both sides — an engine selector, not a gate.

## 🐞 What problem does it solve?

Two things, one of them a dead end:

1. **Nothing in the app could author a camera challenge.** The control did not exist and the service dropped the field, so a challenge created in the app was always text-played whatever its author intended. #184's test plan says *"set a challenge's `proof_type` to `photo`"* — until kolabing-v2#249 and this PR, the only ways were SQL or a hand-made API call.
2. **`EventChallengesScreen` pushed a route that was never registered.** Tapping your own custom challenge as the organizer landed on the **not-found page** — since the screen shipped. `updateChallenge` existed in both the service and the provider with **no caller**.

A cold deep link to the edit route has no challenge in `extra` (there is no single-challenge endpoint to hydrate from), so it redirects to the challenge list rather than opening an empty form that would create a **second** challenge on save.

Refs #188

## 🚀 What's needed for this to work in production?

- [x] Backend: nothing new. `proof_type` has been live since kolabing-v2#216 and the API's `StoreChallengeRequest` / `UpdateChallengeRequest` already accept it.
- [x] New App Store / Play Store build for the app half to be usable.
- Staff can already set the switch on system challenges from the admin panel (kolabing-v2#249) without any app release.

## 📱 Which branch should be merged for this work?

- Base branch: **`feat/camera-challenges-people-layer`** (#184)
- Dependent branch(es): #184 must land first. Nothing else.

## 🧪 How to test this merge (reviewer must be able to reproduce)

- **Affected role:** Attendee acting as an event **organizer**.
- **Test account / data:** an account that organizes an event with at least one custom challenge.
- **Steps:**
  1. Open the event's challenges as the organizer → **New challenge**.
  2. Confirm **When the pair agrees** offers *No camera* (preselected) and *Open the camera*; pick the camera and save.
  3. Tap that challenge again in the list: it opens an **Edit challenge** form (this used to be the not-found page) with the name, description, points and the camera already set.
  4. Switch it back to *No camera*, save, reopen — it stayed off.
  5. Complete the camera challenge with another attendee: the camera opens for `photo` and does not for `text` (that path is #184's).
- **Expected result:** the switch round-trips, and nothing opens a camera unless somebody chose it.

## 📸 Screenshots / screen recording

- [ ] This PR has **no UI/design change** (no screenshot needed)

**Not photographed, and I would rather say so than pad this section.** The screen needs an account that organizes an event with a custom challenge; the only session on this simulator is a community owner with no such event. What stands behind it instead is five widget tests that drive the real screen at phone size and read the selection off the rendered border:

```
creating a challenge offers the camera choice, defaulting off   ✓
tapping the camera option selects it                           ✓
editing a camera challenge arrives with the camera on          ✓
editing prefills what the challenge already says               ✓
creating still says create                                     ✓
```

## ✅ Definition of Done (check before requesting review)
- [x] `flutter analyze lib test` clean (0 errors)
- [x] `dart format` applied
- [ ] Tested on **iOS** simulator/device — not the affected screen, for the account reason above; the five tests were run.
- [ ] Tested on **Android** emulator/device — not run. No platform code.
- [ ] **Screenshots** — see above.
- [x] New user-facing strings exist in i18n (`app_en.arb` + `app_es.arb` + `app_ca.arb`) and `flutter gen-l10n` was run — 7 keys
- [x] No hardcoded values
- [x] `BACKLOG.md` — N/A: closes nothing outstanding beyond its own issue

## 🤖 Was AI used?

Yes — Claude Code (Opus 5) wrote both halves (this and kolabing-v2#249) and the tests.

## 🔎 Noticed, not fixed

The **community** leader's challenge surface (`CommunityChallengesScreen`) is a checklist over the system library — a leader picks which challenges their community runs but does not author them, so there is nothing to set the camera on there. If leaders should be able to write their own challenges, that is a separate feature, not a control I can bolt onto a picker.