### PR TITLE
fix(ios): Podfile.lock was missing app_links, so Xcode refused to build

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,6 @@
 PODS:
+  - app_links (6.4.1):
+    - Flutter
   - AppAuth (1.7.6):
     - AppAuth/Core (= 1.7.6)
     - AppAuth/ExternalUserAgent (= 1.7.6)
@@ -223,6 +225,7 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
+  - app_links (from `.symlinks/plugins/app_links/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_crashlytics (from `.symlinks/plugins/firebase_crashlytics/ios`)
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
@@ -274,6 +277,8 @@ SPEC REPOS:
     - Sentry
 
 EXTERNAL SOURCES:
+  app_links:
+    :path: ".symlinks/plugins/app_links/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
   firebase_crashlytics:
@@ -320,6 +325,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
+  app_links: 3dbc685f76b1693c66a6d9dd1e9ab6f73d97dc0a
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppCheckCore: e215d35177a9cf469927863e69c13e220df32a8b
   Firebase: d99ac19b909cd2c548339c2241ecd0d1599ab02e


### PR DESCRIPTION
## 🎯 What does this PR do?

Adds the six lines `pod install` produces for **`app_links`**: its entry in `DEPENDENCIES`, its `SPEC CHECKSUM`, and its external source.

## 🐞 What problem does it solve?

> The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.

Reported by @olucvolkan opening the workspace after switching to the release branch.

#184 added `app_links` to `pubspec.yaml` and shipped a `Podfile.lock` that never learnt about the pod. `flutter build`/`flutter run` hide this because they run `pod install` themselves — which is why that branch's checks and my own `flutter build ipa` archive both passed. **Opening `Runner.xcworkspace` and building from Xcode does not**, and neither does anything that trusts the committed lock.

The diff is purely additive: nothing was removed, no version moved.

## 🚀 What's needed for this to work in production?

Nothing extra. Whoever has a stale `ios/Pods` runs `pod install` once (or any `flutter build`, which does it for them). Already committed on `release/1.6.0` as `227b1c4`, so the pending 1.6.0+41 build is unaffected.

## 📱 Which branch should be merged for this work?

- Base branch: `master`
- Dependent branch(es): none. Cherry-picked from `release/1.6.0`.

## 🧪 How to test this merge (reviewer must be able to reproduce)

- **Affected role:** N/A — build tooling.
- **Steps:**
  1. `git clean -xfd ios/Pods && cd ios && pod install`
  2. `diff ios/Podfile.lock ios/Pods/Manifest.lock` → no output.
  3. `open ios/Runner.xcworkspace`, build the Runner scheme → no sandbox/lock error.
- **Expected result:** the committed lock matches what `pod install` produces, so Xcode stops refusing.

## 📸 Screenshots / screen recording

- [x] This PR has **no UI/design change** (no screenshot needed)

A dependency lock file; nothing renders.

## ✅ Definition of Done (check before requesting review)
- [x] `flutter analyze` clean — no Dart touched
- [x] `dart format` — N/A
- [x] Tested on **iOS** — `pod install` run, `Podfile.lock` and `Pods/Manifest.lock` verified identical, 46 pods installed
- [x] Tested on **Android** — N/A, iOS-only file
- [x] Screenshots — N/A
- [x] i18n — N/A
- [x] No hardcoded values
- [x] `BACKLOG.md` — N/A

## 🤖 Was AI used?

Yes — Claude Code (Opus 5) diagnosed and fixed it.

## 🔎 Noticed, not fixed

`ios/Flutter/Profile.xcconfig` does not include `Pods-Runner.profile.xcconfig`, which is what CocoaPods warns about at the end of every `pod install`. Debug and Release both include theirs, so only `flutter build --profile` is affected. One line, but it is build configuration on a branch that is about to ship — worth its own change rather than a drive-by here.